### PR TITLE
Add Save Temporary Recordings setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ To access and change settings:
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
 *   **Batch Size:** Configure the batch size for transcription.
 *   **Save Audio for Debug:** If enabled, temporary audio recordings will be saved for debugging purposes.
+*   **Save Temporary Recordings:** Keep the temporary `.wav` files after transcription for further review.
 *   **Display Transcript in Terminal:** Show the final text in the terminal window after each recording.
 *   **Use VAD:** enables silence removal without automatically stopping the recording.
 *   **VAD Threshold:** sensitivity of voice detection.

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -52,6 +52,7 @@ Transcribed speech: {text}""",
         "gemini-2.5-pro"
     ],
     "save_audio_for_debug": False,
+    "save_temp_recordings": False,
     "min_transcription_duration": 1.0 # Nova configuração
 }
 
@@ -69,6 +70,7 @@ BATCH_SIZE_MODE_CONFIG_KEY = "batch_size_mode" # Novo
 MANUAL_BATCH_SIZE_CONFIG_KEY = "manual_batch_size" # Novo
 GPU_INDEX_CONFIG_KEY = "gpu_index"
 SAVE_AUDIO_FOR_DEBUG_CONFIG_KEY = "save_audio_for_debug"
+SAVE_TEMP_RECORDINGS_CONFIG_KEY = "save_temp_recordings"
 DISPLAY_TRANSCRIPTS_KEY = "display_transcripts_in_terminal"
 USE_VAD_CONFIG_KEY = "use_vad"
 VAD_THRESHOLD_CONFIG_KEY = "vad_threshold"
@@ -359,3 +361,12 @@ class ConfigManager:
 
     def set_display_transcripts_in_terminal(self, value: bool):
         self.config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY] = bool(value)
+
+    def get_save_temp_recordings(self):
+        return self.config.get(
+            SAVE_TEMP_RECORDINGS_CONFIG_KEY,
+            self.default_config[SAVE_TEMP_RECORDINGS_CONFIG_KEY],
+        )
+
+    def set_save_temp_recordings(self, value: bool):
+        self.config[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = bool(value)

--- a/src/core.py
+++ b/src/core.py
@@ -548,6 +548,7 @@ class AppCore:
                 "new_hotkey_stability_service_enabled": "hotkey_stability_service_enabled", # Nova configuração unificada
                 "new_min_transcription_duration": "min_transcription_duration",
                 "new_save_audio_for_debug": "save_audio_for_debug",
+                "new_save_temp_recordings": "save_temp_recordings",
                 "new_gemini_model_options": "gemini_model_options",
                 "new_use_vad": "use_vad",
                 "new_vad_threshold": "vad_threshold",

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -185,6 +185,7 @@ class UIManager:
                 vad_threshold_var = ctk.DoubleVar(value=self.config_manager.get("vad_threshold"))
                 vad_silence_duration_var = ctk.DoubleVar(value=self.config_manager.get("vad_silence_duration"))
                 save_audio_var = ctk.BooleanVar(value=self.config_manager.get("save_audio_for_debug"))
+                save_temp_recordings_var = ctk.BooleanVar(value=self.config_manager.get("save_temp_recordings"))
                 display_transcripts_var = ctk.BooleanVar(value=self.config_manager.get(DISPLAY_TRANSCRIPTS_KEY))
 
                 def update_text_correction_fields():
@@ -247,6 +248,7 @@ class UIManager:
                     vad_threshold_to_apply = float(vad_threshold_var.get())
                     vad_silence_duration_to_apply = float(vad_silence_duration_var.get())
                     save_audio_for_debug_to_apply = save_audio_var.get()
+                    save_temp_recordings_to_apply = save_temp_recordings_var.get()
                     display_transcripts_to_apply = display_transcripts_var.get()
 
                     # Logic for converting UI to GPU index
@@ -292,6 +294,7 @@ class UIManager:
                         new_hotkey_stability_service_enabled=hotkey_stability_service_enabled_to_apply, # Nova configuração unificada
                         new_min_transcription_duration=min_transcription_duration_to_apply,
                         new_save_audio_for_debug=save_audio_for_debug_to_apply,
+                        new_save_temp_recordings=save_temp_recordings_to_apply,
                         new_use_vad=use_vad_to_apply,
                         new_vad_threshold=vad_threshold_to_apply,
                         new_vad_silence_duration=vad_silence_duration_to_apply,
@@ -355,6 +358,7 @@ class UIManager:
                     vad_threshold_var.set(DEFAULT_CONFIG["vad_threshold"])
                     vad_silence_duration_var.set(DEFAULT_CONFIG["vad_silence_duration"])
                     save_audio_var.set(DEFAULT_CONFIG["save_audio_for_debug"])
+                    save_temp_recordings_var.set(DEFAULT_CONFIG["save_temp_recordings"])
                     display_transcripts_var.set(DEFAULT_CONFIG["display_transcripts_in_terminal"])
 
                     self.config_manager.save_config()
@@ -562,6 +566,12 @@ class UIManager:
                 save_audio_switch = ctk.CTkSwitch(save_audio_frame, text="Save Audio for Debug", variable=save_audio_var)
                 save_audio_switch.pack(side="left", padx=5)
                 Tooltip(save_audio_switch, "Store captured audio files for troubleshooting.")
+
+                temp_recordings_frame = ctk.CTkFrame(transcription_frame)
+                temp_recordings_frame.pack(fill="x", pady=5)
+                temp_recordings_switch = ctk.CTkSwitch(temp_recordings_frame, text="Save Temporary Recordings", variable=save_temp_recordings_var)
+                temp_recordings_switch.pack(side="left", padx=5)
+                Tooltip(temp_recordings_switch, "Keep temporary audio files after processing.")
 
                 display_transcripts_frame = ctk.CTkFrame(transcription_frame)
                 display_transcripts_frame.pack(fill="x", pady=5)


### PR DESCRIPTION
## Summary
- add new config entry `save_temp_recordings`
- support the new option in AppCore
- add switch for Temporary Recordings in the settings GUI
- document the option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68581de0360083308e06b2569349c1f7