### PR TITLE
Atualiza assinatura de _audio_callback

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -35,8 +35,7 @@ class AudioHandler:
         self.vad_manager = VADManager() if self.vad_enabled else None
         self._vad_silence_counter = 0.0
 
-    def _audio_callback(self, indata, *_, **__):
-        status = __.get('status')
+    def _audio_callback(self, indata, frames, time_data, status):
         if status:
             logging.warning(f"Audio callback status: {status}")
         if self.is_recording:


### PR DESCRIPTION
## Notas
- Adequa `_audio_callback` à assinatura padrão do `sounddevice.InputStream`, recebendo agora `indata`, `frames`, `time_data` e `status`.
- O método passa a utilizar `status` diretamente para registrar avisos de callback.

## Testes
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685198a11d1c83309fb3968caa4b7587