### PR TITLE
Implement stop event usage in transcription

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -46,6 +46,8 @@ class TranscriptionHandler:
         self.pipe = None
         # Futura tarefa de transcrição em andamento
         self.transcription_future = None
+        # Evento de sinalização para parar tarefas de transcrição
+        self._stop_signal_event = threading.Event()
         # Executor dedicado para a tarefa de transcrição em background
         self.transcription_executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=1
@@ -279,14 +281,14 @@ class TranscriptionHandler:
 
     def transcribe_audio_segment(self, audio_input: np.ndarray, agent_mode: bool = False):
         """Envia segmento para transcrição assíncrona."""
-        self.transcription_cancel_event.clear()
+        self._stop_signal_event.clear()
 
         self.transcription_future = self.transcription_executor.submit(
             self._transcription_task, audio_input, agent_mode
         )
 
     def _transcription_task(self, audio_input: np.ndarray, agent_mode: bool) -> None:
-        if self.transcription_cancel_event.is_set():
+        if self._stop_signal_event.is_set():
             logging.info("Transcrição cancelada antes do início do processamento.")
             return
 
@@ -328,9 +330,9 @@ class TranscriptionHandler:
             text_result = f"[Transcription Error: {e}]"
 
         finally:
-            if self.transcription_cancel_event.is_set():
+            if self._stop_signal_event.is_set():
                 logging.info("Transcrição cancelada. Resultado descartado.")
-                self.transcription_cancel_event.clear()
+                self._stop_signal_event.clear()
                 return
 
             if text_result and self.config_manager.get(DISPLAY_TRANSCRIPTS_KEY):


### PR DESCRIPTION
## Summary
- use `_stop_signal_event` to manage transcription cancel events
- initialize new event in `TranscriptionHandler`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'onnxruntime', others)*

------
https://chatgpt.com/codex/tasks/task_e_68596c8fbfe88330aa8c926fabcf4469