### PR TITLE
Update AppCore initialization

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -48,6 +48,7 @@ class AppCore:
         self.transcription_lock = RLock()
         self.state_lock = RLock()
         self.keyboard_lock = RLock()
+        self.agent_mode_lock = RLock()
 
         # --- Callbacks para UI (definidos externamente pelo UIManager) ---
         self.state_update_callback = None


### PR DESCRIPTION
## Summary
- add RLock for agent mode in AppCore

## Testing
- `bash setup.sh` *(fails: No such file or directory)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685a9e301f088330ba840153caa7bbfc