### PR TITLE
Remover global desnecessário em on_exit_app_enhanced

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -38,7 +38,6 @@ app_core_instance = None
 ui_manager_instance = None
 
 def on_exit_app_enhanced(*_):
-    global app_core_instance, ui_manager_instance
     logging.info("Saída solicitada pelo ícone da bandeja.")
     if app_core_instance:
         app_core_instance.shutdown()


### PR DESCRIPTION
## Mudanças propostas
- Ajuste na função `on_exit_app_enhanced` para remover a declaração `global app_core_instance, ui_manager_instance`, pois a função apenas lê essas variáveis.

## Notas de teste
- Não há suíte automatizada (`pytest -q` retorna zero testes).
- Foi executado teste manual simulando chamadas da função sem a declaração `global`, confirmando a ordem de desligamento e encerramento (vide saída do bloco `c50808`).
- Instalação de dependências completas não foi possível, impedindo testes integrados.


------
https://chatgpt.com/codex/tasks/task_e_6852f28277d88330bc34c083bc945eb2