### PR TITLE
Update README lint step

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Contributions are welcome! If you have ideas for improvements, bug fixes, or new
     ```bash
     pip install -r requirements-test.txt
     ```
-8.  Run `flake8 src/gemini_api.py src/openrouter_api.py` to check the lint.
+8.  Optionally, run `flake8 src/gemini_api.py src/openrouter_api.py` to check code style.
 
 ## Running Tests
 

--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -82,11 +82,7 @@ class DummyAudioHandler:
     def stop_recording(self):
         self.is_recording = False
         self.on_recording_state_change_callback(core_module.STATE_TRANSCRIBING)
-<<<<<<< codex/instalar-dependências-e-executar-testes
         audio = np.zeros(1600, dtype=np.float32)
-=======
-        audio = np.zeros(160, dtype=np.float32)
->>>>>>> main
         self.on_audio_segment_ready_callback(audio)
 
 class DummyTranscriptionHandler:


### PR DESCRIPTION
## Summary
- note optional flake8 call in README
- resolve leftover merge markers in `tests/test_appcore_state.py`

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`
- `flake8 src/gemini_api.py src/openrouter_api.py`


------
https://chatgpt.com/codex/tasks/task_e_685d5dc0d19483309c6d078efa0aa93c