### PR TITLE
Adicionar configurações de VAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A lightweight, high-performance desktop tool for Windows that turns your speech 
     *   An intuitive GUI for managing all settings without editing files.
     *   Quickly switch between Gemini models directly from the tray menu.
 *   **Auditory Feedback:** Optional sound cues for starting and stopping recording.
+*   **Voice Activity Detection (VAD):** Remove silent segments automatically by enabling this feature.
 *   **Robust and Stable:** Includes a background service to ensure hotkeys remain responsive, a common issue on Windows 11.
 
 ## System Architecture
@@ -227,6 +228,7 @@ To access and change settings:
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
 *   **Batch Size:** Configure the batch size for transcription.
 *   **Save Audio for Debug:** If enabled, temporary audio recordings will be saved for debugging purposes.
+*   **Use VAD:** Check this option in *Transcription Settings* to remove silence using Silero voice activity detection. Adjust **VAD Threshold** and **VAD Silence Duration (s)** for best results.
 
 Remember to save your changes in the settings window.
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -47,6 +47,9 @@ Transcribed speech: {text}""",
         "gemini-2.5-flash-preview-05-20",
         "gemini-2.5-pro-preview-06-05"
     ],
+    "use_vad": False,
+    "vad_threshold": 0.5,
+    "vad_silence_duration": 0.5,
     "save_audio_for_debug": False,
     "min_transcription_duration": 1.0 # Nova configuração
 }
@@ -65,6 +68,9 @@ BATCH_SIZE_MODE_CONFIG_KEY = "batch_size_mode" # Novo
 MANUAL_BATCH_SIZE_CONFIG_KEY = "manual_batch_size" # Novo
 GPU_INDEX_CONFIG_KEY = "gpu_index"
 SAVE_AUDIO_FOR_DEBUG_CONFIG_KEY = "save_audio_for_debug"
+USE_VAD_CONFIG_KEY = "use_vad"
+VAD_THRESHOLD_CONFIG_KEY = "vad_threshold"
+VAD_SILENCE_DURATION_CONFIG_KEY = "vad_silence_duration"
 KEYBOARD_LIBRARY_CONFIG_KEY = "keyboard_library"
 KEYBOARD_LIB_WIN32 = "win32"
 TEXT_CORRECTION_ENABLED_CONFIG_KEY = "text_correction_enabled"
@@ -185,6 +191,19 @@ class ConfigManager:
         except (ValueError, TypeError):
             logging.warning(f"Invalid min_transcription_duration value '{self.config.get(MIN_TRANSCRIPTION_DURATION_CONFIG_KEY)}' in config. Falling back to default ({self.default_config[MIN_TRANSCRIPTION_DURATION_CONFIG_KEY]}).")
             self.config[MIN_TRANSCRIPTION_DURATION_CONFIG_KEY] = self.default_config[MIN_TRANSCRIPTION_DURATION_CONFIG_KEY]
+
+        # Validação das configurações de VAD
+        self.config[USE_VAD_CONFIG_KEY] = bool(self.config.get(USE_VAD_CONFIG_KEY, self.default_config[USE_VAD_CONFIG_KEY]))
+        try:
+            self.config[VAD_THRESHOLD_CONFIG_KEY] = float(self.config.get(VAD_THRESHOLD_CONFIG_KEY, self.default_config[VAD_THRESHOLD_CONFIG_KEY]))
+        except (ValueError, TypeError):
+            logging.warning(f"Invalid vad_threshold value '{self.config.get(VAD_THRESHOLD_CONFIG_KEY)}'. Using default ({self.default_config[VAD_THRESHOLD_CONFIG_KEY]}).")
+            self.config[VAD_THRESHOLD_CONFIG_KEY] = self.default_config[VAD_THRESHOLD_CONFIG_KEY]
+        try:
+            self.config[VAD_SILENCE_DURATION_CONFIG_KEY] = float(self.config.get(VAD_SILENCE_DURATION_CONFIG_KEY, self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]))
+        except (ValueError, TypeError):
+            logging.warning(f"Invalid vad_silence_duration value '{self.config.get(VAD_SILENCE_DURATION_CONFIG_KEY)}'. Using default ({self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]}).")
+            self.config[VAD_SILENCE_DURATION_CONFIG_KEY] = self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]
 
         logging.info(f"Configurações aplicadas: {self.config}")
 

--- a/src/core.py
+++ b/src/core.py
@@ -499,7 +499,10 @@ class AppCore:
                 "new_hotkey_stability_service_enabled": "hotkey_stability_service_enabled", # Nova configuração unificada
                 "new_min_transcription_duration": "min_transcription_duration",
                 "new_save_audio_for_debug": "save_audio_for_debug",
-                "new_gemini_model_options": "gemini_model_options"
+                "new_gemini_model_options": "gemini_model_options",
+                "new_use_vad": "use_vad",
+                "new_vad_threshold": "vad_threshold",
+                "new_vad_silence_duration": "vad_silence_duration"
             }
             mapped_key = config_key_map.get(key, key) # Usa o nome original se não mapeado
 

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -183,6 +183,9 @@ class UIManager:
                 gemini_mode_var = ctk.StringVar(value=self.config_manager.get("gemini_mode"))
                 batch_size_var = ctk.StringVar(value=str(self.config_manager.get("batch_size")))
                 min_transcription_duration_var = ctk.DoubleVar(value=self.config_manager.get("min_transcription_duration")) # Nova variável
+                use_vad_var = ctk.BooleanVar(value=self.config_manager.get("use_vad"))
+                vad_threshold_var = ctk.DoubleVar(value=self.config_manager.get("vad_threshold"))
+                vad_silence_duration_var = ctk.DoubleVar(value=self.config_manager.get("vad_silence_duration"))
                 save_audio_var = ctk.BooleanVar(value=self.config_manager.get("save_audio_for_debug"))
                 gemini_prompt_correction_var = ctk.StringVar(value=self.config_manager.get("gemini_prompt"))
 
@@ -231,6 +234,9 @@ class UIManager:
                     agentico_prompt_to_apply = agentico_prompt_textbox.get("1.0", "end-1c")
                     batch_size_to_apply = int(batch_size_var.get())
                     min_transcription_duration_to_apply = float(min_transcription_duration_var.get()) # Coleta o valor
+                    use_vad_to_apply = use_vad_var.get()
+                    vad_threshold_to_apply = float(vad_threshold_var.get())
+                    vad_silence_duration_to_apply = float(vad_silence_duration_var.get())
                     save_audio_for_debug_to_apply = save_audio_var.get()
 
                     # Logic for converting UI to GPU index
@@ -276,7 +282,10 @@ class UIManager:
                         new_gpu_index=gpu_index_to_apply,
                         new_hotkey_stability_service_enabled=hotkey_stability_service_enabled_to_apply, # Nova configuração unificada
                         new_min_transcription_duration=min_transcription_duration_to_apply,
-                        new_save_audio_for_debug=save_audio_for_debug_to_apply
+                        new_save_audio_for_debug=save_audio_for_debug_to_apply,
+                        new_use_vad=use_vad_to_apply,
+                        new_vad_threshold=vad_threshold_to_apply,
+                        new_vad_silence_duration=vad_silence_duration_to_apply
                     )
                     self._close_settings_window() # Call class method
 
@@ -428,6 +437,17 @@ class UIManager:
                 ctk.CTkLabel(min_transcription_duration_frame, text="Ignore Transcriptions Shorter Than (sec):").pack(side="left", padx=(5, 10))
                 min_transcription_duration_entry = ctk.CTkEntry(min_transcription_duration_frame, textvariable=min_transcription_duration_var, width=80)
                 min_transcription_duration_entry.pack(side="left", padx=5)
+
+                vad_enable_frame = ctk.CTkFrame(transcription_frame)
+                vad_enable_frame.pack(fill="x", pady=5)
+                ctk.CTkCheckBox(vad_enable_frame, text="Use VAD", variable=use_vad_var).pack(side="left", padx=5)
+
+                vad_params_frame = ctk.CTkFrame(transcription_frame)
+                vad_params_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(vad_params_frame, text="VAD Threshold:").pack(side="left", padx=(5, 10))
+                ctk.CTkEntry(vad_params_frame, textvariable=vad_threshold_var, width=60).pack(side="left", padx=5)
+                ctk.CTkLabel(vad_params_frame, text="Silence (s):").pack(side="left", padx=(5, 10))
+                ctk.CTkEntry(vad_params_frame, textvariable=vad_silence_duration_var, width=60).pack(side="left", padx=5)
     
                 save_audio_frame = ctk.CTkFrame(transcription_frame)
                 save_audio_frame.pack(fill="x", pady=5)


### PR DESCRIPTION
## Summary
- incluir `use_vad`, `vad_threshold` e `vad_silence_duration` nas configurações
- suportar novas opções na aplicação e na GUI
- documentar o funcionamento do VAD no README

## Testing
- `pytest -q`
- `python -m py_compile src/config_manager.py src/core.py src/ui_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68516f565dac8330bae4c053ec8b5826