### PR TITLE
Fix test constant

### DIFF
--- a/tests/test_audio_handler.py
+++ b/tests/test_audio_handler.py
@@ -103,7 +103,7 @@ class AudioHandlerTest(unittest.TestCase):
 
     def test_temp_recording_saved_and_cleanup(self):
         """Garante que o arquivo temporário é salvo e removido ao final."""
-        self.config.data['save_temp_recordings'] = True
+        self.config.data[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = True
 
         handler = AudioHandler(self.config, lambda *_: None, lambda *_: None)
 


### PR DESCRIPTION
## Summary
- use `SAVE_TEMP_RECORDINGS_CONFIG_KEY` constant in `test_audio_handler`

## Testing
- `pytest tests/test_audio_handler.py -k temp_recording_saved_and_cleanup -q`

------
https://chatgpt.com/codex/tasks/task_e_6858401d06788330b073eaa985f096bf