### PR TITLE
Fix DISPLAY_TRANSCRIPTS_KEY import

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -10,7 +10,8 @@ from PIL import Image, ImageDraw
 from .config_manager import (
     SETTINGS_WINDOW_GEOMETRY,
     SERVICE_NONE, SERVICE_OPENROUTER, SERVICE_GEMINI,
-    GEMINI_MODEL_OPTIONS_CONFIG_KEY
+    GEMINI_MODEL_OPTIONS_CONFIG_KEY,
+    DISPLAY_TRANSCRIPTS_KEY,
 )
 
 # Importar get_available_devices_for_ui (pode ser movido para um utils ou ficar aqui)


### PR DESCRIPTION
## Summary
- fix missing import for `DISPLAY_TRANSCRIPTS_KEY` in `UIManager`

## Testing
- `python -m py_compile src/ui_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6852e04a01388330a0eaea8d51d8c652