### PR TITLE
Add shutdown method to transcription handler

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -397,7 +397,5 @@ class TranscriptionHandler:
 
     def shutdown(self) -> None:
         """Encerra o executor de transcrição."""
-        try:
-            self.transcription_executor.shutdown(wait=False)
-        except Exception as e:
-            logging.error(f"Erro ao encerrar o executor de transcrição: {e}")
+        logging.info("Shutting down transcription thread pool executor.")
+        self.transcription_executor.shutdown(wait=False, cancel_futures=True)


### PR DESCRIPTION
## Summary
- simplify shutdown of TranscriptionHandler

## Testing
- `pytest -q` *(fails: numpy missing zeros, onnxruntime missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859d49d59a8833085effc00eba9deee