### PR TITLE
Adicionar opções de cancelamento no menu

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -683,6 +683,16 @@ class UIManager:
                     )
                 )
             ),
+            pystray.MenuItem(
+                '🚫 Cancel Transcription',
+                lambda: self.core_instance_ref.cancel_transcription(),
+                enabled=self.core_instance_ref.is_transcription_running()
+            ),
+            pystray.MenuItem(
+                '⛔ Cancel Correction',
+                lambda: self.core_instance_ref.cancel_text_correction(),
+                enabled=self.core_instance_ref.is_correction_running()
+            ),
             pystray.Menu.SEPARATOR,
             pystray.MenuItem('❌ Exit', self.on_exit_app)
         ]


### PR DESCRIPTION
## Notas
- Inclusão dos itens "🚫 Cancel Transcription" e "⛔ Cancel Correction" na função `create_dynamic_menu`.
- Cada item invoca os métodos correspondentes do núcleo (`cancel_transcription` e `cancel_text_correction`) e é habilitado apenas quando o processo relacionado está ativo.

## Testes
- `pytest -q` executado após instalação do `numpy` — todos os testes passaram.

------
https://chatgpt.com/codex/tasks/task_e_68530affd5b88330840cfbfcd291b0e3