### PR TITLE
Ajustes de lint e documentação

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Contributions are welcome! If you have ideas for improvements, bug fixes, or new
 4.  Push your changes to your fork.
 5.  Open a Pull Request from your fork to the original repository's `master` branch.
 6.  Describe your changes and why they should be included.
+7.  Execute `flake8 gemini_api.py openrouter_api.py` para verificar o lint.
 
 ## Support
 

--- a/gemini_api.py
+++ b/gemini_api.py
@@ -1,22 +1,28 @@
 import logging
-import json
 import time
-import google.generativeai as genai
 from typing import Optional
+
+import google.generativeai as genai
+
 
 class GeminiAPI:
     """
     A client for the Google Gemini API to correct transcribed text.
     """
 
-    def __init__(self, api_key: str, model_id: str = "gemini-2.0-flash-001", prompt: str = ""):
+    def __init__(
+        self,
+        api_key: str,
+        model_id: str = "gemini-2.0-flash-001",
+        prompt: str = "",
+    ) -> None:
         """
         Initialize the Gemini API client.
 
         Args:
-            api_key: The Gemini API key
-            model_id: The model ID to use for text correction (default: gemini-2.0-flash-001)
-            prompt: The prompt to use for text correction (default: "")
+            api_key: Chave da API do Gemini.
+            model_id: ID do modelo (padrão: gemini-2.0-flash-001).
+            prompt: Prompt usado na correção (padrão: "").
         """
         self.api_key = api_key
         self.model_id = model_id
@@ -29,12 +35,21 @@ class GeminiAPI:
 
             # Initialize the model
             self.model = genai.GenerativeModel(self.model_id)
-            logging.info(f"Gemini API client initialized with model: {self.model_id}")
+            logging.info(
+                "Gemini API client initialized with model: %s",
+                self.model_id,
+            )
         except Exception as e:
             logging.error(f"Failed to initialize Gemini API client: {e}")
             self.model = None
 
-    def correct_text(self, text: str, max_retries: int = 3, retry_delay: int = 1, override_prompt: Optional[str] = None) -> str:
+    def correct_text(
+        self,
+        text: str,
+        max_retries: int = 3,
+        retry_delay: int = 1,
+        override_prompt: Optional[str] = None,
+    ) -> str:
         """
         Correct the transcribed text using the Gemini API.
 
@@ -42,7 +57,8 @@ class GeminiAPI:
             text: The text to correct
             max_retries: Maximum number of retries on failure
             retry_delay: Delay between retries in seconds
-            override_prompt: Optional prompt to override the default prompt for this correction.
+            override_prompt: Prompt opcional para substituir o padrão
+                nesta correção.
 
         Returns:
             The corrected text or the original text if correction fails
@@ -50,7 +66,7 @@ class GeminiAPI:
         if not text or not self.model:
             return text
 
-        # Create the prompt by formatting self.prompt with the text to be corrected
+        # Cria o prompt formatando self.prompt com o texto a ser corrigido
         if override_prompt is not None:
             prompt_to_format = override_prompt
         else:
@@ -60,7 +76,12 @@ class GeminiAPI:
 
         for attempt in range(max_retries):
             try:
-                logging.info(f"Sending text to Gemini API for correction (attempt {attempt+1}/{max_retries})")
+                logging.info(
+                    "Sending text to Gemini API for correction "
+                    "(attempt %s/%s)",
+                    attempt + 1,
+                    max_retries,
+                )
 
                 # Generate content with the model
                 response = self.model.generate_content(prompt)
@@ -68,7 +89,9 @@ class GeminiAPI:
                 # Check if the response is valid
                 if hasattr(response, 'text') and response.text:
                     corrected_text = response.text.strip()
-                    logging.info("Successfully received corrected text from Gemini API")
+                    logging.info(
+                        "Successfully received corrected text from Gemini API"
+                    )
 
                     if corrected_text != text:
                         logging.info("Gemini API made corrections to the text")
@@ -77,16 +100,29 @@ class GeminiAPI:
 
                     return corrected_text
                 else:
-                    logging.warning(f"Gemini API returned empty response (attempt {attempt+1}/{max_retries})")
+                    logging.warning(
+                        "Gemini API returned empty response (attempt %s/%s)",
+                        attempt + 1,
+                        max_retries,
+                    )
 
             except Exception as e:
-                logging.error(f"Error during Gemini API text correction (attempt {attempt+1}/{max_retries}): {e}")
+                logging.error(
+                    "Error during Gemini API text correction "
+                    "(attempt %s/%s): %s",
+                    attempt + 1,
+                    max_retries,
+                    e,
+                )
 
                 # Wait before retrying
                 if attempt < max_retries - 1:
-                    logging.info(f"Retrying in {retry_delay} seconds...")
+                    logging.info("Retrying in %s seconds...", retry_delay)
                     time.sleep(retry_delay)
 
         # If all retries failed, return the original text
-        logging.error("All Gemini API correction attempts failed, returning original text")
+        logging.error(
+            "All Gemini API correction attempts failed, "
+            "returning original text",
+        )
         return text

--- a/openrouter_api.py
+++ b/openrouter_api.py
@@ -3,65 +3,81 @@ import json
 import logging
 import time
 
-class OpenRouterAPI:
-    """
-    Class to handle interactions with the OpenRouter API for text correction using Deepseek model.
-    """
-    def __init__(self, api_key, model_id="deepseek/deepseek-chat-v3-0324:free"):
-        """
-        Initialize the OpenRouter API client.
 
-        Args:
-            api_key (str): Your OpenRouter API key
-            model_id (str): The model ID to use (default: "deepseek/deepseek-chat-v3-0324:free")
-        """
+class OpenRouterAPI:
+    """Cliente para a API OpenRouter usado na correção de texto."""
+    def __init__(
+        self,
+        api_key: str,
+        model_id: str = "deepseek/deepseek-chat-v3-0324:free",
+    ) -> None:
+        """Inicializa o cliente OpenRouter."""
         self.api_key = api_key
         self.model_id = model_id
         self.base_url = "https://openrouter.ai/api/v1/chat/completions"
         self.headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
-            "HTTP-Referer": "https://whisper-recorder.app",  # Replace with your actual app URL
-            "X-Title": "Whisper Recorder"  # Replace with your actual app name
+            "HTTP-Referer": "https://whisper-recorder.app",
+            "X-Title": "Whisper Recorder",
         }
 
-    def correct_text(self, text: str, max_retries: int = 3, retry_delay: float = 1) -> str:
+    def correct_text(
+        self,
+        text: str,
+        max_retries: int = 3,
+        retry_delay: float = 1,
+    ) -> str:
         """
-        Send text to the Deepseek model for correction of punctuation, capitalization, and names.
+        Corrige o texto transcrito usando o modelo Deepseek.
 
         Args:
-            text (str): The text to correct
-            max_retries (int): Maximum number of retries on failure
-            retry_delay (float): Delay between retries in seconds
+            text: Texto a ser corrigido.
+            max_retries: Número máximo de tentativas.
+            retry_delay: Atraso entre tentativas em segundos.
 
         Returns:
-            str: The corrected text, or the original text if the API call fails
+            str: Texto corrigido ou original caso falhe.
         """
         if not text or not text.strip():
-            logging.warning("Empty text provided to OpenRouter API, skipping correction")
+            logging.warning(
+                "Empty text provided to OpenRouter API; skipping correction"
+            )
             return text
 
         # Create the prompt for the model
-        system_message = """You are a text correction assistant. Your task is to correct the following transcribed text:
-1. Fix punctuation (commas, periods, question marks, etc.)
-2. Maintain the original meaning and all content
-3. Do not add, edit, or remove information/words.
-4. Return only the corrected text without any explanations or additional comments"""
+        system_message = (
+            "You are a text correction assistant. "
+            "Your task is to correct the following transcribed text:\n"
+            "1. Fix punctuation (commas, periods, question marks, etc.)\n"
+            "2. Maintain the original meaning and all content\n"
+            "3. Do not add, edit, or remove information/words.\n"
+            "4. Return only the corrected text without any explanations or "
+            "additional comments"
+        )
 
         payload = {
             "model": self.model_id,
             "messages": [
                 {"role": "system", "content": system_message},
-                {"role": "user", "content": f"Please correct this transcribed text: {text}"}
+                {
+                    "role": "user",
+                    "content": f"Please correct this transcribed text: {text}",
+                }
             ],
-            "temperature": 0.0,  # Low temperature for more deterministic outputs
+            "temperature": 0.0,
+            # Low temperature for mais determinismo
             "max_tokens": 10000   # Adjust based on your expected output length
         }
 
         # Try to make the API call with retries
         for attempt in range(max_retries):
             try:
-                logging.info(f"Sending text to OpenRouter API (attempt {attempt+1}/{max_retries})")
+                logging.info(
+                    "Sending text to OpenRouter API (attempt %s/%s)",
+                    attempt + 1,
+                    max_retries,
+                )
                 response = requests.post(
                     self.base_url,
                     headers=self.headers,
@@ -69,33 +85,47 @@ class OpenRouterAPI:
                     timeout=30  # 30 second timeout
                 )
 
-                response.raise_for_status()  # Raise exception for 4XX/5XX responses
+                response.raise_for_status()  # Exceção para erros 4XX/5XX
 
                 result = response.json()
                 if 'choices' in result and len(result['choices']) > 0:
                     corrected_text = result['choices'][0]['message']['content']
-                    logging.info("Successfully received corrected text from OpenRouter API")
+                    logging.info(
+                        "Successfully received corrected text from "
+                        "OpenRouter API"
+                    )
                     if corrected_text != text:
-                        logging.info("OpenRouter API made corrections to the text")
+                        logging.info(
+                            "OpenRouter API made corrections to the text"
+                        )
                     else:
                         logging.info("OpenRouter API returned text unchanged")
                     return corrected_text
                 else:
-                    logging.error(f"Unexpected response format from OpenRouter API: {result}")
-                    logging.debug(f"Full response: {json.dumps(result, indent=2)}")
+                    logging.error(
+                        "Unexpected response format from OpenRouter API: %s",
+                        result,
+                    )
+                    logging.debug(
+                        "Full response: %s",
+                        json.dumps(result, indent=2),
+                    )
 
             except requests.exceptions.RequestException as e:
-                logging.error(f"Error calling OpenRouter API: {e}")
+                logging.error("Error calling OpenRouter API: %s", e)
                 if attempt < max_retries - 1:
-                    logging.info(f"Retrying in {retry_delay} seconds...")
+                    logging.info("Retrying in %s seconds...", retry_delay)
                     time.sleep(retry_delay)
                     # Increase retry delay for subsequent attempts
                     retry_delay *= 2
 
             except Exception as e:
-                logging.error(f"Unexpected error with OpenRouter API: {e}")
+                logging.error("Unexpected error with OpenRouter API: %s", e)
                 break
 
         # If we get here, all attempts failed
-        logging.warning("Failed to correct text with OpenRouter API, returning original text")
+        logging.warning(
+            "Failed to correct text with OpenRouter API, "
+            "returning original text",
+        )
         return text


### PR DESCRIPTION
## Resumo
- removido import `json` não utilizado e ajustes de estilo no `gemini_api.py`
- refatorado `openrouter_api.py` seguindo PEP 8
- adicionado passo de verificação de lint no README

## Testes
- `flake8 gemini_api.py openrouter_api.py`

------
https://chatgpt.com/codex/tasks/task_e_684f2ca9507483309ad52f9c7c835bda