### PR TITLE
Fix flake8 warnings in tests

### DIFF
--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -82,11 +82,7 @@ class DummyAudioHandler:
     def stop_recording(self):
         self.is_recording = False
         self.on_recording_state_change_callback(core_module.STATE_TRANSCRIBING)
-<<<<<<< codex/instalar-dependências-e-executar-testes
         audio = np.zeros(1600, dtype=np.float32)
-=======
-        audio = np.zeros(160, dtype=np.float32)
->>>>>>> main
         self.on_audio_segment_ready_callback(audio)
 
 class DummyTranscriptionHandler:

--- a/tests/test_openrouter_api.py
+++ b/tests/test_openrouter_api.py
@@ -5,10 +5,16 @@ import json
 from unittest.mock import patch, MagicMock
 
 # Garantir que o diretório src esteja no path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+)
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")),
+)
 
-from src.openrouter_api import OpenRouterAPI
+from src.openrouter_api import OpenRouterAPI  # noqa: E402
 
 
 def test_correct_text_success():
@@ -20,7 +26,10 @@ def test_correct_text_success():
     }
     mock_response.raise_for_status.return_value = None
 
-    with patch('src.openrouter_api.requests.post', return_value=mock_response) as mock_post:
+    with patch(
+        'src.openrouter_api.requests.post',
+        return_value=mock_response,
+    ) as mock_post:
         result = api.correct_text('texto original')
         assert result == 'texto corrigido'
         mock_post.assert_called_once()
@@ -33,7 +42,9 @@ def test_correct_text_fails_after_retries():
         side_effect=requests.exceptions.RequestException('boom'),
     ) as mock_post:
         with patch('src.openrouter_api.time.sleep', return_value=None):
-            result = api.correct_text('texto original', max_retries=3, retry_delay=0.01)
+            result = api.correct_text(
+                'texto original', max_retries=3, retry_delay=0.01
+            )
 
     assert mock_post.call_count == 3
     assert result == 'texto original'
@@ -57,8 +68,13 @@ def test_correct_text_async_custom_prompt():
     mock_response.raise_for_status.return_value = None
 
     prompt = 'Corrija o texto: {text}'
-    with patch('src.openrouter_api.requests.post', return_value=mock_response) as mock_post:
-        result = api.correct_text_async('texto original', prompt, 'newkey', 'modelo1')
+    with patch(
+        'src.openrouter_api.requests.post',
+        return_value=mock_response,
+    ) as mock_post:
+        result = api.correct_text_async(
+            'texto original', prompt, 'newkey', 'modelo1'
+        )
 
         assert result == 'corrigido'
         mock_post.assert_called_once()

--- a/tests/test_temp_recording_cleanup.py
+++ b/tests/test_temp_recording_cleanup.py
@@ -4,8 +4,14 @@ from unittest.mock import MagicMock
 import sys
 import numpy as np
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+)
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")),
+)
 
 
 def test_temp_recording_cleanup(tmp_path, monkeypatch):
@@ -14,7 +20,10 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
     fake_pyautogui.hotkey = MagicMock()
     fake_pyperclip = types.ModuleType("pyperclip")
     fake_pyperclip.copy = MagicMock()
-    fake_sd = types.SimpleNamespace(PortAudioError=Exception, InputStream=MagicMock())
+    fake_sd = types.SimpleNamespace(
+        PortAudioError=Exception,
+        InputStream=MagicMock(),
+    )
     fake_sf = types.ModuleType("soundfile")
     fake_sf.write = MagicMock()
     fake_onnx = types.ModuleType("onnxruntime")
@@ -44,10 +53,19 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
     from src import core as core_module
 
     class DummyAudioHandler:
-        def __init__(self, config, on_audio_segment_ready_callback, on_recording_state_change_callback):
+        def __init__(
+            self,
+            config,
+            on_audio_segment_ready_callback,
+            on_recording_state_change_callback,
+        ):
             self.config_manager = config
-            self.on_audio_segment_ready_callback = on_audio_segment_ready_callback
-            self.on_recording_state_change_callback = on_recording_state_change_callback
+            self.on_audio_segment_ready_callback = (
+                on_audio_segment_ready_callback
+            )
+            self.on_recording_state_change_callback = (
+                on_recording_state_change_callback
+            )
             self.is_recording = False
             self.temp_file_path = None
 
@@ -99,10 +117,22 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
         def detect_single_key(self):
             return None
 
-    monkeypatch.setattr(core_module, "AudioHandler", DummyAudioHandler)
-    monkeypatch.setattr(core_module, "TranscriptionHandler", DummyTranscriptionHandler)
+    monkeypatch.setattr(
+        core_module,
+        "AudioHandler",
+        DummyAudioHandler,
+    )
+    monkeypatch.setattr(
+        core_module,
+        "TranscriptionHandler",
+        DummyTranscriptionHandler,
+    )
     monkeypatch.setattr(core_module, "GeminiAPI", DummyGeminiAPI)
-    monkeypatch.setattr(core_module, "KeyboardHotkeyManager", DummyHotkeyManager)
+    monkeypatch.setattr(
+        core_module,
+        "KeyboardHotkeyManager",
+        DummyHotkeyManager,
+    )
 
     dummy_root = types.SimpleNamespace(after=lambda *a, **k: None)
     app = core_module.AppCore(dummy_root)

--- a/tests/test_transcription_handler_shutdown.py
+++ b/tests/test_transcription_handler_shutdown.py
@@ -1,10 +1,17 @@
 import importlib.machinery
 import types
 from unittest.mock import MagicMock
-import os, sys
+import os
+import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+)
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")),
+)
 
 # Stub torch and transformers
 fake_torch = types.ModuleType("torch")
@@ -19,8 +26,8 @@ fake_transformers.AutoProcessor = MagicMock()
 fake_transformers.AutoModelForSpeechSeq2Seq = MagicMock()
 sys.modules["transformers"] = fake_transformers
 
-from src.transcription_handler import TranscriptionHandler
-from src.config_manager import (
+from src.transcription_handler import TranscriptionHandler  # noqa: E402
+from src.config_manager import (  # noqa: E402
     BATCH_SIZE_CONFIG_KEY,
     BATCH_SIZE_MODE_CONFIG_KEY,
     MANUAL_BATCH_SIZE_CONFIG_KEY,
@@ -35,6 +42,7 @@ from src.config_manager import (
     DISPLAY_TRANSCRIPTS_KEY,
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
 )
+
 
 class DummyConfig:
     def __init__(self):
@@ -78,7 +86,10 @@ def test_executor_shutdown_parameters():
 
     handler.shutdown()
 
-    dummy_exec.shutdown.assert_called_once_with(wait=False, cancel_futures=True)
+    dummy_exec.shutdown.assert_called_once_with(
+        wait=False,
+        cancel_futures=True,
+    )
     assert handler.transcription_cancel_event.is_set()
 
 
@@ -105,4 +116,3 @@ def test_correction_thread_join_called_when_alive():
     handler.shutdown()
 
     dummy_thread.join.assert_called_once()
-

--- a/tests/test_transcription_handler_state.py
+++ b/tests/test_transcription_handler_state.py
@@ -1,10 +1,17 @@
 import importlib.machinery
 import types
 from types import SimpleNamespace
-import os, sys
+import os
+import sys
 from unittest.mock import MagicMock
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+)
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")),
+)
 
 # Stub simples de torch para evitar importacoes pesadas
 fake_torch = types.ModuleType("torch")
@@ -12,7 +19,6 @@ fake_torch.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
 fake_torch.__version__ = "0.0"
 fake_torch.cuda = SimpleNamespace(is_available=lambda: False)
 
-import sys  # noqa: E402
 sys.modules["torch"] = fake_torch
 
 fake_transformers = types.ModuleType("transformers")
@@ -22,10 +28,8 @@ fake_transformers.AutoModelForSpeechSeq2Seq = MagicMock()
 sys.modules["transformers"] = fake_transformers
 
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-from src.transcription_handler import TranscriptionHandler
-from src.config_manager import (
+from src.transcription_handler import TranscriptionHandler  # noqa: E402
+from src.config_manager import (  # noqa: E402
     BATCH_SIZE_CONFIG_KEY,
     BATCH_SIZE_MODE_CONFIG_KEY,
     MANUAL_BATCH_SIZE_CONFIG_KEY,


### PR DESCRIPTION
## Summary
- adjust imports and sys.path blocks in various tests
- break overly long lines and clean up lambda usage
- resolve leftover conflict in `test_appcore_state`

## Testing
- `flake8 tests/test_openrouter_api.py tests/test_temp_recording_cleanup.py tests/test_transcription_handler_callback.py tests/test_transcription_handler_shutdown.py tests/test_transcription_handler_state.py tests/test_vad_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d5da9fbf483308f580d0d1be7839b