### PR TITLE
Mostrar transcrição bruta no terminal

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -173,14 +173,15 @@ class AppCore:
             self.on_segment_transcribed(text)
         self.full_transcription += text + " " # Acumula a transcrição completa
 
-    def _handle_transcription_result(self, text_to_display):
+    def _handle_transcription_result(self, corrected_text, raw_text):
         """Lida com o resultado final da transcrição (copiar/colar)."""
         logging.info("AppCore: Lidando com o resultado final da transcrição.")
         # O texto já foi acumulado em _on_segment_transcribed_for_ui
-        final_text = self.full_transcription.strip()
+        final_text = corrected_text
 
         if self.display_transcripts_in_terminal:
-            print("\n=== TRANSCRIÇÃO COMPLETA ===\n" + final_text + "\n============================\n")
+            print("\n=== TRANSCRIÇÃO BRUTA ===\n" + raw_text + "\n======================\n")
+            print("\n=== TRANSCRIÇÃO CORRIGIDA ===\n" + final_text + "\n===========================\n")
 
         if pyperclip:
             try:

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -300,7 +300,7 @@ class TranscriptionHandler:
                 if text_result and self.on_segment_transcribed_callback:
                     self.on_segment_transcribed_callback(text_result or "")
                 if not agent_mode and text_result:
-                     self.on_transcription_result_callback(text_result)
+                     self.on_transcription_result_callback(text_result, text_result)
                 return
 
             # A partir daqui, text_result é válido. Mostra a transcrição crua na UI.
@@ -328,7 +328,7 @@ class TranscriptionHandler:
                 if self.config_manager.get("save_audio_for_debug"):
                     logging.info(f"Transcrição corrigida: {final_text}")
 
-                self.on_transcription_result_callback(final_text)
+                self.on_transcription_result_callback(final_text, text_result)
 
             # Limpeza de cache da GPU sempre ao final
             if torch.cuda.is_available():


### PR DESCRIPTION
## Summary
- exibimos tanto a transcrição bruta quanto a corrigida no terminal quando `display_transcripts_in_terminal` está ativo
- passamos o texto bruto para o callback da transcrição

## Testing
- `python -m py_compile src/transcription_handler.py src/core.py`

------
https://chatgpt.com/codex/tasks/task_e_6851f4d92cf083308d49b6ad16745694