### PR TITLE
Adiciona sys.exit após mainloop

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -71,3 +71,4 @@ if __name__ == "__main__":
     logging.info("Iniciando o mainloop do Tkinter na thread principal.")
     main_tk_root.mainloop()
     logging.info("Mainloop do Tkinter finalizado. A aplicação será encerrada.")
+    sys.exit(0)


### PR DESCRIPTION
## Summary
- encerra a aplicação explicitamente após `mainloop`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685418c17a748330b765478187ed4d75