### PR TITLE
Implement state-aware correction thread

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -161,7 +161,7 @@ class TranscriptionHandler:
             logging.error(f"Erro ao chamar get_correction da API Gemini: {e}")
             return text
 
-    def _async_text_correction(self, text: str, service: str) -> None:
+    def _async_text_correction(self, text: str, service: str, was_transcribing: bool) -> None:
         """Corrige o texto de forma assíncrona com timeout."""
 
         corrected = text
@@ -185,7 +185,11 @@ class TranscriptionHandler:
                     logging.error(f"Erro ao corrigir texto: {exc}")
         finally:
             self.correction_in_progress = False
-            if self.is_state_transcribing_fn and self.is_state_transcribing_fn():
+            if (
+                self.is_state_transcribing_fn
+                and was_transcribing
+                and self.is_state_transcribing_fn()
+            ):
                 if self.config_manager.get(SAVE_TEMP_RECORDINGS_CONFIG_KEY):
                     logging.info(f"Transcrição corrigida: {corrected}")
                 self.on_transcription_result_callback(corrected, text)
@@ -381,9 +385,14 @@ class TranscriptionHandler:
                         )
             else:
                 service = self._get_text_correction_service()
+                was_transcribing = (
+                    self.is_state_transcribing_fn()
+                    if self.is_state_transcribing_fn
+                    else False
+                )
                 self.correction_thread = threading.Thread(
                     target=self._async_text_correction,
-                    args=(text_result, service),
+                    args=(text_result, service, was_transcribing),
                     daemon=True,
                     name="TextCorrectionThread",
                 )

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -92,7 +92,11 @@ def test_transcription_task_handles_missing_callback(monkeypatch):
     handler.transcription_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
     monkeypatch.setattr(handler, "_get_dynamic_batch_size", lambda: 1)
-    monkeypatch.setattr(handler, "_async_text_correction", lambda text, service: result_callback(text, text))
+    monkeypatch.setattr(
+        handler,
+        "_async_text_correction",
+        lambda text, service, was_transcribing: result_callback(text, text),
+    )
 
     handler._transcription_task(None, agent_mode=False)
 
@@ -126,7 +130,7 @@ def test_async_text_correction_service_selection(monkeypatch):
         selected = handler._get_text_correction_service()
         handler._correct_text_with_gemini.reset_mock()
         handler._correct_text_with_openrouter.reset_mock()
-        handler._async_text_correction("txt", selected)
+        handler._async_text_correction("txt", selected, False)
 
         if service == SERVICE_GEMINI:
             assert handler._correct_text_with_gemini.called


### PR DESCRIPTION
## Summary
- track transcribing state when launching correction thread
- pass state flag to `_async_text_correction`
- adapt tests to new function signature

## Testing
- `pip install -r requirements.txt` *(failed: Operation cancelled)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'onnxruntime')*

------
https://chatgpt.com/codex/tasks/task_e_68596c9122048330a4a7379ba47f580b