### PR TITLE
Atualização do método _on_audio_segment_ready

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -25,6 +25,7 @@ DEFAULT_CONFIG = {
     "gemini_api_key": "",
     "gemini_model": "gemini-2.5-flash-lite-preview-06-17",
     "gemini_agent_model": "gemini-2.5-flash-lite-preview-06-17",
+    "openrouter_prompt": "",
     "prompt_agentico": "You are an AI assistant that executes text commands. The user will provide an instruction followed by the text to be processed. Your task is to execute the instruction on the text and return ONLY the final result. Do not add explanations, greetings, or any extra text. The user's instruction is your top priority. The output language should match the main language of the provided text.",
     "gemini_prompt": """You are a meticulous speech-to-text correction AI. Your primary task is to correct punctuation, capitalization, and minor transcription errors in the text below while preserving the original content and structure as closely as possible.
 Key instructions:
@@ -78,6 +79,7 @@ KEYBOARD_LIBRARY_CONFIG_KEY = "keyboard_library"
 KEYBOARD_LIB_WIN32 = "win32"
 TEXT_CORRECTION_ENABLED_CONFIG_KEY = "text_correction_enabled"
 TEXT_CORRECTION_SERVICE_CONFIG_KEY = "text_correction_service"
+ENABLE_AI_CORRECTION_CONFIG_KEY = TEXT_CORRECTION_ENABLED_CONFIG_KEY
 SERVICE_NONE = "none"
 SERVICE_OPENROUTER = "openrouter"
 SERVICE_GEMINI = "gemini"
@@ -87,6 +89,8 @@ GEMINI_API_KEY_CONFIG_KEY = "gemini_api_key"
 GEMINI_MODEL_CONFIG_KEY = "gemini_model"
 GEMINI_AGENT_MODEL_CONFIG_KEY = "gemini_agent_model"
 GEMINI_MODEL_OPTIONS_CONFIG_KEY = "gemini_model_options"
+GEMINI_PROMPT_CONFIG_KEY = "gemini_prompt"
+OPENROUTER_PROMPT_CONFIG_KEY = "openrouter_prompt"
 SETTINGS_WINDOW_GEOMETRY = "550x700"
 REREGISTER_INTERVAL_SECONDS = 60
 MAX_HOTKEY_FAILURES = 3

--- a/src/core.py
+++ b/src/core.py
@@ -22,6 +22,9 @@ from .config_manager import (
     HOTKEY_HEALTH_CHECK_INTERVAL,
     DISPLAY_TRANSCRIPTS_KEY,
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
+    ENABLE_AI_CORRECTION_CONFIG_KEY,
+    GEMINI_PROMPT_CONFIG_KEY,
+    OPENROUTER_PROMPT_CONFIG_KEY,
 )
 from .audio_handler import AudioHandler, AUDIO_SAMPLE_RATE # AUDIO_SAMPLE_RATE ainda é usado em _handle_transcription_result
 from .transcription_handler import TranscriptionHandler
@@ -121,27 +124,29 @@ class AppCore:
         """Define o callback para atualizar a UI com a tecla detectada."""
         self.key_detection_callback = callback
 
-    def _on_audio_segment_ready(self, audio_segment: np.ndarray):
-        """Callback do AudioHandler quando um segmento de áudio está pronto para transcrição."""
-        duration_seconds = len(audio_segment) / AUDIO_SAMPLE_RATE
-        min_duration = self.config_manager.get('min_transcription_duration')
-        
-        if duration_seconds < min_duration:
-            logging.info(f"Segmento de áudio ({duration_seconds:.2f}s) é mais curto que o mínimo configurado ({min_duration}s). Ignorando.")
-            self._set_state(STATE_IDLE) # Volta para o estado IDLE
-            return # Interrompe o processamento
+    def _on_audio_segment_ready(self, audio_segment_path, duration_seconds):
+        with self.transcription_lock:
+            if not os.path.exists(audio_segment_path):
+                logging.warning(f"AppCore: Arquivo de segmento de áudio não encontrado: {audio_segment_path}. Cancelando transcrição.")
+                self._set_state(STATE_IDLE) # Volta para o estado IDLE
+                return # Interrompe o processamento
 
-        # Captura o estado do modo agente ANTES de qualquer coisa.
-        is_agent_mode = self.agent_mode_active
-        
-        # Reseta o estado imediatamente após capturá-lo para a próxima gravação.
-        if is_agent_mode:
-            self.agent_mode_active = False
+            # Captura e reseta o estado do modo agente de forma atômica para evitar race conditions.
+            with self.agent_mode_lock:
+                is_agent_mode = self.agent_mode_active
+                if is_agent_mode:
+                    self.agent_mode_active = False
 
-        logging.info(f"AppCore: Segmento de áudio pronto ({duration_seconds:.2f}s). Enviando para TranscriptionHandler (Modo Agente: {is_agent_mode}).")
-        
-        # Passa o estado capturado para o handler de transcrição.
-        self.transcription_handler.transcribe_audio_segment(audio_segment, agent_mode=is_agent_mode)
+            logging.info(f"AppCore: Segmento de áudio pronto ({duration_seconds:.2f}s). Enviando para TranscriptionHandler (Modo Agente: {is_agent_mode}).")
+
+            # Delega a tarefa de transcrição para o TranscriptionHandler
+            self.transcription_handler.transcribe_audio_segment(
+                audio_segment_path,
+                is_agent_mode,
+                self.config_manager.get(ENABLE_AI_CORRECTION_CONFIG_KEY),
+                self.config_manager.get(GEMINI_PROMPT_CONFIG_KEY),
+                self.config_manager.get(OPENROUTER_PROMPT_CONFIG_KEY)
+            )
 
     def _on_model_loaded(self):
         """Callback do TranscriptionHandler quando o modelo é carregado com sucesso."""

--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -80,7 +80,10 @@ class DummyAudioHandler:
     def stop_recording(self):
         self.is_recording = False
         self.on_recording_state_change_callback(core_module.STATE_TRANSCRIBING)
-        self.on_audio_segment_ready_callback([0.0])
+        path = "dummy.wav"
+        with open(path, "w") as f:
+            f.write("data")
+        self.on_audio_segment_ready_callback(path, 0.1)
 
 class DummyTranscriptionHandler:
     def __init__(self, config_manager, gemini_api_client, on_model_ready_callback,
@@ -94,7 +97,10 @@ class DummyTranscriptionHandler:
     def start_model_loading(self):
         pass
 
-    def transcribe_audio_segment(self, audio, agent_mode=False):
+    def transcribe_audio_segment(self, *args):
+        agent_mode = False
+        if len(args) > 1:
+            agent_mode = args[1]
         if self.config_manager.get(TEXT_CORRECTION_ENABLED_CONFIG_KEY):
             def _run():
                 time.sleep(0.01)


### PR DESCRIPTION
## Summary
- proteger manipulação de `agent_mode_active` em `_on_audio_segment_ready`
- acrescentar novas chaves de configuração para prompts e correção
- ajustar testes de `AppCore` para nova assinatura

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae968174c8330a9dc3b0749f5d9d7