### PR TITLE
Adicionar log opcional do texto corrigido

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -321,7 +321,10 @@ class TranscriptionHandler:
                     final_text = self._correct_text_with_gemini(text_result)
                 elif correction_service == SERVICE_OPENROUTER:
                     final_text = self._correct_text_with_openrouter(text_result)
-                
+
+                if self.config_manager.get("save_audio_for_debug"):
+                    logging.info(f"Transcrição corrigida: {final_text}")
+
                 self.on_transcription_result_callback(final_text)
 
             # Limpeza de cache da GPU sempre ao final


### PR DESCRIPTION
## Summary
- logar a transcrição corrigida quando a opção `save_audio_for_debug` estiver ativa

## Testing
- `python -m py_compile src/transcription_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_6851f01a9b208330b49c742c850ce573