### PR TITLE
Add openrouter prompt config

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -27,6 +27,7 @@ DEFAULT_CONFIG = {
     "gemini_agent_model": "gemini-2.5-flash-lite-preview-06-17",
     "ai_provider": "gemini",
     "openrouter_agent_prompt": "",
+    "openrouter_prompt": "",
     "prompt_agentico": "You are an AI assistant that executes text commands. The user will provide an instruction followed by the text to be processed. Your task is to execute the instruction on the text and return ONLY the final result. Do not add explanations, greetings, or any extra text. The user's instruction is your top priority. The output language should match the main language of the provided text.",
     "gemini_prompt": """You are a meticulous speech-to-text correction AI. Your primary task is to correct punctuation, capitalization, and minor transcription errors in the text below while preserving the original content and structure as closely as possible.
 Key instructions:
@@ -93,6 +94,7 @@ GEMINI_MODEL_OPTIONS_CONFIG_KEY = "gemini_model_options"
 AI_PROVIDER_CONFIG_KEY = TEXT_CORRECTION_SERVICE_CONFIG_KEY
 GEMINI_AGENT_PROMPT_CONFIG_KEY = "prompt_agentico"
 OPENROUTER_AGENT_PROMPT_CONFIG_KEY = "openrouter_agent_prompt"
+OPENROUTER_PROMPT_CONFIG_KEY = "openrouter_prompt"
 SETTINGS_WINDOW_GEOMETRY = "550x700"
 REREGISTER_INTERVAL_SECONDS = 60
 MAX_HOTKEY_FAILURES = 3

--- a/src/core.py
+++ b/src/core.py
@@ -22,6 +22,7 @@ from .config_manager import (
     HOTKEY_HEALTH_CHECK_INTERVAL,
     DISPLAY_TRANSCRIPTS_KEY,
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
+    OPENROUTER_PROMPT_CONFIG_KEY,
 )
 from .audio_handler import AudioHandler, AUDIO_SAMPLE_RATE # AUDIO_SAMPLE_RATE ainda é usado em _handle_transcription_result
 from .transcription_handler import TranscriptionHandler
@@ -553,6 +554,7 @@ class AppCore:
                 "new_gemini_api_key": "gemini_api_key", "new_gemini_model": "gemini_model",
                 "new_agent_model": "gemini_agent_model",
                 "new_gemini_prompt": "gemini_prompt",
+                "new_openrouter_prompt": OPENROUTER_PROMPT_CONFIG_KEY,
                 "new_batch_size": "batch_size", "new_gpu_index": "gpu_index",
                 "new_hotkey_stability_service_enabled": "hotkey_stability_service_enabled", # Nova configuração unificada
                 "new_min_transcription_duration": "min_transcription_duration",

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -18,6 +18,7 @@ from .config_manager import (
     AI_PROVIDER_CONFIG_KEY,
     GEMINI_AGENT_PROMPT_CONFIG_KEY,
     OPENROUTER_AGENT_PROMPT_CONFIG_KEY,
+    OPENROUTER_PROMPT_CONFIG_KEY,
     MIN_TRANSCRIPTION_DURATION_CONFIG_KEY, DISPLAY_TRANSCRIPTS_KEY, # Nova constante
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
 )
@@ -419,7 +420,7 @@ class TranscriptionHandler:
                     if self.is_state_transcribing_fn
                     else False
                 )
-                openrouter_prompt = self.config_manager.get(OPENROUTER_AGENT_PROMPT_CONFIG_KEY)
+                openrouter_prompt = self.config_manager.get(OPENROUTER_PROMPT_CONFIG_KEY)
                 self.correction_thread = threading.Thread(
                     target=self._async_text_correction,
                     args=(text_result, agent_mode, self.gemini_prompt, openrouter_prompt, was_transcribing_when_started),


### PR DESCRIPTION
## Summary
- add `openrouter_prompt` entry to `DEFAULT_CONFIG`
- expose constant `OPENROUTER_PROMPT_CONFIG_KEY`
- map `new_openrouter_prompt` to config key
- ensure `TranscriptionHandler` reads the prompt from the correct key

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for 'numpy' and 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685d4c1cbf188330bf619aad1b44dbbb