### PR TITLE
Remove unused import

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -7,7 +7,6 @@ import soundfile as sf
 from .vad_manager import VADManager # Assumindo que vad_manager.py está na raiz ou em um path acessível
 from .config_manager import SAVE_TEMP_RECORDINGS_CONFIG_KEY
 import os
-import wave
 
 # Constantes de áudio (movidas de whisper_tkinter.py)
 AUDIO_SAMPLE_RATE = 16000

--- a/src/gemini_api.py
+++ b/src/gemini_api.py
@@ -5,7 +5,8 @@ from typing import Optional
 import google.generativeai as genai
 
 
-from .config_manager import ConfigManager, GEMINI_PROMPT_CONFIG_KEY  # Importar ConfigManager e constante
+from .config_manager import ConfigManager
+from .config_manager import GEMINI_PROMPT_CONFIG_KEY
 
 
 class GeminiAPI:
@@ -182,7 +183,9 @@ class GeminiAPI:
         """
         if not text:
             return ""
-        correction_prompt_template = self.config_manager.get(GEMINI_PROMPT_CONFIG_KEY)
+        correction_prompt_template = self.config_manager.get(
+            GEMINI_PROMPT_CONFIG_KEY
+        )
         full_prompt = correction_prompt_template.format(text=text)
         corrected_text = self._execute_request(full_prompt)
         return corrected_text if corrected_text else text


### PR DESCRIPTION
## Summary
- remove `wave` module from `audio_handler`
- split `gemini_api` import line
- wrap long line in `gemini_api`

## Testing
- `flake8 src/gemini_api.py src/openrouter_api.py`
- `pytest -q` *(fails: SyntaxError in tests/test_appcore_state.py)*

------
https://chatgpt.com/codex/tasks/task_e_685d51a2ec788330b54d91ad557ae13a