### PR TITLE
Remove cancelled callbacks from DummyTranscriptionHandler

### DIFF
--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -91,7 +91,7 @@ class DummyTranscriptionHandler:
     def __init__(self, config_manager, gemini_api_client, on_model_ready_callback,
                  on_model_error_callback, on_transcription_result_callback,
                  on_agent_result_callback, on_segment_transcribed_callback,
-                 is_state_transcribing_fn, on_transcription_cancelled_callback=None):
+                 is_state_transcribing_fn):
         self.pipe = True
         self.on_transcription_result_callback = on_transcription_result_callback
         self.config_manager = config_manager
@@ -107,12 +107,6 @@ class DummyTranscriptionHandler:
             threading.Thread(target=_run).start()
         else:
             self.on_transcription_result_callback("raw", "raw")
-
-    def cancel_transcription(self):
-        pass
-
-    def cancel_text_correction(self):
-        pass
 
     def shutdown(self):
         pass

--- a/tests/test_is_any_operation_running.py
+++ b/tests/test_is_any_operation_running.py
@@ -61,12 +61,6 @@ class DummyTranscriptionHandler:
     def is_text_correction_running(self):
         return self.correction_in_progress
 
-    def cancel_transcription(self):
-        pass
-
-    def cancel_text_correction(self):
-        pass
-
     def shutdown(self):
         pass
 

--- a/tests/test_temp_recording_cleanup.py
+++ b/tests/test_temp_recording_cleanup.py
@@ -72,12 +72,6 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
         def is_transcription_running(self):
             return False
 
-        def cancel_transcription(self):
-            pass
-
-        def cancel_text_correction(self):
-            pass
-
         def shutdown(self):
             pass
 
@@ -113,9 +107,6 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
     app = core_module.AppCore(dummy_root)
     app.current_state = core_module.STATE_IDLE
 
-    # Evita erros caso o AppCore chame métodos de cancelamento inexistentes
-    app.cancel_transcription = lambda: None
-    app.cancel_text_correction = lambda: None
 
     app.start_recording()
     app.stop_recording()


### PR DESCRIPTION
## Summary
- simplify `DummyTranscriptionHandler` in tests
- clean up unused cancellation logic in test stubs

## Testing
- `pytest tests/test_temp_recording_cleanup.py -q`
- `pytest tests/test_is_any_operation_running.py -q`
- `pytest -q` *(fails: '<' not supported between instances of 'float' and 'NoneType', AssertionError: False is not true, AttributeError: <module 'requests'> does not have the attribute 'post', AttributeError: module 'torch' has no attribute 'cuda', ModuleNotFoundError: No module named 'onnxruntime')*

------
https://chatgpt.com/codex/tasks/task_e_6859d470fc408330af7442a559da588b