### PR TITLE
Fix state_check_callback initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,11 @@ If `pip install -r requirements.txt` fails or the application doesn't run due to
 *   **CUDA Compatibility:** If you are trying to install the CUDA version, double-check that your NVIDIA driver and CUDA toolkit versions are compatible with the PyTorch version you are trying to install, according to the PyTorch website.
 *   **Internet Connection:** Ensure you have a stable internet connection, as PyTorch and other libraries are large downloads.
 
+### Erro "state_check_callback"
+
+Caso ocorra a mensagem `AttributeError: 'TranscriptionHandler' object has no attribute 'state_check_callback'`,
+atualize para a versão mais recente. O atributo agora é inicializado corretamente em `TranscriptionHandler.__init__`.
+
 ## Contributing
 
 Contributions are welcome! If you have ideas for improvements, bug fixes, or new features, please:

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -28,6 +28,8 @@ class TranscriptionHandler:
         self.on_agent_result_callback = on_agent_result_callback # Para resultado do agente
         self.on_segment_transcribed_callback = on_segment_transcribed_callback # Para segmentos em tempo real
         self.is_state_transcribing_fn = is_state_transcribing_fn
+        # Alias para manter compatibilidade com referências existentes
+        self.state_check_callback = is_state_transcribing_fn
         self.correction_cancel_event = threading.Event()
 
         self.pipe = None

--- a/tests/test_transcription_handler_state.py
+++ b/tests/test_transcription_handler_state.py
@@ -1,0 +1,72 @@
+import importlib.machinery
+import types
+from types import SimpleNamespace
+
+# Stub simples de torch para evitar importacoes pesadas
+fake_torch = types.ModuleType("torch")
+fake_torch.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
+fake_torch.__version__ = "0.0"
+fake_torch.cuda = SimpleNamespace(is_available=lambda: False)
+
+import sys
+sys.modules["torch"] = fake_torch
+
+from src.transcription_handler import TranscriptionHandler
+from src.config_manager import (
+    BATCH_SIZE_CONFIG_KEY,
+    BATCH_SIZE_MODE_CONFIG_KEY,
+    MANUAL_BATCH_SIZE_CONFIG_KEY,
+    GPU_INDEX_CONFIG_KEY,
+    TEXT_CORRECTION_ENABLED_CONFIG_KEY,
+    TEXT_CORRECTION_SERVICE_CONFIG_KEY,
+    SERVICE_NONE,
+    OPENROUTER_API_KEY_CONFIG_KEY,
+    OPENROUTER_MODEL_CONFIG_KEY,
+    GEMINI_API_KEY_CONFIG_KEY,
+    MIN_TRANSCRIPTION_DURATION_CONFIG_KEY,
+    DISPLAY_TRANSCRIPTS_KEY,
+)
+
+
+class DummyConfig:
+    def __init__(self):
+        self.data = {
+            BATCH_SIZE_CONFIG_KEY: 16,
+            BATCH_SIZE_MODE_CONFIG_KEY: "auto",
+            MANUAL_BATCH_SIZE_CONFIG_KEY: 8,
+            GPU_INDEX_CONFIG_KEY: -1,
+            "batch_size_specified": False,
+            "gpu_index_specified": False,
+            TEXT_CORRECTION_ENABLED_CONFIG_KEY: False,
+            TEXT_CORRECTION_SERVICE_CONFIG_KEY: SERVICE_NONE,
+            OPENROUTER_API_KEY_CONFIG_KEY: "",
+            OPENROUTER_MODEL_CONFIG_KEY: "",
+            GEMINI_API_KEY_CONFIG_KEY: "",
+            "gemini_agent_model": "",
+            "gemini_prompt": "",
+            MIN_TRANSCRIPTION_DURATION_CONFIG_KEY: 1.0,
+            DISPLAY_TRANSCRIPTS_KEY: False,
+        }
+
+    def get(self, key):
+        return self.data.get(key)
+
+
+# Funções de callback dummy
+noop = lambda *a, **k: None
+
+
+def test_state_check_callback_attribute():
+    cfg = DummyConfig()
+    handler = TranscriptionHandler(
+        cfg,
+        gemini_api_client=None,
+        on_model_ready_callback=noop,
+        on_model_error_callback=noop,
+        on_transcription_result_callback=noop,
+        on_agent_result_callback=noop,
+        on_segment_transcribed_callback=noop,
+        is_state_transcribing_fn=noop,
+    )
+    assert hasattr(handler, "state_check_callback")
+    assert handler.state_check_callback is handler.is_state_transcribing_fn


### PR DESCRIPTION
## Summary
- ensure `state_check_callback` is created inside `TranscriptionHandler`
- document the bug fix in README
- test presence of new attribute

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530bf531448330a7e86a907c0ee4ca