### PR TITLE
Implement transcription cancel callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ A lightweight, high-performance desktop tool for Windows that turns your speech 
     *   An intuitive GUI for managing all settings without editing files.
     *   Quickly switch between Gemini models directly from the tray menu.
 *   **Auditory Feedback:** Optional sound cues for starting and stopping recording.
-*   **Remove trechos silenciosos de forma automática** por meio do Silero VAD. A inicialização do VAD usa `onnxruntime` com seleção automática de `CUDAExecutionProvider` quando disponível, garantindo funcionamento estável também em CPU (`CPUExecutionProvider`).
+*   **Automatically remove silent sections** using the Silero VAD. Initialization uses `onnxruntime` with automatic selection of `CUDAExecutionProvider` when available, falling back to `CPUExecutionProvider`.
 *   **Robust and Stable:** Includes a background service to ensure hotkeys remain responsive, a common issue on Windows 11.
-*   **Gerenciamento Simplificado de Estados:** o antigo estado "SAVING" foi removido por não haver funcionalidade associada.
+*   **Simplified State Management:** the former "SAVING" state was removed as no functionality depended on it.
 
 ## System Architecture
 
@@ -89,7 +89,7 @@ graph TD
 *   **`AudioHandler`**: Manages microphone input, recording, and sound feedback.
 *   **`TranscriptionHandler`**: Manages the Whisper model, runs the transcription pipeline, and coordinates with AI correction services.
 *   **`KeyboardHotkeyManager`**: Listens for and handles global hotkeys.
-*   ****`GeminiAPI` / `OpenRouterAPI`**: Clientes para interação com serviços externos de IA e correção de texto. Ambos expõem o método `reinitialize_client()` para recarregar chave e modelo em tempo de execução.
+*   ****`GeminiAPI` / `OpenRouterAPI`**: Clients for interacting with external AI services and text correction. Both expose the method `reinitialize_client()` to reload key and model at runtime.
 
 ## Installation
 
@@ -188,13 +188,13 @@ The `pip` command is Python's package installer. The `-r requirements.txt` part 
     *   If you do *not* have a compatible GPU or prefer not to use it, you can skip this step. The application will still work using your CPU, just slower.
 
 3.  **Optional: Install onnxruntime-gpu (for VAD acceleration):**
-    O VAD usa a biblioteca **ONNX Runtime**. O `requirements.txt` instala a versão para CPU (`onnxruntime`), mas quem possui GPU compatível pode optar por instalar `onnxruntime-gpu` para acelerar a detecção de voz. A aplicação seleciona automaticamente `CUDAExecutionProvider` caso disponível; do contrário, usa `CPUExecutionProvider`.
+    The VAD relies on **ONNX Runtime**. While `requirements.txt` installs the CPU version (`onnxruntime`), you can install `onnxruntime-gpu` if you own a compatible GPU to speed up voice detection. The application automatically selects `CUDAExecutionProvider` when available or falls back to `CPUExecutionProvider`.
 
 ### Step 5: Run the Application
 
 You are now ready to run the Whisper Transcription App!
 
-**Importante:** certifique-se de ter executado `pip install -r requirements.txt` antes de rodar o comando abaixo.
+**Important:** make sure you ran `pip install -r requirements.txt` before executing the command below.
 
 1.  **Start the main script:** In your **activated virtual environment** within the `whisper-flash-transcriber` directory, run:
     ```bash
@@ -229,17 +229,17 @@ To access and change settings:
     *   **How to get a Google Gemini API Key:** Visit [https://makersuite.google.com/app/apikey](https://makersuite.google.com/app/apikey) and generate a new API key.
 *   **Model:** For text correction, choose one of the available models for the selected service (e.g., "deepseek/deepseek-chat-v3-0324:free" on OpenRouter or "gemini-2.5-flash" on Gemini).
 *   **Gemini Correction Prompt:** Customize the prompt sent to Gemini for text correction.
-*   **Prompt do Modo Agêntico:** Customize the prompt sent to Gemini when using "Agent Mode".
+*   **Agent Mode Prompt:** Customize the prompt sent to Gemini when using "Agent Mode".
 *   **Gemini Models (one per line):** Manage the list of available Gemini models in the dropdown.
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
 *   **Batch Size:** Configure the batch size for transcription.
 *   **Save Audio for Debug:** If enabled, temporary audio recordings will be saved for debugging purposes.
 *   **Display Transcript in Terminal:** Show the final text in the terminal window after each recording.
-*   **Use VAD:** ativa a remoção de silêncio, sem encerrar a gravação automaticamente.
-*   **VAD Threshold:** sensibilidade da detecção de voz.
-*   **VAD Silence Duration (s):** tempo máximo de pausa que será mantido; silêncios mais longos são cortados.
+*   **Use VAD:** enables silence removal without automatically stopping the recording.
+*   **VAD Threshold:** sensitivity of voice detection.
+*   **VAD Silence Duration (s):** maximum pause length to keep; longer silences are trimmed.
 
-O usuário encerra a gravação manualmente.
+The user stops recording manually.
 
 ### Displaying Transcripts in the Terminal
 
@@ -277,15 +277,15 @@ If `pip install -r requirements.txt` fails or the application doesn't run due to
 *   **CUDA Compatibility:** If you are trying to install the CUDA version, double-check that your NVIDIA driver and CUDA toolkit versions are compatible with the PyTorch version you are trying to install, according to the PyTorch website.
 *   **Internet Connection:** Ensure you have a stable internet connection, as PyTorch and other libraries are large downloads.
 
-### Erro "state_check_callback"
+### "state_check_callback" Error
 
-Caso ocorra a mensagem `AttributeError: 'TranscriptionHandler' object has no attribute 'state_check_callback'`,
-atualize para a versão mais recente. O atributo agora é inicializado corretamente em `TranscriptionHandler.__init__`.
+If you encounter the message `AttributeError: 'TranscriptionHandler' object has no attribute 'state_check_callback'`,
+update to the latest version. The attribute is now properly initialized in `TranscriptionHandler.__init__`.
 
-### Novo callback `on_transcription_cancelled_callback`
+### New callback `on_transcription_cancelled_callback`
 
-Para desenvolvedores que instanciam manualmente o `TranscriptionHandler`, foi adicionado o parâmetro opcional `on_transcription_cancelled_callback`. Ele 
-é executado quando `cancel_transcription()` é chamado e o segmento ainda está em processamento, permitindo redefinir estados ou fechar janelas personalizadas.
+For developers instantiating `TranscriptionHandler` manually, there is now an optional `on_transcription_cancelled_callback` parameter. It
+is invoked when `cancel_transcription()` is called and the segment is still being processed, allowing you to reset state or close custom windows.
 
 ## Contributing
 
@@ -297,11 +297,11 @@ Contributions are welcome! If you have ideas for improvements, bug fixes, or new
 4.  Push your changes to your fork.
 5.  Open a Pull Request from your fork to the original repository's `master` branch.
 6.  Describe your changes and why they should be included.
-7.  Instale as dependências de desenvolvimento com:
+7.  Install the development dependencies with:
     ```bash
     pip install -r requirements-dev.txt
     ```
-8.  Execute `flake8 src/gemini_api.py src/openrouter_api.py` para verificar o lint.
+8.  Run `flake8 src/gemini_api.py src/openrouter_api.py` to check the lint.
 
 ## License
 

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -42,7 +42,6 @@ class TranscriptionHandler:
         self.on_transcription_cancelled_callback = on_transcription_cancelled_callback
         # Alias para manter compatibilidade com referências existentes
         self.state_check_callback = is_state_transcribing_fn
-        self.on_transcription_cancelled_callback = None # Novo callback para notificar cancelamento
         self.correction_cancel_event = threading.Event()
         self.transcription_cancel_event = threading.Event()
         self.correction_in_progress = False
@@ -349,12 +348,6 @@ class TranscriptionHandler:
             if self.transcription_cancel_event.is_set():
                 logging.info("Transcrição cancelada. Resultado descartado.")
                 self.transcription_cancel_event.clear()
-                if self.on_transcription_cancelled_callback:
-                    try:
-                        self.on_transcription_cancelled_callback()
-                    except Exception as e:
-                        logging.error(
-                            f"Erro no callback de cancelamento: {e}")
                 return
 
             if text_result and self.config_manager.get(DISPLAY_TRANSCRIPTS_KEY):


### PR DESCRIPTION
## Summary
- ensure the cancellation callback passed to `TranscriptionHandler` is stored
- call the callback only once when cancelling transcription
- translate README content fully to English

## Testing
- `flake8 src/gemini_api.py src/openrouter_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a5f5dcdc833089d5c1764bf0bcc7