### PR TITLE
docs: clarify state_check_callback alias

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -39,7 +39,8 @@ class TranscriptionHandler:
         self.on_agent_result_callback = on_agent_result_callback # Para resultado do agente
         self.on_segment_transcribed_callback = on_segment_transcribed_callback # Para segmentos em tempo real
         self.is_state_transcribing_fn = is_state_transcribing_fn
-        # Alias para manter compatibilidade com referências existentes
+        # "state_check_callback" é preservado apenas para retrocompatibilidade;
+        # utilize "is_state_transcribing_fn" nas novas implementações.
         self.state_check_callback = is_state_transcribing_fn
         self.correction_in_progress = False
 


### PR DESCRIPTION
## Summary
- keep `state_check_callback` pointing to `is_state_transcribing_fn`
- clarify in code comment that `state_check_callback` is only for backward compatibility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'onnxruntime')*

------
https://chatgpt.com/codex/tasks/task_e_68596c945dd88330bd7115220ee63a91