### PR TITLE
Update docs for state clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A lightweight, high-performance desktop tool for Windows that turns your speech 
 *   **Auditory Feedback:** Optional sound cues for starting and stopping recording.
 *   **Automatically remove silent sections** using the Silero VAD. Initialization uses `onnxruntime` with automatic selection of `CUDAExecutionProvider` when available, falling back to `CPUExecutionProvider`.
 *   **Robust and Stable:** Includes a background service to ensure hotkeys remain responsive, a common issue on Windows 11.
-*   **Simplified State Management:** the former "SAVING" state was removed as no functionality depended on it.
+*   **Unified `TRANSCRIBING` State:** recording, Whisper processing, and optional AI correction all occur while the application remains in this state. Once the final text is ready, the state returns to `IDLE`.
 
 ## System Architecture
 


### PR DESCRIPTION
## Summary
- clarify that the `TRANSCRIBING` state spans the entire process
- remove leftover mention of old `SAVING` state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68595ac62d988330beed5e985e21f97f