### PR TITLE
Remover estado SAVING

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A lightweight, high-performance desktop tool for Windows that turns your speech 
 *   **Auditory Feedback:** Optional sound cues for starting and stopping recording.
 *   **Remove trechos silenciosos de forma automática** por meio do Silero VAD.
 *   **Robust and Stable:** Includes a background service to ensure hotkeys remain responsive, a common issue on Windows 11.
+*   **Gerenciamento Simplificado de Estados:** o antigo estado "SAVING" foi removido por não haver funcionalidade associada.
 
 ## System Architecture
 

--- a/src/core.py
+++ b/src/core.py
@@ -32,7 +32,6 @@ from .gemini_api import GeminiAPI # Adicionado para correção de texto
 STATE_IDLE = "IDLE"
 STATE_LOADING_MODEL = "LOADING_MODEL"
 STATE_RECORDING = "RECORDING"
-STATE_SAVING = "SAVING"
 STATE_TRANSCRIBING = "TRANSCRIBING"
 STATE_ERROR_MODEL = "ERROR_MODEL"
 STATE_ERROR_AUDIO = "ERROR_AUDIO"
@@ -398,7 +397,7 @@ class AppCore:
 
     def force_reregister_hotkeys(self):
         with self.state_lock: current_state = self.current_state
-        if current_state not in [STATE_RECORDING, STATE_SAVING, STATE_LOADING_MODEL]:
+        if current_state not in [STATE_RECORDING, STATE_LOADING_MODEL]:
             logging.info(f"Manual trigger: State is {current_state}. Attempting hotkey re-registration.")
             with self.hotkey_lock:
                 try:

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -64,7 +64,6 @@ class UIManager:
             "IDLE": ('green', 'white'),
             "LOADING_MODEL": ('gray', 'yellow'),
             "RECORDING": ('red', 'white'),
-            "SAVING": ('orange', 'white'),
             "TRANSCRIBING": ('blue', 'white'),
             "ERROR_MODEL": ('black', 'red'),
             "ERROR_AUDIO": ('black', 'red'),


### PR DESCRIPTION
## Summary
- remove a constante `STATE_SAVING` do núcleo
- ajustar verificação de hotkeys
- limpar mapeamento de cor da UI
- documentar remoção de estado

## Testing
- `flake8 src/gemini_api.py src/openrouter_api.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852f2eb9d048330b5db3791176d8e5f