### PR TITLE
Adjust audio segment callback

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -121,10 +121,10 @@ class AppCore:
         """Define o callback para atualizar a UI com a tecla detectada."""
         self.key_detection_callback = callback
 
-    def _on_audio_segment_ready(self, audio_segment: np.ndarray):
-        """Callback do AudioHandler quando um segmento de áudio está pronto para transcrição."""
-        duration_seconds = len(audio_segment) / AUDIO_SAMPLE_RATE
-        min_duration = self.config_manager.get('min_transcription_duration')
+    def _on_audio_segment_ready(self, audio_data: np.ndarray):
+        """Callback do ``AudioHandler`` quando um segmento de áudio está pronto para transcrição."""
+        duration_seconds = len(audio_data) / AUDIO_SAMPLE_RATE
+        min_duration = self.config_manager.get("min_transcription_duration")
         
         if duration_seconds < min_duration:
             logging.info(f"Segmento de áudio ({duration_seconds:.2f}s) é mais curto que o mínimo configurado ({min_duration}s). Ignorando.")
@@ -138,10 +138,12 @@ class AppCore:
         if is_agent_mode:
             self.agent_mode_active = False
 
-        logging.info(f"AppCore: Segmento de áudio pronto ({duration_seconds:.2f}s). Enviando para TranscriptionHandler (Modo Agente: {is_agent_mode}).")
+        logging.info(
+            f"AppCore: Segmento de áudio pronto ({duration_seconds:.2f}s). Enviando para TranscriptionHandler (Modo Agente: {is_agent_mode})."
+        )
         
         # Passa o estado capturado para o handler de transcrição.
-        self.transcription_handler.transcribe_audio_segment(audio_segment, agent_mode=is_agent_mode)
+        self.transcription_handler.transcribe_audio_segment(audio_data, is_agent_mode)
 
     def _on_model_loaded(self):
         """Callback do TranscriptionHandler quando o modelo é carregado com sucesso."""

--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -3,6 +3,7 @@ import time
 import threading
 import os
 import sys
+import numpy as np
 from unittest.mock import MagicMock
 
 # Stub external dependencies before importing core module
@@ -80,10 +81,8 @@ class DummyAudioHandler:
     def stop_recording(self):
         self.is_recording = False
         self.on_recording_state_change_callback(core_module.STATE_TRANSCRIBING)
-        path = "dummy.wav"
-        with open(path, "w") as f:
-            f.write("data")
-        self.on_audio_segment_ready_callback(path, 0.1)
+        audio = np.zeros(160, dtype=np.float32)
+        self.on_audio_segment_ready_callback(audio)
 
 class DummyTranscriptionHandler:
     def __init__(self, config_manager, gemini_api_client, on_model_ready_callback,
@@ -97,10 +96,7 @@ class DummyTranscriptionHandler:
     def start_model_loading(self):
         pass
 
-    def transcribe_audio_segment(self, *args):
-        agent_mode = False
-        if len(args) > 1:
-            agent_mode = args[1]
+    def transcribe_audio_segment(self, audio_data, agent_mode=False):
         if self.config_manager.get(TEXT_CORRECTION_ENABLED_CONFIG_KEY):
             def _run():
                 time.sleep(0.01)


### PR DESCRIPTION
## Summary
- update `_on_audio_segment_ready` to receive `audio_data`
- adjust log message and call to transcription handler
- update tests for new callback signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4c3c2f948330b878da430326dddd