### PR TITLE
Corrige imports de testes

### DIFF
--- a/tests/test_audio_handler.py
+++ b/tests/test_audio_handler.py
@@ -1,7 +1,10 @@
 import sys
+import os
 import unittest
 from unittest.mock import MagicMock, patch
 import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Módulos falsos para dependências nativas ausentes
 fake_sd = types.SimpleNamespace(

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,5 +1,8 @@
 import os
+import sys
 import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from src import config_manager
 
 

--- a/tests/test_transcription_handler_state.py
+++ b/tests/test_transcription_handler_state.py
@@ -1,6 +1,8 @@
 import importlib.machinery
 import types
 from types import SimpleNamespace
+import os
+from unittest.mock import MagicMock
 
 # Stub simples de torch para evitar importacoes pesadas
 fake_torch = types.ModuleType("torch")
@@ -10,6 +12,17 @@ fake_torch.cuda = SimpleNamespace(is_available=lambda: False)
 
 import sys
 sys.modules["torch"] = fake_torch
+
+fake_transformers = types.ModuleType("transformers")
+fake_transformers.pipeline = MagicMock()
+fake_transformers.AutoProcessor = MagicMock()
+fake_transformers.AutoModelForSpeechSeq2Seq = MagicMock()
+sys.modules["transformers"] = fake_transformers
+
+fake_requests = types.ModuleType("requests")
+sys.modules["requests"] = fake_requests
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.transcription_handler import TranscriptionHandler
 from src.config_manager import (


### PR DESCRIPTION
## Resumo
- insere ajuste de `sys.path` em arquivos de teste com `from src...`
- adiciona stubs leves para dependências pesadas nos testes

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540dd9b3708330a626b321afa370fb