### PR TITLE
Implementa VAD para parar gravação em silêncio

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -30,11 +30,25 @@ class AudioHandler:
         self.sound_volume = self.config_manager.get("sound_volume")
         self.min_record_duration = self.config_manager.get("min_record_duration")
 
+        self.vad_enabled = self.config_manager.get("vad_enabled")
+        self.vad_silence_duration = self.config_manager.get("vad_silence_duration")
+        self.vad_manager = VADManager() if self.vad_enabled else None
+        self._vad_silence_counter = 0.0
+
     def _audio_callback(self, indata, *_, **__):
         status = __.get('status')
         if status:
             logging.warning(f"Audio callback status: {status}")
         if self.is_recording:
+            if self.vad_enabled:
+                is_speech = self.vad_manager.is_speech(indata[:, 0])
+                if is_speech:
+                    self._vad_silence_counter = 0.0
+                else:
+                    self._vad_silence_counter += len(indata) / AUDIO_SAMPLE_RATE
+                    if self._vad_silence_counter >= self.vad_silence_duration:
+                        threading.Thread(target=self.stop_recording, daemon=True).start()
+                        self._vad_silence_counter = 0.0
             self.recording_data.append(indata.copy())
 
     def _record_audio_task(self):

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -48,7 +48,9 @@ Transcribed speech: {text}""",
         "gemini-2.5-pro-preview-06-05"
     ],
     "save_audio_for_debug": False,
-    "min_transcription_duration": 1.0 # Nova configuração
+    "min_transcription_duration": 1.0, # Nova configuração
+    "vad_enabled": False,
+    "vad_silence_duration": 1.0
 }
 
 # Outras constantes de configuração (movidas de whisper_tkinter.py)
@@ -65,6 +67,8 @@ BATCH_SIZE_MODE_CONFIG_KEY = "batch_size_mode" # Novo
 MANUAL_BATCH_SIZE_CONFIG_KEY = "manual_batch_size" # Novo
 GPU_INDEX_CONFIG_KEY = "gpu_index"
 SAVE_AUDIO_FOR_DEBUG_CONFIG_KEY = "save_audio_for_debug"
+VAD_ENABLED_CONFIG_KEY = "vad_enabled"
+VAD_SILENCE_DURATION_CONFIG_KEY = "vad_silence_duration"
 KEYBOARD_LIBRARY_CONFIG_KEY = "keyboard_library"
 KEYBOARD_LIB_WIN32 = "win32"
 TEXT_CORRECTION_ENABLED_CONFIG_KEY = "text_correction_enabled"
@@ -185,6 +189,19 @@ class ConfigManager:
         except (ValueError, TypeError):
             logging.warning(f"Invalid min_transcription_duration value '{self.config.get(MIN_TRANSCRIPTION_DURATION_CONFIG_KEY)}' in config. Falling back to default ({self.default_config[MIN_TRANSCRIPTION_DURATION_CONFIG_KEY]}).")
             self.config[MIN_TRANSCRIPTION_DURATION_CONFIG_KEY] = self.default_config[MIN_TRANSCRIPTION_DURATION_CONFIG_KEY]
+
+        self.config[VAD_ENABLED_CONFIG_KEY] = bool(self.config.get(VAD_ENABLED_CONFIG_KEY, self.default_config[VAD_ENABLED_CONFIG_KEY]))
+        try:
+            raw_vad_silence = loaded_config.get(VAD_SILENCE_DURATION_CONFIG_KEY, self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY])
+            vad_silence_val = float(raw_vad_silence)
+            if not (0.1 <= vad_silence_val <= 10.0):
+                logging.warning(f"Invalid vad_silence_duration '{vad_silence_val}'. Using default ({self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]}).")
+                self.config[VAD_SILENCE_DURATION_CONFIG_KEY] = self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]
+            else:
+                self.config[VAD_SILENCE_DURATION_CONFIG_KEY] = vad_silence_val
+        except (ValueError, TypeError):
+            logging.warning(f"Invalid vad_silence_duration value '{self.config.get(VAD_SILENCE_DURATION_CONFIG_KEY)}' in config. Falling back to default ({self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]}).")
+            self.config[VAD_SILENCE_DURATION_CONFIG_KEY] = self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]
 
         logging.info(f"Configurações aplicadas: {self.config}")
 


### PR DESCRIPTION
## Resumo
- inclui `vad_enabled` e `vad_silence_duration` na configuração
- instancia `VADManager` no `AudioHandler`
- controla contador de silêncio no callback e para gravação em thread
- corrige final do arquivo `audio_handler.py`

## Testes
- `python -m py_compile src/config_manager.py src/audio_handler.py src/vad_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68516f55f8c0833099b3c391aa66c82f