### PR TITLE
Ajuste de test para verificar temp_file_path

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -211,9 +211,11 @@ class AudioHandler:
                 ts = int(time.time())
                 filename = f"temp_recording_{ts}.wav"
                 sf.write(filename, full_audio, AUDIO_SAMPLE_RATE)
+                self.temp_file_path = filename
                 logging.info(f"Temporary recording saved to {filename}")
             except Exception as e:
                 logging.error(f"Failed to save temporary recording: {e}")
+                self.temp_file_path = None
 
         self.start_time = None
         # Mudar o estado para TRANSCRIBING ANTES de enviar o áudio para processamento

--- a/tests/test_audio_handler.py
+++ b/tests/test_audio_handler.py
@@ -114,14 +114,17 @@ class AudioHandlerTest(unittest.TestCase):
                     handler.start_recording()
                     time.sleep(0.05)
                     handler.stop_recording()
+                    self.assertEqual(handler.temp_file_path, 'temp_recording_1111111111.wav')
 
         filename = 'temp_recording_1111111111.wav'
         self.assertTrue(os.path.exists(filename))
 
         for f in glob.glob('temp_recording_*.wav'):
             os.remove(f)
+        handler.temp_file_path = None
 
         self.assertFalse(os.path.exists(filename))
+        self.assertIsNone(handler.temp_file_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Descrição
- salva caminho do arquivo temporário em `AudioHandler`
- valida `temp_file_path` no teste de gravação temporária

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858245cb8f88330a0721ed31d373fe8