### PR TITLE
Fix join thread no close input stream

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -112,9 +112,9 @@ class AudioHandler:
         t = threading.Thread(target=_closer)
         t.start()
         finished_event.wait(timeout)
+        t.join(timeout)
         if t.is_alive():
-            logging.error("Timeout ao fechar InputStream.")
-        t.join(timeout=0)
+            logging.error("Thread de fechamento n\u00e3o terminou em %ss", timeout)
 
 
     def start_recording(self):


### PR DESCRIPTION
## Summary
- aguardar encerramento da thread de fechamento do `InputStream`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540da0bc548330aacb9df6684d5cba