### PR TITLE
Add text correction completion test

### DIFF
--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -1,6 +1,8 @@
 import importlib.machinery
 import types
 import concurrent.futures
+import threading
+import time
 from unittest.mock import MagicMock
 
 # Stub simples de torch
@@ -161,3 +163,44 @@ def test_get_dynamic_batch_size_for_cpu_and_gpu(monkeypatch):
 
     monkeypatch.setattr(fake_torch.cuda, "is_available", lambda: False)
     assert handler._get_dynamic_batch_size() == 4
+
+
+def test_text_correction_preserves_result_when_state_changes(monkeypatch):
+    cfg = DummyConfig()
+    cfg.data[TEXT_CORRECTION_ENABLED_CONFIG_KEY] = True
+    cfg.data[TEXT_CORRECTION_SERVICE_CONFIG_KEY] = SERVICE_GEMINI
+    results = []
+
+    def result_callback(text, original):
+        results.append(text)
+
+    handler = TranscriptionHandler(
+        cfg,
+        gemini_api_client=None,
+        on_model_ready_callback=noop,
+        on_model_error_callback=noop,
+        on_transcription_result_callback=result_callback,
+        on_agent_result_callback=noop,
+        on_segment_transcribed_callback=None,
+        is_state_transcribing_fn=lambda: True,
+    )
+    handler.gemini_client = MagicMock(is_valid=True)
+
+    def delayed_correct(text):
+        time.sleep(0.05)
+        return "corrigido"
+
+    monkeypatch.setattr(handler, "_correct_text_with_gemini", delayed_correct)
+
+    thread = threading.Thread(
+        target=handler._async_text_correction,
+        args=("texto", SERVICE_GEMINI),
+        daemon=True,
+    )
+    thread.start()
+    time.sleep(0.01)
+    handler.is_state_transcribing_fn = lambda: False
+    thread.join()
+
+    assert results == ["corrigido"]
+


### PR DESCRIPTION
## Summary
- add missing imports for concurrency utilities
- ensure text correction results are preserved when state changes

## Testing
- `flake8 tests/test_transcription_handler_callback.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'onnxruntime', AttributeError: module 'requests' has no attribute 'post', AssertionError: assert [] == ['corrigido'])*

------
https://chatgpt.com/codex/tasks/task_e_68596c9331108330a1e899c70555d7d3