### PR TITLE
Inicia thread de re-registro após carregamento

### DIFF
--- a/whisper_tkinter.py
+++ b/whisper_tkinter.py
@@ -1012,6 +1012,19 @@ class WhisperCore: # Renamed from WhisperApp
         # Iniciar o KeyboardHotkeyManager e registrar callbacks
         self._start_autohotkey()
 
+        # Iniciar thread de re-registro periódico das hotkeys
+        try:
+            self.stop_reregister_event.clear()
+            self.reregister_timer_thread = threading.Thread(
+                target=self._periodic_reregister_task,
+                daemon=True,
+                name="PeriodicHotkeyReregister",
+            )
+            self.reregister_timer_thread.start()
+            logging.info("Periodic re-register thread started.")
+        except Exception as e:
+            logging.error(f"Erro ao iniciar thread de re-registro periódico: {e}")
+
         logging.info("Hotkeys registered using keyboard library.")
 
     def _on_model_load_failed(self, error_msg):


### PR DESCRIPTION
## Resumo
- inicia `self.reregister_timer_thread` após o carregamento do modelo em `_on_model_loaded`
- garante que o evento `stop_reregister_event` seja limpo antes de iniciar a thread
- mantém o join da thread no `shutdown`

## Testes
- `python -m py_compile whisper_tkinter.py`

------
https://chatgpt.com/codex/tasks/task_e_6841a7259fb8833096aa878fe1ba8f9c