### PR TITLE
Adicionar pacote src e ajustar testes

### DIFF
--- a/tests/test_audio_handler.py
+++ b/tests/test_audio_handler.py
@@ -2,6 +2,10 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 import types
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
 
 # Módulos falsos para dependências nativas ausentes
 fake_sd = types.SimpleNamespace(

--- a/tests/test_batch_size.py
+++ b/tests/test_batch_size.py
@@ -5,8 +5,8 @@ from types import SimpleNamespace
 from unittest import mock
 
 # Garantir que o diretório src esteja no path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
-
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 def _run_with_vram(free_gb):
     free_bytes = int(free_gb * (1024 ** 3))

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,5 +1,8 @@
 import os
 import time
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 from src import config_manager
 
 

--- a/tests/test_transcription_handler_state.py
+++ b/tests/test_transcription_handler_state.py
@@ -1,6 +1,9 @@
 import importlib.machinery
 import types
 from types import SimpleNamespace
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 # Stub simples de torch para evitar importacoes pesadas
 fake_torch = types.ModuleType("torch")


### PR DESCRIPTION
## Resumo
- cria arquivo `src/__init__.py` para tornar `src` um pacote Python
- insere ajustes de `sys.path` em todos os testes para garantir importações

## Testes
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68540da1794c83308a5f7eef05d8945a