### PR TITLE
Implement stop_transcription event

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ update to the latest version. The attribute is now properly initialized in `Tran
 ### New callback `on_transcription_cancelled_callback`
 
 For developers instantiating `TranscriptionHandler` manually, there is now an optional `on_transcription_cancelled_callback` parameter. It
-is invoked when `cancel_transcription()` is called and the segment is still being processed, allowing you to reset state or close custom windows.
+is invoked when `stop_transcription()` is called and the segment is still being processed, allowing you to reset state or close custom windows.
 
 ## Contributing
 

--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -108,7 +108,7 @@ class DummyTranscriptionHandler:
         else:
             self.on_transcription_result_callback("raw", "raw")
 
-    def cancel_transcription(self):
+    def stop_transcription(self):
         pass
 
     def cancel_text_correction(self):

--- a/tests/test_is_any_operation_running.py
+++ b/tests/test_is_any_operation_running.py
@@ -61,7 +61,7 @@ class DummyTranscriptionHandler:
     def is_text_correction_running(self):
         return self.correction_in_progress
 
-    def cancel_transcription(self):
+    def stop_transcription(self):
         pass
 
     def cancel_text_correction(self):

--- a/tests/test_temp_recording_cleanup.py
+++ b/tests/test_temp_recording_cleanup.py
@@ -72,7 +72,7 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
         def is_transcription_running(self):
             return False
 
-        def cancel_transcription(self):
+        def stop_transcription(self):
             pass
 
         def cancel_text_correction(self):
@@ -114,7 +114,7 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
     app.current_state = core_module.STATE_IDLE
 
     # Evita erros caso o AppCore chame métodos de cancelamento inexistentes
-    app.cancel_transcription = lambda: None
+    app.stop_transcription = lambda: None
     app.cancel_text_correction = lambda: None
 
     app.start_recording()


### PR DESCRIPTION
## Summary
- add `_stop_signal_event` and new `stop_transcription` method in `TranscriptionHandler`
- rename old cancel event uses to `_stop_signal_event`
- update documentation to mention `stop_transcription`
- align tests with new method name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68596c8f9018833088bb5a81ca550eb3