### PR TITLE
Atualiza testes para nova API de áudio

### DIFF
--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -4,6 +4,7 @@ import threading
 import os
 import sys
 from unittest.mock import MagicMock
+import numpy as np
 
 # Stub external dependencies before importing core module
 fake_pyautogui = types.ModuleType("pyautogui")
@@ -80,10 +81,8 @@ class DummyAudioHandler:
     def stop_recording(self):
         self.is_recording = False
         self.on_recording_state_change_callback(core_module.STATE_TRANSCRIBING)
-        path = "dummy.wav"
-        with open(path, "w") as f:
-            f.write("data")
-        self.on_audio_segment_ready_callback(path, 0.1)
+        audio = np.zeros(1600, dtype=np.float32)
+        self.on_audio_segment_ready_callback(audio)
 
 class DummyTranscriptionHandler:
     def __init__(self, config_manager, gemini_api_client, on_model_ready_callback,
@@ -97,10 +96,7 @@ class DummyTranscriptionHandler:
     def start_model_loading(self):
         pass
 
-    def transcribe_audio_segment(self, *args):
-        agent_mode = False
-        if len(args) > 1:
-            agent_mode = args[1]
+    def transcribe_audio_segment(self, audio_data, agent_mode=False):
         if self.config_manager.get(TEXT_CORRECTION_ENABLED_CONFIG_KEY):
             def _run():
                 time.sleep(0.01)

--- a/tests/test_temp_recording_cleanup.py
+++ b/tests/test_temp_recording_cleanup.py
@@ -2,6 +2,7 @@ import os
 import types
 from unittest.mock import MagicMock
 import sys
+import numpy as np
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
@@ -58,6 +59,8 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
             path = tmp_path / "temp_recording_test.wav"
             path.write_text("data")
             self.temp_file_path = str(path)
+            audio = np.zeros(1600, dtype=np.float32)
+            self.on_audio_segment_ready_callback(audio)
 
     class DummyTranscriptionHandler:
         def __init__(self, *a, **k):


### PR DESCRIPTION
## Resumo
- ajusta `DummyAudioHandler` para repassar arrays de áudio em vez de caminhos
- modifica `DummyTranscriptionHandler` para esperar `(audio_data, agent_mode)`
- inclui importação do NumPy nos testes afetados
- confirma que toda a suíte passa com `pytest`

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4c3f82a0833084b9b3bd3fffefff