### PR TITLE
Update max_tokens in OpenRouter and fix callback

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -121,9 +121,17 @@ class AppCore:
         """Define o callback para atualizar a UI com a tecla detectada."""
         self.key_detection_callback = callback
 
-    def _on_audio_segment_ready(self, audio_segment: np.ndarray):
-        """Callback do AudioHandler quando um segmento de áudio está pronto para transcrição."""
-        duration_seconds = len(audio_segment) / AUDIO_SAMPLE_RATE
+    def _on_audio_segment_ready(self, audio_segment, duration: float | None = None):
+        """Callback do AudioHandler quando um segmento de áudio está pronto para transcrição.
+
+        Aceita tanto o *array* de áudio quanto um caminho para arquivo. Quando
+        ``duration`` é informado, utiliza esse valor em vez de calcular o
+        comprimento do *array*.
+        """
+        if duration is None and not isinstance(audio_segment, str):
+            duration_seconds = len(audio_segment) / AUDIO_SAMPLE_RATE
+        else:
+            duration_seconds = duration or 0.0
         min_duration = self.config_manager.get('min_transcription_duration')
         
         if duration_seconds < min_duration:
@@ -141,7 +149,7 @@ class AppCore:
         logging.info(f"AppCore: Segmento de áudio pronto ({duration_seconds:.2f}s). Enviando para TranscriptionHandler (Modo Agente: {is_agent_mode}).")
         
         # Passa o estado capturado para o handler de transcrição.
-        self.transcription_handler.transcribe_audio_segment(audio_segment, agent_mode=is_agent_mode)
+        self.transcription_handler.transcribe_audio_segment(audio_segment, is_agent_mode)
 
     def _on_model_loaded(self):
         """Callback do TranscriptionHandler quando o modelo é carregado com sucesso."""

--- a/src/openrouter_api.py
+++ b/src/openrouter_api.py
@@ -16,11 +16,20 @@ class OpenRouterAPI:
         self,
         api_key: str,
         model_id: str = "deepseek/deepseek-chat-v3-0324:free",
+        max_tokens: int = 4096,
     ) -> None:
-        """Inicializa o cliente OpenRouter."""
+        """Inicializa o cliente OpenRouter.
+
+        Args:
+            api_key: Chave de acesso para a API.
+            model_id: Identificador do modelo em uso.
+            max_tokens: Limite máximo de tokens retornados pela API. O padrão
+                ``4096`` é compatível com a maioria dos modelos do OpenRouter.
+        """
         self.api_key = api_key
         self.model_id = model_id
         self.base_url = "https://openrouter.ai/api/v1/chat/completions"
+        self.max_tokens = max_tokens
         self.headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
@@ -95,7 +104,7 @@ class OpenRouterAPI:
             ],
             "temperature": 0.0,
             # Low temperature for mais determinismo
-            "max_tokens": 10000   # Adjust based on your expected output length
+            "max_tokens": self.max_tokens  # Ajustável conforme o modelo em uso
         }
 
         # Try to make the API call with retries


### PR DESCRIPTION
## Summary
- add `max_tokens` parameter to `OpenRouterAPI`
- use new `self.max_tokens` in payload
- accept optional duration and file paths in `_on_audio_segment_ready`
- adjust call to transcription handler accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4c354d6883308b630a65d0dbecb2