### PR TITLE
Conserto de chave duplicada na configuração

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -24,7 +24,6 @@ DEFAULT_CONFIG = {
     "gemini_api_key": "",
     "gemini_model": "gemini-2.5-flash-preview-05-20",
     "gemini_agent_model": "gemini-2.5-flash-preview-05-20",
-    "display_transcripts_in_terminal": True,
     "prompt_agentico": "Você é um assistente de IA que executa comandos de texto. O usuário fornecerá uma instrução seguida do texto a ser processado. Sua tarefa é executar a instrução sobre o texto e retornar APENAS o resultado final. Não adicione explicações, saudações ou qualquer texto extra. A instrução do usuário é a prioridade máxima. O idioma de saída deve corresponder ao idioma principal do texto fornecido.",
     "gemini_prompt": """You are a speech-to-text correction specialist. Your task is to refine the following transcribed speech.
 Key instructions:
@@ -55,8 +54,7 @@ Transcribed speech: {text}""",
         "gemini-2.5-pro"
     ],
     "save_audio_for_debug": False,
-    "min_transcription_duration": 1.0, # Nova configuração
-    "display_transcripts": False
+    "min_transcription_duration": 1.0 # Nova configuração
 }
 
 # Outras constantes de configuração (movidas de whisper_tkinter.py)
@@ -77,7 +75,7 @@ DISPLAY_TRANSCRIPTS_KEY = "display_transcripts_in_terminal"
 USE_VAD_CONFIG_KEY = "use_vad"
 VAD_THRESHOLD_CONFIG_KEY = "vad_threshold"
 VAD_SILENCE_DURATION_CONFIG_KEY = "vad_silence_duration"
-DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY = "display_transcripts_in_terminal"
+DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY = DISPLAY_TRANSCRIPTS_KEY
 KEYBOARD_LIBRARY_CONFIG_KEY = "keyboard_library"
 KEYBOARD_LIB_WIN32 = "win32"
 TEXT_CORRECTION_ENABLED_CONFIG_KEY = "text_correction_enabled"
@@ -95,7 +93,6 @@ SETTINGS_WINDOW_GEOMETRY = "550x700"
 REREGISTER_INTERVAL_SECONDS = 60
 MAX_HOTKEY_FAILURES = 3
 HOTKEY_HEALTH_CHECK_INTERVAL = 10
-DISPLAY_TRANSCRIPTS_KEY = "display_transcripts"
 
 class ConfigManager:
     def __init__(self, config_file=CONFIG_FILE, default_config=DEFAULT_CONFIG):

--- a/src/core.py
+++ b/src/core.py
@@ -10,7 +10,13 @@ import queue # Adicionado para queue.Full no shutdown
 from tkinter import messagebox # Adicionado para messagebox no _on_model_load_failed
 
 # Importar os novos módulos
-from .config_manager import ConfigManager, DEFAULT_CONFIG, REREGISTER_INTERVAL_SECONDS, HOTKEY_HEALTH_CHECK_INTERVAL
+from .config_manager import (
+    ConfigManager,
+    DEFAULT_CONFIG,
+    REREGISTER_INTERVAL_SECONDS,
+    HOTKEY_HEALTH_CHECK_INTERVAL,
+    DISPLAY_TRANSCRIPTS_KEY,
+)
 from .audio_handler import AudioHandler, AUDIO_SAMPLE_RATE # AUDIO_SAMPLE_RATE ainda é usado em _handle_transcription_result
 from .transcription_handler import TranscriptionHandler
 from .keyboard_hotkey_manager import KeyboardHotkeyManager # Assumindo que está na raiz
@@ -94,7 +100,7 @@ class AppCore:
         self.hotkey_stability_service_enabled = self.config_manager.get("hotkey_stability_service_enabled") # Nova configuração unificada
         self.keyboard_library = self.config_manager.get("keyboard_library")
         self.min_record_duration = self.config_manager.get("min_record_duration")
-        self.display_transcripts_in_terminal = self.config_manager.get("display_transcripts_in_terminal")
+        self.display_transcripts_in_terminal = self.config_manager.get(DISPLAY_TRANSCRIPTS_KEY)
         # ... e outras configurações que AppCore precisa diretamente
 
     # --- Callbacks de Módulos ---

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -11,9 +11,13 @@ from tkinter import simpledialog # Adicionado para askstring
 
 # Importar constantes de configuração
 from .config_manager import (
-    DEFAULT_CONFIG, SETTINGS_WINDOW_GEOMETRY,
-    SERVICE_NONE, SERVICE_OPENROUTER, SERVICE_GEMINI,
-    GEMINI_MODEL_OPTIONS_CONFIG_KEY
+    DEFAULT_CONFIG,
+    SETTINGS_WINDOW_GEOMETRY,
+    SERVICE_NONE,
+    SERVICE_OPENROUTER,
+    SERVICE_GEMINI,
+    GEMINI_MODEL_OPTIONS_CONFIG_KEY,
+    DISPLAY_TRANSCRIPTS_KEY,
 )
 
 # Importar get_available_devices_for_ui (pode ser movido para um utils ou ficar aqui)
@@ -186,7 +190,7 @@ class UIManager:
                 vad_threshold_var = ctk.DoubleVar(value=self.config_manager.get("vad_threshold"))
                 vad_silence_duration_var = ctk.DoubleVar(value=self.config_manager.get("vad_silence_duration"))
                 save_audio_var = ctk.BooleanVar(value=self.config_manager.get("save_audio_for_debug"))
-                display_transcripts_var = ctk.BooleanVar(value=self.config_manager.get("display_transcripts_in_terminal"))
+                display_transcripts_var = ctk.BooleanVar(value=self.config_manager.get(DISPLAY_TRANSCRIPTS_KEY))
                 gemini_prompt_correction_var = ctk.StringVar(value=self.config_manager.get("gemini_prompt"))
 
                 # GPU selection variable


### PR DESCRIPTION
## Resumo
- remove duplicação `display_transcripts_in_terminal` em `DEFAULT_CONFIG`
- define `DISPLAY_TRANSCRIPTS_KEY` uma única vez
- usa a chave padronizada em `core` e `ui_manager`

## Testes
- `python -m py_compile $(git ls-files '*.py')`
- script manual para validar persistência de `display_transcripts_in_terminal`


------
https://chatgpt.com/codex/tasks/task_e_6851f85476b48330aa9f5184c6a144cb