### PR TITLE
Implementação de botão de cancelamento na gravação

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -517,6 +517,13 @@ class AppCore:
     def is_correction_running(self) -> bool:
         return self.transcription_handler.is_text_correction_running()
 
+    def cancel_recording_and_corrections(self):
+        """Interrompe a gravação e cancela transcrições e correções em andamento."""
+        self.stop_recording_if_needed()
+        self.cancel_transcription()
+        self.cancel_text_correction()
+        self._set_state(STATE_IDLE)
+
     # --- Settings Application Logic (delegando para ConfigManager e outros) ---
     def apply_settings_from_external(self, **kwargs):
         logging.info("AppCore: Applying new configuration from external source.")

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -642,6 +642,17 @@ class UIManager:
                 default=True,
                 enabled=(is_recording or is_idle)
             ),
+        ]
+
+        if is_recording:
+            menu_items.append(
+                pystray.MenuItem(
+                    '🛑 Cancelar Transcrição e Correções',
+                    lambda: self.core_instance_ref.cancel_recording_and_corrections(),
+                )
+            )
+
+        menu_items.extend([
             pystray.MenuItem(
                 '⚙️ Settings',
                 lambda: self.main_tk_root.after(0, self.run_settings_gui), # Call on main thread
@@ -683,19 +694,9 @@ class UIManager:
                     )
                 )
             ),
-            pystray.MenuItem(
-                '🚫 Cancel Transcription',
-                lambda: self.core_instance_ref.cancel_transcription(),
-                enabled=self.core_instance_ref.is_transcription_running()
-            ),
-            pystray.MenuItem(
-                '⛔ Cancel Correction',
-                lambda: self.core_instance_ref.cancel_text_correction(),
-                enabled=self.core_instance_ref.is_correction_running()
-            ),
             pystray.Menu.SEPARATOR,
             pystray.MenuItem('❌ Exit', self.on_exit_app)
-        ]
+        ])
         return tuple(menu_items)
 
     def on_exit_app(self, *_):

--- a/tests/test_ui_manager_menu.py
+++ b/tests/test_ui_manager_menu.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+import types
+fake_ctk = types.ModuleType("customtkinter")
+sys.modules["customtkinter"] = fake_ctk
+fake_pystray = types.ModuleType("pystray")
+fake_pystray.MenuItem = lambda *a, **k: types.SimpleNamespace(text=a[0])
+fake_pystray.Menu = lambda *a, **k: list(a)
+fake_pystray.Menu.SEPARATOR = object()
+sys.modules["pystray"] = fake_pystray
+fake_pil = types.ModuleType("PIL")
+fake_pil.Image = types.SimpleNamespace(new=lambda *a, **k: None)
+fake_pil.ImageDraw = types.SimpleNamespace(Draw=lambda *a, **k: None)
+sys.modules["PIL"] = fake_pil
+fake_torch = types.ModuleType("torch")
+fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+sys.modules["torch"] = fake_torch
+
+import src.ui_manager as ui_manager
+from src.ui_manager import UIManager
+from src.config_manager import GEMINI_MODEL_OPTIONS_CONFIG_KEY
+
+class DummyConfig:
+    def __init__(self):
+        self.data = {GEMINI_MODEL_OPTIONS_CONFIG_KEY: []}
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+class DummyCore:
+    def __init__(self, state):
+        self.current_state = state
+    def toggle_recording(self):
+        pass
+    def cancel_recording_and_corrections(self):
+        pass
+    def is_transcription_running(self):
+        return False
+    def is_correction_running(self):
+        return False
+
+class DummyPystray:
+    class MenuItem:
+        def __init__(self, text, *a, **k):
+            self.text = text
+    class Menu(list):
+        def __init__(self, *items):
+            super().__init__(items)
+    Menu.SEPARATOR = object()
+
+
+def test_menu_contains_cancel_option_only_when_recording(monkeypatch):
+    dummy_tk = types.SimpleNamespace()
+    core = DummyCore('RECORDING')
+    ui = UIManager(dummy_tk, DummyConfig(), core)
+    monkeypatch.setattr(ui_manager, 'pystray', DummyPystray)
+
+    menu = ui.create_dynamic_menu()
+    texts = [getattr(item, 'text', None) for item in menu if hasattr(item, 'text')]
+    assert '🛑 Cancelar Transcrição e Correções' in texts
+
+    core.current_state = 'IDLE'
+    menu = ui.create_dynamic_menu()
+    texts = [getattr(item, 'text', None) for item in menu if hasattr(item, 'text')]
+    assert '🛑 Cancelar Transcrição e Correções' not in texts


### PR DESCRIPTION
## Resumo
- adicionar método `cancel_recording_and_corrections` em `AppCore`
- criar item de menu dinâmico "Cancelar Transcrição e Correções" durante gravação
- remover itens separados de cancelamento de transcrição e correção
- adicionar testes para o novo menu

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685423f6a0fc8330a28a30ad2f790866