### PR TITLE
Zera contador de silêncio ao iniciar e parar gravação

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -107,6 +107,11 @@ class AudioHandler:
         self.start_time = time.time()
         self.recording_data.clear()
 
+        if self.use_vad and self.vad_manager:
+            self.vad_manager.reset_states()
+        self._vad_silence_counter = 0.0
+        logging.debug("VAD reiniciado e contador de silêncio zerado para nova gravação.")
+
         self.on_recording_state_change_callback("RECORDING")
 
         threading.Thread(target=self._record_audio_task, daemon=True, name="AudioRecordThread").start()
@@ -120,6 +125,11 @@ class AudioHandler:
             return False
         
         self.is_recording = False
+
+        if self.use_vad and self.vad_manager:
+            self.vad_manager.reset_states()
+        self._vad_silence_counter = 0.0
+        logging.debug("VAD reiniciado e contador de silêncio zerado ao parar a gravação.")
 
         threading.Thread(target=self._play_generated_tone_stream, kwargs={"is_start": False}, daemon=True, name="StopSoundThread").start()
 


### PR DESCRIPTION
## Resumo
- reinicia estados do VAD e contador `_vad_silence_counter` ao iniciar a gravação
- faz a mesma limpeza ao parar gravação
- inclui logging informativo para cada reinicialização

## Testes
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6852de3966c48330b27a5241da511459