### PR TITLE
Fix stop_recording logic to preserve recorded audio

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -154,8 +154,9 @@ class AudioHandler:
         if not self.is_recording:
             logging.warning("Gravação não está ativa para ser parada.")
             return False
-        
+
         self.is_recording = False
+        stream_was_started = self.stream_started
         self._stop_event.set()
 
         if self.use_vad and self.vad_manager:
@@ -168,7 +169,7 @@ class AudioHandler:
         if self._record_thread:
             self._record_thread.join(timeout=2)
 
-        if not self.stream_started:
+        if not stream_was_started:
             logging.warning("Stop recording called but audio stream never started. Ignoring data.")
             self.recording_data.clear()
             self.on_recording_state_change_callback("IDLE")

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -1,6 +1,7 @@
 import importlib.machinery
 import types
 import concurrent.futures
+from unittest.mock import MagicMock
 
 # Stub simples de torch
 fake_torch = types.ModuleType("torch")
@@ -10,6 +11,12 @@ fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
 
 import sys
 sys.modules["torch"] = fake_torch
+
+fake_transformers = types.ModuleType("transformers")
+fake_transformers.pipeline = MagicMock()
+fake_transformers.AutoProcessor = MagicMock()
+fake_transformers.AutoModelForSpeechSeq2Seq = MagicMock()
+sys.modules["transformers"] = fake_transformers
 
 from src.transcription_handler import TranscriptionHandler
 from src.config_manager import (


### PR DESCRIPTION
## Summary
- store `stream_started` status in a local variable during `stop_recording`
- respect the saved flag to decide whether to process audio
- ensure start/stop sequence succeeds without warning
- patch transcription handler tests for missing heavy modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541280b35c83309cf2680f3f61ed33