### PR TITLE
Refatorar configuração de VAD

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -30,9 +30,9 @@ class AudioHandler:
         self.sound_volume = self.config_manager.get("sound_volume")
         self.min_record_duration = self.config_manager.get("min_record_duration")
 
-        self.vad_enabled = self.config_manager.get("vad_enabled")
+        self.use_vad = self.config_manager.get("use_vad")
         self.vad_silence_duration = self.config_manager.get("vad_silence_duration")
-        self.vad_manager = VADManager() if self.vad_enabled else None
+        self.vad_manager = VADManager() if self.use_vad else None
         self._vad_silence_counter = 0.0
 
     def _audio_callback(self, indata, *_, **__):
@@ -40,7 +40,7 @@ class AudioHandler:
         if status:
             logging.warning(f"Audio callback status: {status}")
         if self.is_recording:
-            if self.vad_enabled:
+            if self.use_vad:
                 is_speech = self.vad_manager.is_speech(indata[:, 0])
                 if is_speech:
                     self._vad_silence_counter = 0.0

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -51,13 +51,8 @@ Transcribed speech: {text}""",
         "gemini-2.5-flash-preview-05-20",
         "gemini-2.5-pro-preview-06-05"
     ],
-    "use_vad": False,
-    "vad_threshold": 0.5,
-    "vad_silence_duration": 0.5,
     "save_audio_for_debug": False,
-    "min_transcription_duration": 1.0, # Nova configuração
-    "vad_enabled": False,
-    "vad_silence_duration": 1.0
+    "min_transcription_duration": 1.0  # Nova configuração
 }
 
 # Outras constantes de configuração (movidas de whisper_tkinter.py)
@@ -117,6 +112,9 @@ class ConfigManager:
                 if "new_prompt_agentico" in loaded_config_from_file:
                     logging.info("Removing obsolete 'new_prompt_agentico' key from config file.")
                     loaded_config_from_file.pop("new_prompt_agentico", None)
+                if "vad_enabled" in loaded_config_from_file:
+                    logging.info("Migrating legacy 'vad_enabled' key to 'use_vad'.")
+                    loaded_config_from_file["use_vad"] = loaded_config_from_file.pop("vad_enabled")
                 cfg.update(loaded_config_from_file)
                 logging.info(f"Configuration loaded from {self.config_file}.")
 


### PR DESCRIPTION
## Resumo
- remover entradas duplicadas e chave antiga `vad_enabled`
- migrar automaticamente a configuração antiga no carregamento
- ajustar `audio_handler` para usar a nova chave

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685198a210488330b1cc03d829aa3bc7