### PR TITLE
Fix missing transcription executor

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -738,6 +738,11 @@ class AppCore:
             if self.transcription_handler.transcription_in_progress:
                 logging.warning("Shutting down while transcription is in progress. Transcription may not complete.")
 
+        try:
+            self.transcription_handler.shutdown()
+        except Exception as e:
+            logging.error(f"Error shutting down TranscriptionHandler executor: {e}")
+
         if self.reregister_timer_thread and self.reregister_timer_thread.is_alive():
             self.reregister_timer_thread.join(timeout=1.5)
         if self.health_check_thread and self.health_check_thread.is_alive():

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -37,6 +37,10 @@ class TranscriptionHandler:
         self.pipe = None
         self.transcription_in_progress = False
         self.transcription_lock = threading.RLock()
+        # Executor dedicado para a tarefa de transcrição em background
+        self.transcription_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1
+        )
 
         # Configurações de modelo e API (carregadas do config_manager)
         self.batch_size = self.config_manager.get(BATCH_SIZE_CONFIG_KEY) # Agora é o batch_size padrão para o modo auto
@@ -391,3 +395,10 @@ class TranscriptionHandler:
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
                 logging.debug("Cache da GPU limpo após tarefa de transcrição.")
+
+    def shutdown(self) -> None:
+        """Encerra o executor de transcrição."""
+        try:
+            self.transcription_executor.shutdown(wait=False)
+        except Exception as e:
+            logging.error(f"Erro ao encerrar o executor de transcrição: {e}")


### PR DESCRIPTION
## Summary
- add dedicated transcription executor in TranscriptionHandler
- gracefully shutdown executor when closing the application

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685413eaaf408330bb58a5ef29f26f38