### PR TITLE
Remover psutil das dependências

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ pystray
 pillow
 pyperclip
 requests
-psutil
 google-generativeai
 customtkinter
 keyboard

--- a/requirements.txt.bak
+++ b/requirements.txt.bak
@@ -7,5 +7,4 @@ pystray
 pillow
 pyperclip
 requests
-psutil
 google-generativeai


### PR DESCRIPTION
## Resumo
- exclui `psutil` de `requirements.txt` e `requirements.txt.bak`
- verifiquei com `pip install --dry-run -r requirements.txt` que o pacote não é solicitado

## Testes
- `pip install --dry-run -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6852f135e9e08330bb1410010d097a34