### PR TITLE
Remove deprecated callback mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,11 +280,6 @@ If `pip install -r requirements.txt` fails or the application doesn't run due to
 If you encounter the message `AttributeError: 'TranscriptionHandler' object has no attribute 'state_check_callback'`,
 update to the latest version. The attribute is now properly initialized in `TranscriptionHandler.__init__`.
 
-### New callback `on_transcription_cancelled_callback`
-
-For developers instantiating `TranscriptionHandler` manually, there is now an optional `on_transcription_cancelled_callback` parameter. It
-is invoked when `cancel_transcription()` is called and the segment is still being processed, allowing you to reset state or close custom windows.
-
 ## Contributing
 
 Contributions are welcome! If you have ideas for improvements, bug fixes, or new features, please:


### PR DESCRIPTION
## Summary
- clean up Troubleshooting instructions

## Testing
- `pytest -q` *(fails: module 'numpy' has no attribute 'zeros', module 'onnxruntime' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d470d6448330885be11143d65a77