### PR TITLE
Remove VAD hint

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -440,12 +440,6 @@ class UIManager:
                 ctk.CTkEntry(vad_params_frame, textvariable=vad_threshold_var, width=60).pack(side="left", padx=5)
                 ctk.CTkLabel(vad_params_frame, text="Duração do silêncio (s):").pack(side="left", padx=(5, 10))
                 ctk.CTkEntry(vad_params_frame, textvariable=vad_silence_duration_var, width=60).pack(side="left", padx=5)
-                ctk.CTkLabel(
-                    vad_params_frame,
-                    text="Valores maiores preservam pausas curtas e descartam trechos silenciosos longos.",
-                    font=ctk.CTkFont(size=10, slant="italic")
-                ).pack(anchor="w", padx=5)
-    
                 save_audio_frame = ctk.CTkFrame(transcription_frame)
                 save_audio_frame.pack(fill="x", pady=5)
                 ctk.CTkSwitch(save_audio_frame, text="Save Audio for Debug", variable=save_audio_var).pack(side="left", padx=5)


### PR DESCRIPTION
## Summary
- remove the explanatory label for VAD threshold in the settings UI

## Testing
- `flake8 src/gemini_api.py src/openrouter_api.py` *(fails: E261, E302, E501, E129, E701, W391)*

------
https://chatgpt.com/codex/tasks/task_e_6851ee43d140833087ef2559da7458cb