### PR TITLE
Melhoria no tratamento de VAD ausente

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ With your virtual environment activated, you can now install the libraries the a
     ```bash
     pip install -r requirements.txt
     ```
-    The `pip` command is Python's package installer. The `-r requirements.txt` part tells pip to install everything listed in that file. This step will download and install all necessary packages, including large ones like `torch` and `transformers`. This might take several minutes depending on your internet speed.
+The `pip` command is Python's package installer. The `-r requirements.txt` part tells pip to install everything listed in that file. This step will download and install all necessary packages, including large ones like `torch` and `transformers`. This might take several minutes depending on your internet speed.
 
 2.  **Optional: Install PyTorch with CUDA (For GPU Acceleration):**
     The `requirements.txt` includes a basic installation of PyTorch. However, if you have a compatible NVIDIA graphics card, you can significantly speed up the transcription process by installing a version of PyTorch that uses your GPU (CUDA).
@@ -185,6 +185,15 @@ With your virtual environment activated, you can now install the libraries the a
         ```
     *   This command will download and install the GPU-accelerated version of PyTorch. It's a large download. If you already installed the CPU version via `requirements.txt`, this command will upgrade it.
     *   If you do *not* have a compatible GPU or prefer not to use it, you can skip this step. The application will still work using your CPU, just slower.
+
+### Opcional: Baixar o modelo Silero VAD
+
+Para remover trechos silenciosos automaticamente é necessário o arquivo `silero_vad.onnx` na pasta `src/models/`.
+Caso ele não esteja presente, o aplicativo irá registrar um erro e prosseguir sem o VAD.
+
+1. Acesse <https://github.com/snakers4/silero-vad>.
+2. Baixe o arquivo `silero_vad.onnx` disponível no repositório.
+3. Copie o arquivo para a pasta `src/models/` deste projeto.
 
 ### Step 5: Run the Application
 

--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -35,6 +35,10 @@ class AudioHandler:
         self.vad_threshold = self.config_manager.get("vad_threshold")
         self.vad_silence_duration = self.config_manager.get("vad_silence_duration")
         self.vad_manager = VADManager(threshold=self.vad_threshold) if self.use_vad else None
+        if self.use_vad and self.vad_manager and not self.vad_manager.enabled:
+            logging.error("VAD desativado: modelo n\u00e3o encontrado.")
+            self.use_vad = False
+            self.vad_manager = None
         self._vad_silence_counter = 0.0
 
     def _audio_callback(self, indata, frames, time_data, status):
@@ -266,6 +270,10 @@ class AudioHandler:
                 self.vad_manager = VADManager(threshold=self.vad_threshold)
             else:
                 self.vad_manager.threshold = self.vad_threshold
+            if not self.vad_manager.enabled:
+                logging.error("VAD desativado: modelo n\u00e3o encontrado.")
+                self.use_vad = False
+                self.vad_manager = None
         else:
             self.vad_manager = None
 

--- a/src/vad_manager.py
+++ b/src/vad_manager.py
@@ -12,25 +12,33 @@ class VADManager:
     """Gerencia a detecção de voz usando o modelo Silero."""
 
     def __init__(self, threshold: float = 0.5, sampling_rate: int = 16000):
-        """
-        Inicializa o VAD Manager. O caminho do modelo é determinado internamente
-        para garantir robustez.
-        """
+        """Inicializa o VAD Manager."""
+
+        self.threshold = threshold
+        self.sr = sampling_rate
+        self.enabled = False
+
+        if not MODEL_PATH.exists():
+            logging.error(
+                "Arquivo do modelo VAD ausente em '%s'. Recurso VAD desabilitado.",
+                MODEL_PATH,
+            )
+            self.session = None
+            return
+
         try:
-            # Garante que o caminho seja uma string para a sessão ONNX
             model_path_str = str(MODEL_PATH)
             self.session = onnxruntime.InferenceSession(model_path_str)
-            self.threshold = threshold
-            self.sr = sampling_rate
+            self.enabled = True
             self.reset_states()
-            logging.info(f"Modelo VAD carregado com sucesso de '{model_path_str}'.")
-        except FileNotFoundError:
-            logging.error(f"Arquivo do modelo VAD não encontrado no caminho esperado: {MODEL_PATH}")
-            logging.error("Certifique-se de que o arquivo 'silero_vad.onnx' existe em 'src/models/'.")
-            raise
+            logging.info(
+                "Modelo VAD carregado com sucesso de '%s'.", model_path_str
+            )
         except Exception as exc:
-            logging.error(f"Erro ao carregar o modelo VAD de '{MODEL_PATH}': {exc}", exc_info=True)
-            raise
+            logging.error(
+                "Erro ao carregar o modelo VAD de '%s': %s", MODEL_PATH, exc, exc_info=True
+            )
+            self.session = None
 
     def reset_states(self) -> None:
         """Reseta os estados internos do modelo."""
@@ -38,7 +46,12 @@ class VADManager:
         self._state = np.zeros((2, 1, 128), dtype=np.float32)
 
     def is_speech(self, audio_chunk: np.ndarray) -> bool:
-        """Retorna True se o chunk contém fala."""
+        """Retorna ``True`` se o chunk contém fala."""
+
+        if self.session is None:
+            # VAD desabilitado – assume sempre haver fala para não cortar áudio
+            return True
+
         if not isinstance(audio_chunk, np.ndarray):
             raise TypeError("audio_chunk deve ser um np.ndarray")
         if audio_chunk.dtype != np.float32:


### PR DESCRIPTION
## Resumo
- validar existencia do arquivo `silero_vad.onnx` antes de criar a sessao ONNX
- desabilitar VAD quando o modelo nao estiver disponivel
- ajustar `AudioHandler` para refletir o estado do VAD
- documentar no README como obter o modelo Silero VAD

## Testes
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6852f197a6bc833087102cf005c56c43