### PR TITLE
Implement temp file path update

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -212,8 +212,10 @@ class AudioHandler:
                 filename = f"temp_recording_{ts}.wav"
                 sf.write(filename, full_audio, AUDIO_SAMPLE_RATE)
                 logging.info(f"Temporary recording saved to {filename}")
+                self.temp_file_path = filename
             except Exception as e:
                 logging.error(f"Failed to save temporary recording: {e}")
+                self.temp_file_path = None
 
         self.start_time = None
         # Mudar o estado para TRANSCRIBING ANTES de enviar o áudio para processamento


### PR DESCRIPTION
## Summary
- update audio handler to track temp audio filepath after saving
- ensure handler temp file path is cleared when save fails
- test temp file path handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858245ab7548330bfc8a70c385e4018