### PR TITLE
Fix terminal transcript label language

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -180,7 +180,7 @@ class AppCore:
         final_text = self.full_transcription.strip()
 
         if self.display_transcripts_in_terminal:
-            print("\n=== TRANSCRIÇÃO COMPLETA ===\n" + final_text + "\n============================\n")
+            print("\n=== COMPLETE TRANSCRIPTION ===\n" + final_text + "\n==============================\n")
 
         if pyperclip:
             try:
@@ -192,7 +192,7 @@ class AppCore:
         if self.auto_paste:
             self._do_paste()
         else:
-            self._log_status("Transcrição completa. Auto-colar desativado.")
+            self._log_status("Transcription complete. Auto-paste disabled.")
         
         self._set_state(STATE_IDLE)
         if self.ui_manager:


### PR DESCRIPTION
## Summary
- update terminal transcript heading to English
- log status in English when auto-paste is disabled

## Testing
- `flake8 src/gemini_api.py src/openrouter_api.py` *(fails: style errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851f4edef3883309ced8caba792ddd4