### PR TITLE
Fix duplicate temp file path assignment

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -211,7 +211,6 @@ class AudioHandler:
                 sf.write(filename, full_audio, AUDIO_SAMPLE_RATE)
                 self.temp_file_path = filename
                 logging.info(f"Temporary recording saved to {filename}")
-                self.temp_file_path = filename
             except Exception as e:
                 logging.error(f"Failed to save temporary recording: {e}")
                 self.temp_file_path = None


### PR DESCRIPTION
## Summary
- remove redundant self.temp_file_path assignment in `AudioHandler`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582a5183108330a501e31437eb245c