### PR TITLE
Ajuste no .gitignore para gravações temporárias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ __pycache__/
 
 # Arquivos temporários de áudio
 recording_*.wav
-temp_recording_*.wav
+temp_recording_*.wav # gravações temporárias
 
 # Arquivos de sistema
 .DS_Store


### PR DESCRIPTION
## Resumo
- adiciona comentário descrevendo o uso de `temp_recording_*.wav`

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858245ded0c8330bbfec3a68f1ebe29