### PR TITLE
Add terminal transcript display option

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,16 @@ To access and change settings:
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
 *   **Batch Size:** Configure the batch size for transcription.
 *   **Save Audio for Debug:** If enabled, temporary audio recordings will be saved for debugging purposes.
+*   **Display Transcript in Terminal:** Show the final text in the terminal window after each recording.
 *   **Use VAD:** ativa a remoção de silêncio, sem encerrar a gravação automaticamente.
 *   **VAD Threshold:** sensibilidade da detecção de voz.
 *   **VAD Silence Duration (s):** tempo máximo de pausa que será mantido; silêncios mais longos são cortados.
 
 O usuário encerra a gravação manualmente.
+
+### Displaying Transcripts in the Terminal
+
+Set `display_transcripts_in_terminal` to `true` in `config.json` or toggle the option in the settings window to print the full transcript in the terminal after each recording.
 
 Remember to save your changes in the settings window.
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -47,6 +47,7 @@ Transcribed speech: {text}""",
     "vad_threshold": 0.5,
     # Duração máxima da pausa preservada antes que o silêncio seja descartado
     "vad_silence_duration": 1.0,
+    "display_transcripts_in_terminal": False,
     "gemini_model_options": [
         "gemini-2.0-flash-001",
         "gemini-2.5-flash-preview-05-20",
@@ -73,6 +74,7 @@ SAVE_AUDIO_FOR_DEBUG_CONFIG_KEY = "save_audio_for_debug"
 USE_VAD_CONFIG_KEY = "use_vad"
 VAD_THRESHOLD_CONFIG_KEY = "vad_threshold"
 VAD_SILENCE_DURATION_CONFIG_KEY = "vad_silence_duration"
+DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY = "display_transcripts_in_terminal"
 KEYBOARD_LIBRARY_CONFIG_KEY = "keyboard_library"
 KEYBOARD_LIB_WIN32 = "win32"
 TEXT_CORRECTION_ENABLED_CONFIG_KEY = "text_correction_enabled"
@@ -203,6 +205,12 @@ class ConfigManager:
 
         # Lógica para uso do VAD
         self.config[USE_VAD_CONFIG_KEY] = bool(self.config.get(USE_VAD_CONFIG_KEY, self.default_config[USE_VAD_CONFIG_KEY]))
+        self.config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY] = bool(
+            self.config.get(
+                DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY,
+                self.default_config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY]
+            )
+        )
         try:
             raw_threshold = self.config.get(VAD_THRESHOLD_CONFIG_KEY, self.default_config[VAD_THRESHOLD_CONFIG_KEY])
             self.config[VAD_THRESHOLD_CONFIG_KEY] = float(raw_threshold)
@@ -315,3 +323,12 @@ class ConfigManager:
             self.config[VAD_SILENCE_DURATION_CONFIG_KEY] = float(value)
         except (ValueError, TypeError):
             self.config[VAD_SILENCE_DURATION_CONFIG_KEY] = self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]
+
+    def get_display_transcripts_in_terminal(self):
+        return self.config.get(
+            DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY,
+            self.default_config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY]
+        )
+
+    def set_display_transcripts_in_terminal(self, value: bool):
+        self.config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY] = bool(value)

--- a/src/core.py
+++ b/src/core.py
@@ -94,6 +94,7 @@ class AppCore:
         self.hotkey_stability_service_enabled = self.config_manager.get("hotkey_stability_service_enabled") # Nova configuração unificada
         self.keyboard_library = self.config_manager.get("keyboard_library")
         self.min_record_duration = self.config_manager.get("min_record_duration")
+        self.display_transcripts_in_terminal = self.config_manager.get("display_transcripts_in_terminal")
         # ... e outras configurações que AppCore precisa diretamente
 
     # --- Callbacks de Módulos ---
@@ -179,7 +180,8 @@ class AppCore:
         final_text = self.full_transcription.strip()
         self.full_transcription = "" # Reset para a próxima gravação
 
-
+        if self.display_transcripts_in_terminal:
+            print("\n=== TRANSCRIÇÃO COMPLETA ===\n" + final_text + "\n============================\n")
 
         if pyperclip:
             try:
@@ -504,7 +506,8 @@ class AppCore:
                 "new_gemini_model_options": "gemini_model_options",
                 "new_use_vad": "use_vad",
                 "new_vad_threshold": "vad_threshold",
-                "new_vad_silence_duration": "vad_silence_duration"
+                "new_vad_silence_duration": "vad_silence_duration",
+                "new_display_transcripts_in_terminal": "display_transcripts_in_terminal"
             }
             mapped_key = config_key_map.get(key, key) # Usa o nome original se não mapeado
 

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -186,6 +186,7 @@ class UIManager:
                 vad_threshold_var = ctk.DoubleVar(value=self.config_manager.get("vad_threshold"))
                 vad_silence_duration_var = ctk.DoubleVar(value=self.config_manager.get("vad_silence_duration"))
                 save_audio_var = ctk.BooleanVar(value=self.config_manager.get("save_audio_for_debug"))
+                display_transcripts_var = ctk.BooleanVar(value=self.config_manager.get("display_transcripts_in_terminal"))
                 gemini_prompt_correction_var = ctk.StringVar(value=self.config_manager.get("gemini_prompt"))
 
                 # GPU selection variable
@@ -237,6 +238,7 @@ class UIManager:
                     vad_threshold_to_apply = float(vad_threshold_var.get())
                     vad_silence_duration_to_apply = float(vad_silence_duration_var.get())
                     save_audio_for_debug_to_apply = save_audio_var.get()
+                    display_transcripts_to_apply = display_transcripts_var.get()
 
                     # Logic for converting UI to GPU index
                     selected_device_str = gpu_selection_var.get()
@@ -284,7 +286,8 @@ class UIManager:
                         new_save_audio_for_debug=save_audio_for_debug_to_apply,
                         new_use_vad=use_vad_to_apply,
                         new_vad_threshold=vad_threshold_to_apply,
-                        new_vad_silence_duration=vad_silence_duration_to_apply
+                        new_vad_silence_duration=vad_silence_duration_to_apply,
+                        new_display_transcripts_in_terminal=display_transcripts_to_apply
                     )
                     self._close_settings_window() # Call class method
 
@@ -449,6 +452,10 @@ class UIManager:
                 save_audio_frame = ctk.CTkFrame(transcription_frame)
                 save_audio_frame.pack(fill="x", pady=5)
                 ctk.CTkSwitch(save_audio_frame, text="Save Audio for Debug", variable=save_audio_var).pack(side="left", padx=5)
+
+                display_transcripts_frame = ctk.CTkFrame(transcription_frame)
+                display_transcripts_frame.pack(fill="x", pady=5)
+                ctk.CTkSwitch(display_transcripts_frame, text="Display Transcript in Terminal", variable=display_transcripts_var).pack(side="left", padx=5)
 
                 # --- Action Buttons ---
                 button_frame = ctk.CTkFrame(settings_win) # Move outside scrollable_frame to keep fixed


### PR DESCRIPTION
## Summary
- document `display_transcripts_in_terminal`
- store setting in `ConfigManager`
- show transcript text in terminal when enabled
- expose the option in settings GUI

## Testing
- `flake8 src/gemini_api.py src/openrouter_api.py` *(fails: E261, E302, E501, E129, E701, W391)*
- `python src/main.py` *(fails: KeyError: 'DISPLAY')*

------
https://chatgpt.com/codex/tasks/task_e_6851f0381f70833094975d8898b40314