### PR TITLE
Handle new_prompt_agentico setting

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -112,6 +112,9 @@ class ConfigManager:
             if os.path.exists(self.config_file):
                 with open(self.config_file, "r", encoding='utf-8') as f:
                     loaded_config_from_file = json.load(f)
+                if "new_prompt_agentico" in loaded_config_from_file:
+                    logging.info("Removing obsolete 'new_prompt_agentico' key from config file.")
+                    loaded_config_from_file.pop("new_prompt_agentico", None)
                 cfg.update(loaded_config_from_file)
                 logging.info(f"Configuration loaded from {self.config_file}.")
 

--- a/src/core.py
+++ b/src/core.py
@@ -495,6 +495,7 @@ class AppCore:
                 "new_openrouter_api_key": "openrouter_api_key", "new_openrouter_model": "openrouter_model",
                 "new_gemini_api_key": "gemini_api_key", "new_gemini_model": "gemini_model",
                 "new_gemini_mode": "gemini_mode", "new_gemini_prompt": "gemini_prompt",
+                "new_prompt_agentico": "prompt_agentico",
                 "new_batch_size": "batch_size", "new_gpu_index": "gpu_index",
                 "new_hotkey_stability_service_enabled": "hotkey_stability_service_enabled", # Nova configuração unificada
                 "new_min_transcription_duration": "min_transcription_duration",


### PR DESCRIPTION
## Summary
- map `new_prompt_agentico` to `prompt_agentico` when applying external settings
- clean up `new_prompt_agentico` from config files during load

## Testing
- `python -m py_compile src/config_manager.py src/core.py`

------
https://chatgpt.com/codex/tasks/task_e_685192ed711c83308fae22f8d2fb61ff