### PR TITLE
Verificação de estado antes de atualizar UI

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -66,7 +66,8 @@ class AppCore:
             on_model_error_callback=self._on_model_load_failed,
             on_transcription_result_callback=self._handle_transcription_result,
             on_agent_result_callback=self._handle_agent_result_final, # Usa o novo callback
-            on_segment_transcribed_callback=self._on_segment_transcribed_for_ui
+            on_segment_transcribed_callback=self._on_segment_transcribed_for_ui,
+            state_check_callback=self.is_state_transcribing,
         )
         self.ui_manager = None # Será setado externamente pelo main.py
 
@@ -300,6 +301,11 @@ class AppCore:
                 callback_to_call(current_state_for_callback)
             except Exception as e:
                 logging.error(f"Error calling state update callback for state {current_state_for_callback}: {e}")
+
+    def is_state_transcribing(self):
+        """Retorna True se o estado atual for TRANSCRIBING."""
+        with self.state_lock:
+            return self.current_state == STATE_TRANSCRIBING
 
     def _log_status(self, text, error=False):
         if error: logging.error(text)


### PR DESCRIPTION
## Summary
- adicionar `state_check_callback` ao `TranscriptionHandler`
- verificar estado antes de atualizar resultados finais de transcrição ou agente
- expor `is_state_transcribing` em `AppCore` e passar como callback

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685306eb499c8330985f2310e0ef17fb