### PR TITLE
Remover torch em vad_manager

### DIFF
--- a/src/vad_manager.py
+++ b/src/vad_manager.py
@@ -1,7 +1,6 @@
 import logging
 import numpy as np
 import onnxruntime
-import torch
 from pathlib import Path
 
 # Construir um caminho absoluto para o modelo ONNX, relativo a este arquivo.
@@ -47,7 +46,7 @@ class VADManager:
             audio_chunk = audio_chunk.mean(axis=1)
 
         ort_inputs = {
-            "input": torch.from_numpy(audio_chunk).unsqueeze(0).numpy(),
+            "input": np.expand_dims(audio_chunk, 0),
             "state": self._state,
             "sr": np.array([self.sr], dtype=np.int64),
         }


### PR DESCRIPTION
## Mudanças principais
- Removido `import torch` do arquivo `src/vad_manager.py`.
- Atualizada a construção de `ort_inputs` para utilizar `np.expand_dims` em vez de `torch.from_numpy`.

## Testes
- Execução de `flake8 src/vad_manager.py` para checar erros de estilo e sintaxe (ainda há advertências pré-existentes).

------
https://chatgpt.com/codex/tasks/task_e_6852e063dcf483309361275d194396fd