### PR TITLE
Remover duplicacao de constante

### DIFF
--- a/whisper_tkinter.py
+++ b/whisper_tkinter.py
@@ -147,8 +147,6 @@ AUTO_REREGISTER_CONFIG_KEY = "auto_reregister_hotkeys"
 # Batch size and GPU index configuration keys
 BATCH_SIZE_CONFIG_KEY = "batch_size"
 GPU_INDEX_CONFIG_KEY = "gpu_index"
-# Agent key configuration
-AGENT_KEY_CONFIG_KEY = "agent_key"
 # Keyboard library configuration - Usando apenas Win32 API
 KEYBOARD_LIBRARY_CONFIG_KEY = "keyboard_library"
 # Apenas uma opção de biblioteca de teclado agora


### PR DESCRIPTION
## Summary
- remover a segunda definicao de `AGENT_KEY_CONFIG_KEY` em `whisper_tkinter.py`
- compilar o arquivo para garantir que nao ha erros

## Testing
- `python -m py_compile whisper_tkinter.py`


------
https://chatgpt.com/codex/tasks/task_e_684c32ab33c483308b75c9ee611bf8c1