### PR TITLE
Fix config key for temp recordings

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -24,7 +24,7 @@ class AudioHandler:
         self.audio_stream = None
         self.sound_lock = threading.RLock()
         self.stream_started = False
-        self.save_audio_for_debug = self.config_manager.get("save_audio_for_debug")
+        self.save_temp_recordings = self.config_manager.get("save_temp_recordings")
         self.temp_file_path = None
 
         # Carregar configurações de som
@@ -33,8 +33,6 @@ class AudioHandler:
         self.sound_duration = self.config_manager.get("sound_duration")
         self.sound_volume = self.config_manager.get("sound_volume")
         self.min_record_duration = self.config_manager.get("min_record_duration")
-
-        self.save_audio_for_debug = self.config_manager.get("save_audio_for_debug")
 
         self.use_vad = self.config_manager.get("use_vad")
         self.vad_threshold = self.config_manager.get("vad_threshold")
@@ -304,7 +302,7 @@ class AudioHandler:
         self.sound_duration = self.config_manager.get("sound_duration")
         self.sound_volume = self.config_manager.get("sound_volume")
         self.min_record_duration = self.config_manager.get("min_record_duration")
-        self.save_temp_recordings = self.config_manager.get("save_audio_for_debug")
+        self.save_temp_recordings = self.config_manager.get("save_temp_recordings")
 
         self.use_vad = self.config_manager.get("use_vad")
         self.vad_threshold = self.config_manager.get("vad_threshold")


### PR DESCRIPTION
## Summary
- update AudioHandler variable init to use new save_temp_recordings config
- remove redundant debug save flag assignment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858245811b4833087e1ba9a00195059