### PR TITLE
Fix start failure propagation

### DIFF
--- a/src/keyboard_hotkey_manager.py
+++ b/src/keyboard_hotkey_manager.py
@@ -67,8 +67,13 @@ class KeyboardHotkeyManager:
             return True
 
         try:
-            # Registrar as hotkeys
-            self._register_hotkeys()
+            # Registrar as hotkeys e verificar o resultado
+            success = self._register_hotkeys()
+            if not success:
+                logging.error("Falha ao registrar hotkeys.")
+                self.stop()
+                return False
+
             self.is_running = True
             logging.info("KeyboardHotkeyManager iniciado com sucesso.")
             return True


### PR DESCRIPTION
## Summary
- fail `KeyboardHotkeyManager.start()` when hotkey registration fails
- keep restart propagation behavior intact

## Testing
- `flake8 src/gemini_api.py src/openrouter_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685864875e70833099591ad497845ded