### PR TITLE
Corrige imports duplicados em test_audio_handler e conflito de merge

### DIFF
--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -5,7 +5,6 @@ import os
 import sys
 import numpy as np
 from unittest.mock import MagicMock
-import numpy as np
 
 # Stub external dependencies before importing core module
 fake_pyautogui = types.ModuleType("pyautogui")
@@ -82,11 +81,7 @@ class DummyAudioHandler:
     def stop_recording(self):
         self.is_recording = False
         self.on_recording_state_change_callback(core_module.STATE_TRANSCRIBING)
-<<<<<<< codex/instalar-dependências-e-executar-testes
         audio = np.zeros(1600, dtype=np.float32)
-=======
-        audio = np.zeros(160, dtype=np.float32)
->>>>>>> main
         self.on_audio_segment_ready_callback(audio)
 
 class DummyTranscriptionHandler:

--- a/tests/test_audio_handler.py
+++ b/tests/test_audio_handler.py
@@ -6,12 +6,9 @@ from unittest.mock import MagicMock, patch
 import types
 import time
 import numpy as np
-import os, sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
-
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Módulos falsos para dependências nativas ausentes
 fake_sd = types.SimpleNamespace(
@@ -28,7 +25,7 @@ sys.modules['onnxruntime'] = fake_onnx
 sys.modules['torch'] = fake_torch
 
 from src.audio_handler import AudioHandler  # noqa: E402
-from src.config_manager import SAVE_TEMP_RECORDINGS_CONFIG_KEY
+from src.config_manager import SAVE_TEMP_RECORDINGS_CONFIG_KEY  # noqa: E402
 
 
 class DummyConfig:


### PR DESCRIPTION
## Resumo
- remove duplicatas de `import os, sys` e blocos extras de `sys.path.insert` em `tests/test_audio_handler.py`
- resolve conflito de merge em `tests/test_appcore_state.py`
- executa `flake8` e `pytest` para validar

## Testes
- `flake8 tests/test_audio_handler.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d5da9c5188330970b056a39f6986b