### PR TITLE
Fix README dev requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Contributions are welcome! If you have ideas for improvements, bug fixes, or new
 6.  Describe your changes and why they should be included.
 7.  Install the development dependencies with:
     ```bash
-    pip install -r requirements-dev.txt
+    pip install -r requirements-test.txt
     ```
 8.  Run `flake8 src/gemini_api.py src/openrouter_api.py` to check the lint.
 


### PR DESCRIPTION
## Summary
- correct path for installing dev requirements in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: numpy, requests)*

------
https://chatgpt.com/codex/tasks/task_e_685d4c37ab5083309cefb25e5562d344