### PR TITLE
Remove obsolete stubs from cleanup test

### DIFF
--- a/tests/test_temp_recording_cleanup.py
+++ b/tests/test_temp_recording_cleanup.py
@@ -113,10 +113,6 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
     app = core_module.AppCore(dummy_root)
     app.current_state = core_module.STATE_IDLE
 
-    # Evita erros caso o AppCore chame métodos de cancelamento inexistentes
-    app.cancel_transcription = lambda: None
-    app.cancel_text_correction = lambda: None
-
     app.start_recording()
     app.stop_recording()
 


### PR DESCRIPTION
## Summary
- remove deprecated `cancel_transcription` and `cancel_text_correction` assignments

## Testing
- `pytest tests/test_temp_recording_cleanup.py::test_temp_recording_cleanup -q`
- `pytest -q` *(fails: TypeError, AssertionError, AttributeError, ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6859d473a5448330831686999dad5492