### PR TITLE
Fix missing event for hotkey health thread

### DIFF
--- a/whisper_tkinter.py
+++ b/whisper_tkinter.py
@@ -228,6 +228,10 @@ class WhisperCore: # Renamed from WhisperApp
         self.reregister_timer_thread = None
         self.stop_reregister_event = threading.Event()
 
+        # --- Hotkey Health Monitoring ---
+        self.health_check_thread = None
+        self.stop_health_check_event = threading.Event()
+
         # --- Application State ---
         self.current_state = STATE_LOADING_MODEL # Initial state
         self.shutting_down = False # <<< FIX: Flag to prevent double shutdown


### PR DESCRIPTION
## Summary
- initialize `stop_health_check_event` in `WhisperCore.__init__`
- add placeholder `health_check_thread` variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684035c7c9c88330937deac6169b0c8b