### PR TITLE
Remove obsolete is_transcription_running

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -525,9 +525,6 @@ class AppCore:
     def cancel_text_correction(self):
         self.transcription_handler.cancel_text_correction()
 
-    def is_transcription_running(self) -> bool:
-        return self.transcription_handler.is_transcription_running()
-
     def is_correction_running(self) -> bool:
         return self.transcription_handler.is_text_correction_running()
 
@@ -535,7 +532,7 @@ class AppCore:
         """Indica se h\u00e1 alguma grava\u00e7\u00e3o, transcri\u00e7\u00e3o ou corre\u00e7\u00e3o em andamento."""
         return (
             self.audio_handler.is_recording
-            or self.transcription_handler.is_transcription_running()
+            or self.is_state_transcribing()
             or self.transcription_handler.is_text_correction_running()
             or self.current_state == STATE_LOADING_MODEL
         )

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -220,10 +220,6 @@ class TranscriptionHandler:
         if self.on_transcription_cancelled_callback:
             self.on_transcription_cancelled_callback()
 
-    def is_transcription_running(self) -> bool:
-        """Indica se há transcrição em andamento."""
-        return self.transcription_in_progress
-
     def cancel_text_correction(self):
         """Cancela a correção de texto em andamento."""
         self.correction_cancel_event.set()

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -688,7 +688,7 @@ class UIManager:
             pystray.MenuItem(
                 '🚫 Cancel Transcription',
                 lambda: self.core_instance_ref.cancel_transcription(),
-                enabled=lambda item: self.core_instance_ref.is_transcription_running()
+                enabled=lambda item: self.core_instance_ref.is_state_transcribing()
             ),
             pystray.MenuItem(
                 '⛔ Cancel Correction',


### PR DESCRIPTION
## Summary
- delete unused `is_transcription_running` in `TranscriptionHandler`
- drop wrapper in `AppCore`
- check transcribing state directly when needed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595ac28ec4833096dce00520c942bb