### PR TITLE
Enable tray menu item callables

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -531,6 +531,20 @@ class AppCore:
     def is_correction_running(self) -> bool:
         return self.transcription_handler.is_text_correction_running()
 
+    def is_any_operation_running(self) -> bool:
+        """Indica se h\u00e1 alguma grava\u00e7\u00e3o, transcri\u00e7\u00e3o ou corre\u00e7\u00e3o em andamento."""
+        return (
+            self.audio_handler.is_recording
+            or self.transcription_handler.is_transcription_running()
+            or self.transcription_handler.is_text_correction_running()
+            or self.current_state == STATE_LOADING_MODEL
+        )
+
+    def cancel_all_operations(self):
+        """Cancela transcri\u00e7\u00f5es e corre\u00e7\u00f5es em andamento."""
+        self.cancel_transcription()
+        self.cancel_text_correction()
+
     # --- Settings Application Logic (delegando para ConfigManager e outros) ---
     def apply_settings_from_external(self, **kwargs):
         logging.info("AppCore: Applying new configuration from external source.")

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -642,12 +642,12 @@ class UIManager:
                 '⏹️ Stop Recording' if is_recording else '▶️ Start Recording',
                 lambda: self.core_instance_ref.toggle_recording(),
                 default=True,
-                enabled=(is_recording or is_idle)
+                enabled=lambda item: self.core_instance_ref.current_state in ['RECORDING', 'IDLE']
             ),
             pystray.MenuItem(
                 '⚙️ Settings',
                 lambda: self.main_tk_root.after(0, self.run_settings_gui), # Call on main thread
-                enabled=(not is_loading and not is_recording)
+                enabled=lambda item: self.core_instance_ref.current_state not in ['LOADING_MODEL', 'RECORDING']
             ),
             pystray.MenuItem(
                 'Gemini Model',
@@ -688,12 +688,17 @@ class UIManager:
             pystray.MenuItem(
                 '🚫 Cancel Transcription',
                 lambda: self.core_instance_ref.cancel_transcription(),
-                enabled=self.core_instance_ref.is_transcription_running()
+                enabled=lambda item: self.core_instance_ref.is_transcription_running()
             ),
             pystray.MenuItem(
                 '⛔ Cancel Correction',
                 lambda: self.core_instance_ref.cancel_text_correction(),
-                enabled=self.core_instance_ref.is_correction_running()
+                enabled=lambda item: self.core_instance_ref.is_correction_running()
+            ),
+            pystray.MenuItem(
+                '❌ Cancel Operation',
+                lambda: self.core_instance_ref.cancel_all_operations(),
+                enabled=lambda item: self.core_instance_ref.is_any_operation_running()
             ),
             pystray.Menu.SEPARATOR,
             pystray.MenuItem('❌ Exit', self.on_exit_app)


### PR DESCRIPTION
## Summary
- add `is_any_operation_running` and `cancel_all_operations` to `AppCore`
- update tray menu items to use callables for the `enabled` flag
- add unified "Cancel Operation" tray action

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593467599c83309a0d967170ba58ee