### PR TITLE
Remove cancel menu items from tray menu

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -685,21 +685,6 @@ class UIManager:
                     )
                 )
             ),
-            pystray.MenuItem(
-                '🚫 Cancel Transcription',
-                lambda: self.core_instance_ref.cancel_transcription(),
-                enabled=lambda item: self.core_instance_ref.is_transcription_running()
-            ),
-            pystray.MenuItem(
-                '⛔ Cancel Correction',
-                lambda: self.core_instance_ref.cancel_text_correction(),
-                enabled=lambda item: self.core_instance_ref.is_correction_running()
-            ),
-            pystray.MenuItem(
-                '❌ Cancel Operation',
-                lambda: self.core_instance_ref.cancel_all_operations(),
-                enabled=lambda item: self.core_instance_ref.is_any_operation_running()
-            ),
             pystray.Menu.SEPARATOR,
             pystray.MenuItem('❌ Exit', self.on_exit_app)
         ]


### PR DESCRIPTION
## Summary
- update tray menu to remove cancel options

## Testing
- `flake8 src/gemini_api.py src/openrouter_api.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6859589a72688330b42719d244707ae5