### PR TITLE
Ajustes na gestão de silêncio

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -45,6 +45,7 @@ Transcribed speech: {text}""",
     "hotkey_stability_service_enabled": True, # Nova configuração unificada
     "use_vad": False,
     "vad_threshold": 0.5,
+    # Duração máxima da pausa preservada antes que o silêncio seja descartado
     "vad_silence_duration": 1.0,
     "gemini_model_options": [
         "gemini-2.0-flash-001",
@@ -213,7 +214,13 @@ class ConfigManager:
 
         try:
             raw_silence = self.config.get(VAD_SILENCE_DURATION_CONFIG_KEY, self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY])
-            self.config[VAD_SILENCE_DURATION_CONFIG_KEY] = float(raw_silence)
+            silence_val = float(raw_silence)
+            if silence_val < 0.1:
+                logging.warning(
+                    f"Invalid vad_silence_duration '{silence_val}'. Must be >= 0.1. Using default ({self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]})."
+                )
+                silence_val = self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]
+            self.config[VAD_SILENCE_DURATION_CONFIG_KEY] = silence_val
         except (ValueError, TypeError):
             logging.warning(
                 f"Invalid vad_silence_duration value '{self.config.get(VAD_SILENCE_DURATION_CONFIG_KEY)}' in config. Using default ({self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]})."

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -438,8 +438,13 @@ class UIManager:
                 vad_params_frame.pack(fill="x", pady=5)
                 ctk.CTkLabel(vad_params_frame, text="VAD Threshold:").pack(side="left", padx=(5, 10))
                 ctk.CTkEntry(vad_params_frame, textvariable=vad_threshold_var, width=60).pack(side="left", padx=5)
-                ctk.CTkLabel(vad_params_frame, text="Silence (s):").pack(side="left", padx=(5, 10))
+                ctk.CTkLabel(vad_params_frame, text="Duração do silêncio (s):").pack(side="left", padx=(5, 10))
                 ctk.CTkEntry(vad_params_frame, textvariable=vad_silence_duration_var, width=60).pack(side="left", padx=5)
+                ctk.CTkLabel(
+                    vad_params_frame,
+                    text="Valores maiores preservam pausas curtas e descartam trechos silenciosos longos.",
+                    font=ctk.CTkFont(size=10, slant="italic")
+                ).pack(anchor="w", padx=5)
     
                 save_audio_frame = ctk.CTkFrame(transcription_frame)
                 save_audio_frame.pack(fill="x", pady=5)


### PR DESCRIPTION
## Summary
- documenta `vad_silence_duration` e adiciona validação mínima
- renomeia rótulo de configuração de silêncio e explica efeito dos valores

## Testing
- `flake8 src/gemini_api.py src/openrouter_api.py` *(falha: várias mensagens E/W)*

------
https://chatgpt.com/codex/tasks/task_e_6851d236f11c83309233032e0c6af02d