### PR TITLE
Hide sensitive config values in logs

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -263,7 +263,10 @@ class ConfigManager:
             )
             self.config[VAD_SILENCE_DURATION_CONFIG_KEY] = self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]
 
-        logging.info(f"Configurações aplicadas: {self.config}")
+        safe_config = self.config.copy()
+        safe_config.pop(GEMINI_API_KEY_CONFIG_KEY, None)
+        safe_config.pop(OPENROUTER_API_KEY_CONFIG_KEY, None)
+        logging.info(f"Configurações aplicadas: {safe_config}")
 
 
     def save_config(self):


### PR DESCRIPTION
## Summary
- avoid logging API keys in config_manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'onnxruntime')*

------
https://chatgpt.com/codex/tasks/task_e_685d4c3335a483308f758df3246edb04