### PR TITLE
use config constant for temp recordings

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -5,6 +5,7 @@ import logging
 import time
 import soundfile as sf
 from .vad_manager import VADManager # Assumindo que vad_manager.py está na raiz ou em um path acessível
+from .config_manager import SAVE_TEMP_RECORDINGS_CONFIG_KEY
 import os
 import wave
 
@@ -24,7 +25,7 @@ class AudioHandler:
         self.audio_stream = None
         self.sound_lock = threading.RLock()
         self.stream_started = False
-        self.save_temp_recordings = self.config_manager.get("save_temp_recordings")
+        self.save_temp_recordings = self.config_manager.get(SAVE_TEMP_RECORDINGS_CONFIG_KEY)
         self.temp_file_path = None
 
         # Carregar configurações de som
@@ -204,7 +205,7 @@ class AudioHandler:
                 logging.info("Áudio já é mono, achatando para formato 1D.")
                 full_audio = full_audio.flatten()
 
-        if self.config_manager.get("save_temp_recordings"):
+        if self.config_manager.get(SAVE_TEMP_RECORDINGS_CONFIG_KEY):
             try:
                 ts = int(time.time())
                 filename = f"temp_recording_{ts}.wav"
@@ -305,7 +306,7 @@ class AudioHandler:
         self.sound_duration = self.config_manager.get("sound_duration")
         self.sound_volume = self.config_manager.get("sound_volume")
         self.min_record_duration = self.config_manager.get("min_record_duration")
-        self.save_temp_recordings = self.config_manager.get("save_temp_recordings")
+        self.save_temp_recordings = self.config_manager.get(SAVE_TEMP_RECORDINGS_CONFIG_KEY)
 
         self.use_vad = self.config_manager.get("use_vad")
         self.vad_threshold = self.config_manager.get("vad_threshold")

--- a/src/core.py
+++ b/src/core.py
@@ -21,6 +21,7 @@ from .config_manager import (
     REREGISTER_INTERVAL_SECONDS,
     HOTKEY_HEALTH_CHECK_INTERVAL,
     DISPLAY_TRANSCRIPTS_KEY,
+    SAVE_TEMP_RECORDINGS_CONFIG_KEY,
 )
 from .audio_handler import AudioHandler, AUDIO_SAMPLE_RATE # AUDIO_SAMPLE_RATE ainda é usado em _handle_transcription_result
 from .transcription_handler import TranscriptionHandler
@@ -551,7 +552,7 @@ class AppCore:
                 "new_batch_size": "batch_size", "new_gpu_index": "gpu_index",
                 "new_hotkey_stability_service_enabled": "hotkey_stability_service_enabled", # Nova configuração unificada
                 "new_min_transcription_duration": "min_transcription_duration",
-                "new_save_temp_recordings": "save_temp_recordings",
+                "new_save_temp_recordings": SAVE_TEMP_RECORDINGS_CONFIG_KEY,
                 "new_gemini_model_options": "gemini_model_options",
                 "new_use_vad": "use_vad",
                 "new_vad_threshold": "vad_threshold",

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -15,7 +15,8 @@ from .config_manager import (
     SERVICE_NONE, SERVICE_OPENROUTER, SERVICE_GEMINI,
     OPENROUTER_API_KEY_CONFIG_KEY, OPENROUTER_MODEL_CONFIG_KEY,
     GEMINI_API_KEY_CONFIG_KEY,
-    MIN_TRANSCRIPTION_DURATION_CONFIG_KEY, DISPLAY_TRANSCRIPTS_KEY # Nova constante
+    MIN_TRANSCRIPTION_DURATION_CONFIG_KEY, DISPLAY_TRANSCRIPTS_KEY, # Nova constante
+    SAVE_TEMP_RECORDINGS_CONFIG_KEY,
 )
 
 class TranscriptionHandler:
@@ -188,7 +189,7 @@ class TranscriptionHandler:
         finally:
             self.correction_in_progress = False
             if not cancel_event.is_set() and self.is_state_transcribing_fn and self.is_state_transcribing_fn():
-                if self.config_manager.get("save_temp_recordings"):
+                if self.config_manager.get(SAVE_TEMP_RECORDINGS_CONFIG_KEY):
                     logging.info(f"Transcrição corrigida: {corrected}")
                 self.on_transcription_result_callback(corrected, text)
 

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -13,6 +13,7 @@ from .config_manager import (
     GEMINI_MODEL_OPTIONS_CONFIG_KEY,
     DISPLAY_TRANSCRIPTS_KEY,
     DEFAULT_CONFIG,
+    SAVE_TEMP_RECORDINGS_CONFIG_KEY,
 )
 
 from .utils.tooltip import Tooltip
@@ -184,7 +185,7 @@ class UIManager:
                 use_vad_var = ctk.BooleanVar(value=self.config_manager.get("use_vad"))
                 vad_threshold_var = ctk.DoubleVar(value=self.config_manager.get("vad_threshold"))
                 vad_silence_duration_var = ctk.DoubleVar(value=self.config_manager.get("vad_silence_duration"))
-                save_temp_recordings_var = ctk.BooleanVar(value=self.config_manager.get("save_temp_recordings"))
+                save_temp_recordings_var = ctk.BooleanVar(value=self.config_manager.get(SAVE_TEMP_RECORDINGS_CONFIG_KEY))
                 display_transcripts_var = ctk.BooleanVar(value=self.config_manager.get(DISPLAY_TRANSCRIPTS_KEY))
 
                 def update_text_correction_fields():
@@ -354,7 +355,7 @@ class UIManager:
                     use_vad_var.set(DEFAULT_CONFIG["use_vad"])
                     vad_threshold_var.set(DEFAULT_CONFIG["vad_threshold"])
                     vad_silence_duration_var.set(DEFAULT_CONFIG["vad_silence_duration"])
-                    save_temp_recordings_var.set(DEFAULT_CONFIG["save_temp_recordings"])
+                    save_temp_recordings_var.set(DEFAULT_CONFIG[SAVE_TEMP_RECORDINGS_CONFIG_KEY])
                     display_transcripts_var.set(DEFAULT_CONFIG["display_transcripts_in_terminal"])
 
                     self.config_manager.save_config()

--- a/tests/test_audio_handler.py
+++ b/tests/test_audio_handler.py
@@ -28,6 +28,7 @@ sys.modules['onnxruntime'] = fake_onnx
 sys.modules['torch'] = fake_torch
 
 from src.audio_handler import AudioHandler  # noqa: E402
+from src.config_manager import SAVE_TEMP_RECORDINGS_CONFIG_KEY
 
 
 class DummyConfig:
@@ -41,7 +42,7 @@ class DummyConfig:
             'use_vad': False,
             'vad_threshold': 0.5,
             'vad_silence_duration': 0.5,
-            'save_temp_recordings': False,
+            SAVE_TEMP_RECORDINGS_CONFIG_KEY: False,
         }
 
     def get(self, key):
@@ -95,7 +96,7 @@ class AudioHandlerTest(unittest.TestCase):
         mock_warn.assert_not_called()
 
     def test_temp_recording_saved_and_cleanup(self):
-        self.config.data['save_temp_recordings'] = True
+        self.config.data[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = True
 
         handler = AudioHandler(self.config, lambda *_: None, lambda *_: None)
 
@@ -128,7 +129,7 @@ class AudioHandlerTest(unittest.TestCase):
         self.assertIsNone(handler.temp_file_path)
 
     def test_temp_recording_save_error(self):
-        self.config.data['save_temp_recordings'] = True
+        self.config.data[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = True
         handler = AudioHandler(self.config, lambda *_: None, lambda *_: None)
 
         def fake_record_audio_task(self):

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -32,6 +32,7 @@ from src.config_manager import (
     GEMINI_API_KEY_CONFIG_KEY,
     MIN_TRANSCRIPTION_DURATION_CONFIG_KEY,
     DISPLAY_TRANSCRIPTS_KEY,
+    SAVE_TEMP_RECORDINGS_CONFIG_KEY,
 )
 
 
@@ -53,7 +54,7 @@ class DummyConfig:
             "gemini_prompt": "",
             MIN_TRANSCRIPTION_DURATION_CONFIG_KEY: 1.0,
             DISPLAY_TRANSCRIPTS_KEY: False,
-            'save_temp_recordings': False,
+            SAVE_TEMP_RECORDINGS_CONFIG_KEY: False,
         }
 
     def get(self, key):

--- a/tests/test_transcription_handler_cancel.py
+++ b/tests/test_transcription_handler_cancel.py
@@ -34,6 +34,7 @@ from src.config_manager import (
     GEMINI_API_KEY_CONFIG_KEY,
     MIN_TRANSCRIPTION_DURATION_CONFIG_KEY,
     DISPLAY_TRANSCRIPTS_KEY,
+    SAVE_TEMP_RECORDINGS_CONFIG_KEY,
 )
 
 
@@ -55,7 +56,7 @@ class DummyConfig:
             "gemini_prompt": "",
             MIN_TRANSCRIPTION_DURATION_CONFIG_KEY: 1.0,
             DISPLAY_TRANSCRIPTS_KEY: False,
-            'save_temp_recordings': False,
+            SAVE_TEMP_RECORDINGS_CONFIG_KEY: False,
         }
 
     def get(self, key):

--- a/tests/test_transcription_handler_state.py
+++ b/tests/test_transcription_handler_state.py
@@ -40,6 +40,7 @@ from src.config_manager import (
     GEMINI_API_KEY_CONFIG_KEY,
     MIN_TRANSCRIPTION_DURATION_CONFIG_KEY,
     DISPLAY_TRANSCRIPTS_KEY,
+    SAVE_TEMP_RECORDINGS_CONFIG_KEY,
 )
 
 
@@ -61,7 +62,7 @@ class DummyConfig:
             "gemini_prompt": "",
             MIN_TRANSCRIPTION_DURATION_CONFIG_KEY: 1.0,
             DISPLAY_TRANSCRIPTS_KEY: False,
-            'save_temp_recordings': False,
+            SAVE_TEMP_RECORDINGS_CONFIG_KEY: False,
         }
 
     def get(self, key):


### PR DESCRIPTION
## Summary
- remove hardcoded `"save_temp_recordings"` values
- import `SAVE_TEMP_RECORDINGS_CONFIG_KEY` where needed
- update all tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582a5637608330aa61d35d59d33db6