### PR TITLE
Add save_temp_recordings configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ To access and change settings:
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
 *   **Batch Size:** Configure the batch size for transcription.
 *   **Save Audio for Debug:** If enabled, temporary audio recordings will be saved for debugging purposes.
+*   **Save Temp Recordings:** Toggle whether the app keeps temporary audio files generated during transcription.
 *   **Display Transcript in Terminal:** Show the final text in the terminal window after each recording.
 *   **Use VAD:** enables silence removal without automatically stopping the recording.
 *   **VAD Threshold:** sensitivity of voice detection.

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -52,6 +52,7 @@ Transcribed speech: {text}""",
         "gemini-2.5-pro"
     ],
     "save_audio_for_debug": False,
+    "save_temp_recordings": False,
     "min_transcription_duration": 1.0 # Nova configuração
 }
 
@@ -69,6 +70,7 @@ BATCH_SIZE_MODE_CONFIG_KEY = "batch_size_mode" # Novo
 MANUAL_BATCH_SIZE_CONFIG_KEY = "manual_batch_size" # Novo
 GPU_INDEX_CONFIG_KEY = "gpu_index"
 SAVE_AUDIO_FOR_DEBUG_CONFIG_KEY = "save_audio_for_debug"
+SAVE_TEMP_RECORDINGS_CONFIG_KEY = "save_temp_recordings"
 DISPLAY_TRANSCRIPTS_KEY = "display_transcripts_in_terminal"
 USE_VAD_CONFIG_KEY = "use_vad"
 VAD_THRESHOLD_CONFIG_KEY = "vad_threshold"
@@ -184,6 +186,14 @@ class ConfigManager:
         # Flag para exibir transcrições brutas no log
         self.config[DISPLAY_TRANSCRIPTS_KEY] = bool(
             self.config.get(DISPLAY_TRANSCRIPTS_KEY, self.default_config[DISPLAY_TRANSCRIPTS_KEY])
+        )
+
+        # Persistência opcional de gravações temporárias
+        self.config[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = bool(
+            self.config.get(
+                SAVE_TEMP_RECORDINGS_CONFIG_KEY,
+                self.default_config[SAVE_TEMP_RECORDINGS_CONFIG_KEY],
+            )
         )
     
         # Para gpu_index_specified e batch_size_specified
@@ -359,3 +369,12 @@ class ConfigManager:
 
     def set_display_transcripts_in_terminal(self, value: bool):
         self.config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY] = bool(value)
+
+    def get_save_temp_recordings(self):
+        return self.config.get(
+            SAVE_TEMP_RECORDINGS_CONFIG_KEY,
+            self.default_config[SAVE_TEMP_RECORDINGS_CONFIG_KEY],
+        )
+
+    def set_save_temp_recordings(self, value: bool):
+        self.config[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = bool(value)


### PR DESCRIPTION
## Summary
- add `save_temp_recordings` option to default config
- create `SAVE_TEMP_RECORDINGS_CONFIG_KEY` constant and related getters/setters
- ensure boolean validation for temporary recording option
- document the new setting in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68581ddf35408330922f2d28242b93f0