### PR TITLE
Fix duplicate gemini_changed initialization

### DIFF
--- a/whisper_tkinter.py
+++ b/whisper_tkinter.py
@@ -2040,7 +2040,6 @@ class WhisperCore: # Renamed from WhisperApp
                 logging.info(f"OpenRouter model changed to: {self.openrouter_model}")
 
         # Apply Gemini settings if provided
-        gemini_changed = False
         if new_gemini_api_key is not None:
             api_key_str = str(new_gemini_api_key)
             if api_key_str != self.gemini_api_key:


### PR DESCRIPTION
## Summary
- remove second `gemini_changed` initialization in `apply_settings_from_external`

## Testing
- `python -m py_compile whisper_tkinter.py`
- `python -m py_compile autohotkey_manager.py keyboard_hotkey_manager.py openrouter_api.py gemini_api.py win32_hotkey_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6841a72a98308330b0175adc417e1908