### PR TITLE
Remover suporte inexistente a gemini_mode

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -498,7 +498,7 @@ class AppCore:
                 "new_openrouter_api_key": "openrouter_api_key", "new_openrouter_model": "openrouter_model",
                 "new_gemini_api_key": "gemini_api_key", "new_gemini_model": "gemini_model",
                 "new_agent_model": "gemini_agent_model",
-                "new_gemini_mode": "gemini_mode", "new_gemini_prompt": "gemini_prompt",
+                "new_gemini_prompt": "gemini_prompt",
                 "new_prompt_agentico": "prompt_agentico",
                 "new_batch_size": "batch_size", "new_gpu_index": "gpu_index",
                 "new_hotkey_stability_service_enabled": "hotkey_stability_service_enabled", # Nova configuração unificada

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -46,10 +46,8 @@ class TranscriptionHandler:
         self.openrouter_api_key = self.config_manager.get(OPENROUTER_API_KEY_CONFIG_KEY)
         self.openrouter_model = self.config_manager.get(OPENROUTER_MODEL_CONFIG_KEY)
         self.gemini_api_key = self.config_manager.get(GEMINI_API_KEY_CONFIG_KEY)
-        self.gemini_model = self.config_manager.get(GEMINI_MODEL_CONFIG_KEY)
         self.gemini_agent_model = self.config_manager.get('gemini_agent_model')
         self.gemini_prompt = self.config_manager.get("gemini_prompt")
-        self.gemini_mode = self.config_manager.get("gemini_mode")
         self.min_transcription_duration = self.config_manager.get(MIN_TRANSCRIPTION_DURATION_CONFIG_KEY)
 
         self.openrouter_client = None
@@ -85,7 +83,6 @@ class TranscriptionHandler:
         self.openrouter_api_key = self.config_manager.get(OPENROUTER_API_KEY_CONFIG_KEY)
         self.openrouter_model = self.config_manager.get(OPENROUTER_MODEL_CONFIG_KEY)
         self.gemini_api_key = self.config_manager.get(GEMINI_API_KEY_CONFIG_KEY)
-        self.gemini_model = self.config_manager.get(GEMINI_MODEL_CONFIG_KEY)
         self.gemini_agent_model = self.config_manager.get('gemini_agent_model')
         self.gemini_prompt = self.config_manager.get("gemini_prompt")
         self.min_transcription_duration = self.config_manager.get(MIN_TRANSCRIPTION_DURATION_CONFIG_KEY)

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -180,7 +180,6 @@ class UIManager:
                 openrouter_model_var = ctk.StringVar(value=self.config_manager.get("openrouter_model"))
                 gemini_api_key_var = ctk.StringVar(value=self.config_manager.get("gemini_api_key"))
                 gemini_model_var = ctk.StringVar(value=self.config_manager.get("gemini_model"))
-                gemini_mode_var = ctk.StringVar(value=self.config_manager.get("gemini_mode"))
                 batch_size_var = ctk.StringVar(value=str(self.config_manager.get("batch_size")))
                 use_vad_var = ctk.BooleanVar(value=self.config_manager.get("use_vad"))
                 vad_threshold_var = ctk.DoubleVar(value=self.config_manager.get("vad_threshold"))
@@ -229,7 +228,6 @@ class UIManager:
                     openrouter_model_to_apply = openrouter_model_var.get()
                     gemini_api_key_to_apply = gemini_api_key_var.get()
                     gemini_model_to_apply = gemini_model_var.get()
-                    gemini_mode_to_apply = gemini_mode_var.get()
                     gemini_prompt_correction_to_apply = gemini_prompt_correction_textbox.get("1.0", "end-1c")
                     agentico_prompt_to_apply = agentico_prompt_textbox.get("1.0", "end-1c")
                     batch_size_to_apply = int(batch_size_var.get())
@@ -274,7 +272,6 @@ class UIManager:
                         new_openrouter_model=openrouter_model_to_apply,
                         new_gemini_api_key=gemini_api_key_to_apply,
                         new_gemini_model=gemini_model_to_apply,
-                        new_gemini_mode=gemini_mode_to_apply,
                         new_gemini_prompt=gemini_prompt_correction_to_apply,
                         new_prompt_agentico=agentico_prompt_to_apply,
                         new_agent_model=model_to_apply,


### PR DESCRIPTION
## Resumo
- exclui todas as menções a `gemini_mode`
- ajusta o mapeamento de configurações em `AppCore`
- remove variáveis não utilizadas na UI

## Testes
- `python -m py_compile src/transcription_handler.py src/core.py src/ui_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851f85674248330b2ceb39fa188e1b1