### PR TITLE
Adicionar método de reinicialização do OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ graph TD
 *   **`AudioHandler`**: Manages microphone input, recording, and sound feedback.
 *   **`TranscriptionHandler`**: Manages the Whisper model, runs the transcription pipeline, and coordinates with AI correction services.
 *   **`KeyboardHotkeyManager`**: Listens for and handles global hotkeys.
-*   ****`GeminiAPI` / `OpenRouterAPI`**: Clients for interacting with external AI services for text correction.
+*   ****`GeminiAPI` / `OpenRouterAPI`**: Clientes para interação com serviços externos de IA e correção de texto. Ambos expõem o método `reinitialize_client()` para recarregar chave e modelo em tempo de execução.
 
 ## Installation
 

--- a/src/core.py
+++ b/src/core.py
@@ -540,7 +540,10 @@ class AppCore:
             if self.transcription_handler.gemini_client:
                 self.transcription_handler.gemini_client.reinitialize_client() # Re-inicializar cliente Gemini do TranscriptionHandler
             if self.transcription_handler.openrouter_client:
-                self.transcription_handler.openrouter_client.reinitialize_client() # Re-inicializar cliente OpenRouter do TranscriptionHandler
+                self.transcription_handler.openrouter_client.reinitialize_client(
+                    api_key=self.config_manager.get("openrouter_api_key"),
+                    model_id=self.config_manager.get("openrouter_model")
+                ) # Re-inicializar cliente OpenRouter do TranscriptionHandler
             
             # Re-registrar hotkeys se as chaves ou modo mudaram
             if kwargs.get("new_key") is not None or kwargs.get("new_mode") is not None or kwargs.get("new_agent_key") is not None:
@@ -606,7 +609,10 @@ class AppCore:
             if self.transcription_handler.gemini_client:
                 self.transcription_handler.gemini_client.reinitialize_client()
             if self.transcription_handler.openrouter_client:
-                self.transcription_handler.openrouter_client.reinitialize_client()
+                self.transcription_handler.openrouter_client.reinitialize_client(
+                    api_key=self.config_manager.get("openrouter_api_key"),
+                    model_id=self.config_manager.get("openrouter_model")
+                )
             logging.info(f"Clientes API re-inicializados via update_setting para '{key}'.")
 
         # Re-registrar hotkeys se as chaves ou modo mudaram

--- a/src/openrouter_api.py
+++ b/src/openrouter_api.py
@@ -5,7 +5,12 @@ import time
 
 
 class OpenRouterAPI:
-    """Cliente para a API OpenRouter usado na correção de texto."""
+    """Cliente para a API OpenRouter usado na correção de texto.
+
+    Possui o método :py:meth:`reinitialize_client` para atualizar chave
+    e modelo dinamicamente, permitindo aplicar novas configurações sem
+    recriar a instância.
+    """
     def __init__(
         self,
         api_key: str,
@@ -21,6 +26,25 @@ class OpenRouterAPI:
             "HTTP-Referer": "https://whisper-recorder.app",
             "X-Title": "Whisper Recorder",
         }
+
+    def reinitialize_client(self, api_key: str | None = None,
+                            model_id: str | None = None) -> None:
+        """Atualiza chave, modelo e cabeçalhos do cliente.
+
+        Args:
+            api_key: Nova chave de API. Se ``None``, mantém a atual.
+            model_id: Novo identificador de modelo.
+                Se ``None``, mantém o atual.
+        """
+        if api_key:
+            self.api_key = api_key
+        if model_id:
+            self.model_id = model_id
+        self.headers["Authorization"] = f"Bearer {self.api_key}"
+        logging.info(
+            "OpenRouter API client re/initialized with model '%s'",
+            self.model_id,
+        )
 
     def correct_text(
         self,


### PR DESCRIPTION
## Notas
- implementado `reinitialize_client` em `OpenRouterAPI`
- documentação e comentários atualizados
- `AppCore` agora passa chave e modelo ao reinicializar
- `flake8 src/gemini_api.py src/openrouter_api.py` executado para verificar lint


------
https://chatgpt.com/codex/tasks/task_e_6851da8491bc8330be8e720ee47c4479