### PR TITLE
Fix UI check for transcription state

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -688,7 +688,7 @@ class UIManager:
             pystray.MenuItem(
                 '🚫 Cancel Transcription',
                 lambda: self.core_instance_ref.cancel_transcription(),
-                enabled=lambda item: self.core_instance_ref.is_transcription_running()
+                enabled=lambda item: self.core_instance_ref.is_state_transcribing()
             ),
             pystray.MenuItem(
                 '⛔ Cancel Correction',


### PR DESCRIPTION
## Summary
- cancel transcription menu item in `UIManager` now uses `is_state_transcribing()`
- kept all other menu options intact

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68595ac496688330a78121d7e79f10cc