### PR TITLE
Implementa validações numéricas no UIManager

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -119,6 +119,22 @@ class UIManager:
             dc.rectangle((width // 4, height // 4, width * 3 // 4, height * 3 // 4), fill=color2)
         return image
 
+    def _safe_get_int(self, var, field_name, parent):
+        """Converte o valor de uma StringVar para int com validação."""
+        try:
+            return int(var.get())
+        except (TypeError, ValueError):
+            messagebox.showerror("Valor inválido", f"Valor inválido para {field_name}.", parent=parent)
+            return None
+
+    def _safe_get_float(self, var, field_name, parent):
+        """Converte o valor de uma StringVar para float com validação."""
+        try:
+            return float(var.get())
+        except (TypeError, ValueError):
+            messagebox.showerror("Valor inválido", f"Valor inválido para {field_name}.", parent=parent)
+            return None
+
     def update_tray_icon(self, state):
         # Logic moved from global, adjusted to use self.tray_icon and self.core_instance_ref
         if self.tray_icon:
@@ -232,9 +248,15 @@ class UIManager:
                     model_to_apply = agent_model_var.get()
                     hotkey_stability_service_enabled_to_apply = hotkey_stability_service_enabled_var.get() # Coleta o valor da nova variável
                     sound_enabled_to_apply = sound_enabled_var.get()
-                    sound_freq_to_apply = int(sound_frequency_var.get())
-                    sound_duration_to_apply = float(sound_duration_var.get())
-                    sound_volume_to_apply = float(sound_volume_var.get())
+                    sound_freq_to_apply = self._safe_get_int(sound_frequency_var, "Frequência do Som", settings_win)
+                    if sound_freq_to_apply is None:
+                        return
+                    sound_duration_to_apply = self._safe_get_float(sound_duration_var, "Duração do Som", settings_win)
+                    if sound_duration_to_apply is None:
+                        return
+                    sound_volume_to_apply = self._safe_get_float(sound_volume_var, "Volume do Som", settings_win)
+                    if sound_volume_to_apply is None:
+                        return
                     text_correction_enabled_to_apply = text_correction_enabled_var.get()
                     text_correction_service_to_apply = text_correction_service_var.get()
                     openrouter_api_key_to_apply = openrouter_api_key_var.get()
@@ -243,11 +265,19 @@ class UIManager:
                     gemini_model_to_apply = gemini_model_var.get()
                     gemini_prompt_correction_to_apply = gemini_prompt_correction_textbox.get("1.0", "end-1c")
                     agentico_prompt_to_apply = agentico_prompt_textbox.get("1.0", "end-1c")
-                    batch_size_to_apply = int(batch_size_var.get())
-                    min_transcription_duration_to_apply = float(min_transcription_duration_var.get()) # Coleta o valor
+                    batch_size_to_apply = self._safe_get_int(batch_size_var, "Batch Size", settings_win)
+                    if batch_size_to_apply is None:
+                        return
+                    min_transcription_duration_to_apply = self._safe_get_float(min_transcription_duration_var, "Duração Mínima", settings_win)
+                    if min_transcription_duration_to_apply is None:
+                        return
                     use_vad_to_apply = use_vad_var.get()
-                    vad_threshold_to_apply = float(vad_threshold_var.get())
-                    vad_silence_duration_to_apply = float(vad_silence_duration_var.get())
+                    vad_threshold_to_apply = self._safe_get_float(vad_threshold_var, "Limiar do VAD", settings_win)
+                    if vad_threshold_to_apply is None:
+                        return
+                    vad_silence_duration_to_apply = self._safe_get_float(vad_silence_duration_var, "Duração do Silêncio", settings_win)
+                    if vad_silence_duration_to_apply is None:
+                        return
                     save_temp_recordings_to_apply = save_temp_recordings_var.get()
                     display_transcripts_to_apply = display_transcripts_var.get()
 
@@ -260,8 +290,8 @@ class UIManager:
                         try:
                             gpu_index_to_apply = int(selected_device_str.split(":")[0].replace("GPU", "").strip())
                         except (ValueError, IndexError):
-                            logging.error(f"Could not parse GPU index from string: '{selected_device_str}'. Using auto-select.")
-                            gpu_index_to_apply = -1
+                            messagebox.showerror("Valor inválido", "Índice de GPU inválido.", parent=settings_win)
+                            return
 
                     models_text = gemini_models_textbox.get("1.0", "end-1c")
                     new_models_list = [line.strip() for line in models_text.split("\n") if line.strip()]

--- a/tests/test_ui_manager_validation.py
+++ b/tests/test_ui_manager_validation.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+# Stub do customtkinter para evitar dependências gráficas
+fake_ctk = types.ModuleType("customtkinter")
+sys.modules.setdefault("customtkinter", fake_ctk)
+sys.modules.setdefault("pystray", types.ModuleType("pystray"))
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("torch", types.ModuleType("torch"))
+
+from src.ui_manager import UIManager
+
+class DummyVar:
+    def __init__(self, value):
+        self._value = value
+    def get(self):
+        return self._value
+
+def _make_manager():
+    return UIManager.__new__(UIManager)
+
+def test_safe_get_int_invalid(monkeypatch):
+    manager = _make_manager()
+    var = DummyVar("abc")
+    mock_error = MagicMock()
+    monkeypatch.setattr('src.ui_manager.messagebox.showerror', mock_error)
+    result = manager._safe_get_int(var, "Teste", None)
+    assert result is None
+    mock_error.assert_called_once()
+
+def test_safe_get_float_invalid(monkeypatch):
+    manager = _make_manager()
+    var = DummyVar("xyz")
+    mock_error = MagicMock()
+    monkeypatch.setattr('src.ui_manager.messagebox.showerror', mock_error)
+    result = manager._safe_get_float(var, "Teste", None)
+    assert result is None
+    mock_error.assert_called_once()
+
+def test_safe_get_int_valid(monkeypatch):
+    manager = _make_manager()
+    var = DummyVar("42")
+    mock_error = MagicMock()
+    monkeypatch.setattr('src.ui_manager.messagebox.showerror', mock_error)
+    assert manager._safe_get_int(var, "Teste", None) == 42
+    mock_error.assert_not_called()
+
+def test_safe_get_float_valid(monkeypatch):
+    manager = _make_manager()
+    var = DummyVar("3.14")
+    mock_error = MagicMock()
+    monkeypatch.setattr('src.ui_manager.messagebox.showerror', mock_error)
+    assert manager._safe_get_float(var, "Teste", None) == 3.14
+    mock_error.assert_not_called()


### PR DESCRIPTION
## Resumo
- adiciona métodos auxiliares para parse seguro de valores numéricos
- usa esses métodos em `apply_settings` para validar entradas
- mostra erro via `messagebox` caso algum valor seja inválido
- cobre novos comportamentos em `tests/test_ui_manager_validation.py`

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d69091f70833080168ab4edee1ddb