### PR TITLE
Improve boolean parsing

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -3,6 +3,20 @@ import json
 import logging
 import copy
 import hashlib
+try:
+    from distutils.util import strtobool
+except Exception:  # Python >= 3.12
+    from setuptools._distutils.util import strtobool
+
+
+def _parse_bool(value):
+    """Converte diferentes representações de booleanos em objetos ``bool``."""
+    if isinstance(value, str):
+        try:
+            return bool(strtobool(value))
+        except ValueError:
+            return bool(value)
+    return bool(value)
 
 # --- Constantes de Configuração (movidas de whisper_tkinter.py) ---
 CONFIG_FILE = "config.json"
@@ -187,16 +201,21 @@ class ConfigManager:
             self.config["record_mode"] = self.default_config['record_mode']
         
         # Unificar auto_paste e agent_auto_paste
-        self.config["auto_paste"] = bool(self.config.get("auto_paste", self.default_config["auto_paste"]))
-        self.config["agent_auto_paste"] = self.config["auto_paste"] # Garante que agent_auto_paste seja sempre igual a auto_paste
+        self.config["auto_paste"] = _parse_bool(
+            self.config.get("auto_paste", self.default_config["auto_paste"])
+        )
+        self.config["agent_auto_paste"] = self.config["auto_paste"]  # Garante que agent_auto_paste seja sempre igual a auto_paste
 
         # Flag para exibir transcrições brutas no log
-        self.config[DISPLAY_TRANSCRIPTS_KEY] = bool(
-            self.config.get(DISPLAY_TRANSCRIPTS_KEY, self.default_config[DISPLAY_TRANSCRIPTS_KEY])
+        self.config[DISPLAY_TRANSCRIPTS_KEY] = _parse_bool(
+            self.config.get(
+                DISPLAY_TRANSCRIPTS_KEY,
+                self.default_config[DISPLAY_TRANSCRIPTS_KEY],
+            )
         )
 
         # Persistência opcional de gravações temporárias
-        self.config[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = bool(
+        self.config[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = _parse_bool(
             self.config.get(
                 SAVE_TEMP_RECORDINGS_CONFIG_KEY,
                 self.default_config[SAVE_TEMP_RECORDINGS_CONFIG_KEY],
@@ -235,8 +254,10 @@ class ConfigManager:
             self.config[MIN_TRANSCRIPTION_DURATION_CONFIG_KEY] = self.default_config[MIN_TRANSCRIPTION_DURATION_CONFIG_KEY]
 
         # Lógica para uso do VAD
-        self.config[USE_VAD_CONFIG_KEY] = bool(self.config.get(USE_VAD_CONFIG_KEY, self.default_config[USE_VAD_CONFIG_KEY]))
-        self.config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY] = bool(
+        self.config[USE_VAD_CONFIG_KEY] = _parse_bool(
+            self.config.get(USE_VAD_CONFIG_KEY, self.default_config[USE_VAD_CONFIG_KEY])
+        )
+        self.config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY] = _parse_bool(
             self.config.get(
                 DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY,
                 self.default_config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY]

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -2,6 +2,8 @@ import os
 import sys
 import time
 import os, sys
+import json
+import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 from src import config_manager
@@ -31,3 +33,31 @@ def test_skip_save_when_unchanged(tmp_path, monkeypatch):
         assert os.path.getmtime(secrets_path) == mtime_sec
     else:
         assert not secrets_path.exists()
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [("true", True), ("false", False), (1, True), (0, False)],
+)
+def test_parse_bool_values(tmp_path, monkeypatch, value, expected):
+    cfg_path = tmp_path / "config.json"
+    secrets_path = tmp_path / "secrets.json"
+
+    config = {
+        "auto_paste": value,
+        "display_transcripts_in_terminal": value,
+        "save_temp_recordings": value,
+        "use_vad": value,
+    }
+
+    cfg_path.write_text(json.dumps(config))
+    monkeypatch.setattr(config_manager, "SECRETS_FILE", str(secrets_path))
+    cm = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+
+    assert cm.get("auto_paste") is expected
+    assert cm.get(config_manager.DISPLAY_TRANSCRIPTS_KEY) is expected
+    assert cm.get(config_manager.SAVE_TEMP_RECORDINGS_CONFIG_KEY) is expected
+    assert cm.get(config_manager.USE_VAD_CONFIG_KEY) is expected


### PR DESCRIPTION
## Summary
- add `_parse_bool` helper for safer boolean parsing
- use this helper in `_validate_and_apply_config`
- cover boolean values like `"true"`, `"false"`, `1` and `0` in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6948885083308e8a20a7630cb040