### PR TITLE
Fix merge conflict markers in tests

### DIFF
--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -82,11 +82,7 @@ class DummyAudioHandler:
     def stop_recording(self):
         self.is_recording = False
         self.on_recording_state_change_callback(core_module.STATE_TRANSCRIBING)
-<<<<<<< codex/instalar-dependências-e-executar-testes
         audio = np.zeros(1600, dtype=np.float32)
-=======
-        audio = np.zeros(160, dtype=np.float32)
->>>>>>> main
         self.on_audio_segment_ready_callback(audio)
 
 class DummyTranscriptionHandler:


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from `tests/test_appcore_state.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685d5da837a8833081212defb9489c7a