### PR TITLE
Remove imports redundantes no UIManager

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -1,17 +1,14 @@
-import tkinter as tk
 import customtkinter as ctk
 import tkinter.messagebox as messagebox
 from tkinter import simpledialog # Adicionado para askstring
 import logging
 import threading
-import time
 import pystray
 from PIL import Image, ImageDraw
-from tkinter import simpledialog # Adicionado para askstring
 
 # Importar constantes de configuração
 from .config_manager import (
-    DEFAULT_CONFIG, SETTINGS_WINDOW_GEOMETRY,
+    SETTINGS_WINDOW_GEOMETRY,
     SERVICE_NONE, SERVICE_OPENROUTER, SERVICE_GEMINI,
     GEMINI_MODEL_OPTIONS_CONFIG_KEY
 )


### PR DESCRIPTION
## Descrição
- remove duplicação de `simpledialog`
- remove imports não utilizados (`tkinter` e `time`)
- ajusta lista de importação de `config_manager`

## Testes
- `ruff check src/ui_manager.py --select F401`

------
https://chatgpt.com/codex/tasks/task_e_6851f8577f04833081093e1865b652e7