### PR TITLE
Add unit tests for transcription handler

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -167,6 +167,9 @@ class TranscriptionHandler:
 
     def _async_text_correction(self, text: str, service: str, cancel_event: threading.Event) -> None:
         """Corrige o texto de forma assíncrona com timeout e verificação de cancelamento."""
+        if cancel_event.is_set():
+            return
+
         corrected = text
         self.correction_in_progress = True
         def _call():


### PR DESCRIPTION
## Summary
- ensure async text correction respects cancellation event
- test service selection logic in TranscriptionHandler
- validate dynamic batch size for CPU/GPU

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859545d6edc833093938f7239f14db1