### PR TITLE
Fix conflict in test_appcore_state

### DIFF
--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -82,11 +82,7 @@ class DummyAudioHandler:
     def stop_recording(self):
         self.is_recording = False
         self.on_recording_state_change_callback(core_module.STATE_TRANSCRIBING)
-<<<<<<< codex/ajustar-testes-para-nova-api
-        audio = np.zeros(1600, dtype=np.float32)
-=======
         audio = np.zeros(160, dtype=np.float32)
->>>>>>> main
         self.on_audio_segment_ready_callback(audio)
 
 class DummyTranscriptionHandler:


### PR DESCRIPTION
## Summary
- clean up merge conflict markers in `tests/test_appcore_state.py`

## Testing
- `pytest -q` *(fails: AttributeError: 'AppCore' object has no attribute '_on_audio_data_ready')*

------
https://chatgpt.com/codex/tasks/task_e_685d51a0861083308f25a384d3298595