### PR TITLE
Remove obsolete cancel references from tests

### DIFF
--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -108,12 +108,6 @@ class DummyTranscriptionHandler:
         else:
             self.on_transcription_result_callback("raw", "raw")
 
-    def cancel_transcription(self):
-        pass
-
-    def cancel_text_correction(self):
-        pass
-
     def shutdown(self):
         pass
 

--- a/tests/test_is_any_operation_running.py
+++ b/tests/test_is_any_operation_running.py
@@ -61,11 +61,6 @@ class DummyTranscriptionHandler:
     def is_text_correction_running(self):
         return self.correction_in_progress
 
-    def cancel_transcription(self):
-        pass
-
-    def cancel_text_correction(self):
-        pass
 
     def shutdown(self):
         pass

--- a/tests/test_temp_recording_cleanup.py
+++ b/tests/test_temp_recording_cleanup.py
@@ -72,11 +72,6 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
         def is_transcription_running(self):
             return False
 
-        def cancel_transcription(self):
-            pass
-
-        def cancel_text_correction(self):
-            pass
 
         def shutdown(self):
             pass
@@ -113,9 +108,6 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
     app = core_module.AppCore(dummy_root)
     app.current_state = core_module.STATE_IDLE
 
-    # Evita erros caso o AppCore chame métodos de cancelamento inexistentes
-    app.cancel_transcription = lambda: None
-    app.cancel_text_correction = lambda: None
 
     app.start_recording()
     app.stop_recording()


### PR DESCRIPTION
## Summary
- clean up leftover `cancel_*` methods from tests

## Testing
- `pytest -q`
- `flake8 src/gemini_api.py src/openrouter_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6859d473c4e48330b1a648a024f1d353