### PR TITLE
Atualiza tipos opcionais do cliente OpenRouter

### DIFF
--- a/src/openrouter_api.py
+++ b/src/openrouter_api.py
@@ -2,6 +2,7 @@ import requests
 import json
 import logging
 import time
+from typing import Optional
 
 
 class OpenRouterAPI:
@@ -27,8 +28,11 @@ class OpenRouterAPI:
             "X-Title": "Whisper Recorder",
         }
 
-    def reinitialize_client(self, api_key: str | None = None,
-                            model_id: str | None = None) -> None:
+    def reinitialize_client(
+        self,
+        api_key: Optional[str] = None,
+        model_id: Optional[str] = None,
+    ) -> None:
         """Atualiza chave, modelo e cabeçalhos do cliente.
 
         Args:


### PR DESCRIPTION
## Resumo
- usa `Optional[str]` nas anotações do `reinitialize_client`
- adiciona import de `Optional`
- valida o arquivo com `flake8`

## Testes
- `flake8 src/openrouter_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6851f8556aec8330aba0e174680c03e7