### PR TITLE
Atualizar prompt agentico e remover chave obsoleta

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -25,7 +25,7 @@ DEFAULT_CONFIG = {
     "gemini_api_key": "",
     "gemini_model": "gemini-2.5-flash-lite-preview-06-17",
     "gemini_agent_model": "gemini-2.5-flash-lite-preview-06-17",
-    "prompt_agentico": "Você é um assistente de IA que executa comandos de texto. O usuário fornecerá uma instrução seguida do texto a ser processado. Sua tarefa é executar a instrução sobre o texto e retornar APENAS o resultado final. Não adicione explicações, saudações ou qualquer texto extra. A instrução do usuário é a prioridade máxima. O idioma de saída deve corresponder ao idioma principal do texto fornecido.",
+    "prompt_agentico": "You are an AI assistant that executes text commands. The user will provide an instruction followed by the text to be processed. Your task is to execute the instruction on the text and return ONLY the final result. Do not add explanations, greetings, or any extra text. The user's instruction is your top priority. The output language should match the main language of the provided text.",
     "gemini_prompt": """You are a speech-to-text correction specialist. Your task is to refine the following transcribed speech.
 Key instructions:
 - Remove self-corrections (when I say something wrong and then correct myself)
@@ -119,9 +119,6 @@ class ConfigManager:
                     loaded_config_from_file = json.load(f)
                 self._config_hash = self._compute_hash(loaded_config_from_file)
 
-                if "new_prompt_agentico" in loaded_config_from_file:
-                    logging.info("Removing obsolete 'new_prompt_agentico' key from config file.")
-                    loaded_config_from_file.pop("new_prompt_agentico", None)
                 if "vad_enabled" in loaded_config_from_file:
                     logging.info("Migrating legacy 'vad_enabled' key to 'use_vad'.")
                     loaded_config_from_file["use_vad"] = loaded_config_from_file.pop("vad_enabled")

--- a/src/core.py
+++ b/src/core.py
@@ -535,7 +535,6 @@ class AppCore:
                 "new_gemini_api_key": "gemini_api_key", "new_gemini_model": "gemini_model",
                 "new_agent_model": "gemini_agent_model",
                 "new_gemini_prompt": "gemini_prompt",
-                "new_prompt_agentico": "prompt_agentico",
                 "new_batch_size": "batch_size", "new_gpu_index": "gpu_index",
                 "new_hotkey_stability_service_enabled": "hotkey_stability_service_enabled", # Nova configuração unificada
                 "new_min_transcription_duration": "min_transcription_duration",

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -284,7 +284,7 @@ class UIManager:
                         new_gemini_api_key=gemini_api_key_to_apply,
                         new_gemini_model=gemini_model_to_apply,
                         new_gemini_prompt=gemini_prompt_correction_to_apply,
-                        new_prompt_agentico=agentico_prompt_to_apply,
+                        prompt_agentico=agentico_prompt_to_apply,
                         new_agent_model=model_to_apply,
                         new_gemini_model_options=new_models_list,
                         new_batch_size=batch_size_to_apply,


### PR DESCRIPTION
## Summary
- atualiza `prompt_agentico` para texto em inglês
- remove verificação por chave `new_prompt_agentico` em `ConfigManager`
- elimina mapeamento `new_prompt_agentico` em `AppCore`
- ajusta `UIManager` para usar `prompt_agentico` diretamente

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy/requests)*

------
https://chatgpt.com/codex/tasks/task_e_68543c74d9888330a01258cecd9a42a9