### PR TITLE
Fix start logic in hotkey manager

### DIFF
--- a/src/keyboard_hotkey_manager.py
+++ b/src/keyboard_hotkey_manager.py
@@ -67,8 +67,13 @@ class KeyboardHotkeyManager:
             return True
 
         try:
-            # Registrar as hotkeys
-            self._register_hotkeys()
+            # Registrar as hotkeys e armazenar o resultado
+            resultado_registro = self._register_hotkeys()
+
+            if not resultado_registro:
+                logging.error("Falha ao registrar hotkeys.")
+                return False
+
             self.is_running = True
             logging.info("KeyboardHotkeyManager iniciado com sucesso.")
             return True


### PR DESCRIPTION
## Summary
- ensure `start()` only sets `is_running` after successful hotkey registration
- log failure when `_register_hotkeys()` returns `False`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68586485a4548330912d8533e7470cf8