### PR TITLE
Fix duplicate key in config

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -22,7 +22,6 @@ DEFAULT_CONFIG = {
     "text_correction_service": "none",
     "openrouter_api_key": "",
     "openrouter_model": "deepseek/deepseek-chat-v3-0324:free",
-    "openrouter_prompt": "",
     "gemini_api_key": "",
     "gemini_model": "gemini-2.5-flash-lite-preview-06-17",
     "gemini_agent_model": "gemini-2.5-flash-lite-preview-06-17",


### PR DESCRIPTION
## Summary
- clean up `DEFAULT_CONFIG` removing the extra `openrouter_prompt` key

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: SyntaxError in tests/test_appcore_state.py)*

------
https://chatgpt.com/codex/tasks/task_e_685d51a1be048330a6c28d645d74497d