### PR TITLE
Add timeout handling to Gemini API

### DIFF
--- a/tests/test_appcore_shutdown.py
+++ b/tests/test_appcore_shutdown.py
@@ -25,6 +25,13 @@ def setup_app(monkeypatch):
     fake_keyboard = types.ModuleType("keyboard")
     fake_google = types.ModuleType("google")
     fake_genai = types.ModuleType("generativeai")
+    fake_types = types.ModuleType("types")
+    fake_helper = types.ModuleType("helper_types")
+    fake_helper.RequestOptions = MagicMock()
+    fake_types.helper_types = fake_helper
+    fake_types.BrokenResponseError = type("BrokenResponseError", (Exception,), {})
+    fake_types.IncompleteIterationError = type("IncompleteIterationError", (Exception,), {})
+    fake_genai.types = fake_types
     fake_google.generativeai = fake_genai
 
     monkeypatch.setitem(sys.modules, "pyautogui", fake_pyautogui)
@@ -37,6 +44,12 @@ def setup_app(monkeypatch):
     monkeypatch.setitem(sys.modules, "keyboard", fake_keyboard)
     monkeypatch.setitem(sys.modules, "google", fake_google)
     monkeypatch.setitem(sys.modules, "google.generativeai", fake_genai)
+    monkeypatch.setitem(sys.modules, "google.generativeai.types", fake_types)
+    monkeypatch.setitem(
+        sys.modules,
+        "google.generativeai.types.helper_types",
+        fake_helper,
+    )
 
     from src import core as core_module
 

--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -26,6 +26,13 @@ fake_google = types.ModuleType("google")
 fake_genai = types.ModuleType("generativeai")
 fake_genai.configure = lambda api_key=None: None
 fake_genai.GenerativeModel = MagicMock()
+fake_types = types.ModuleType("types")
+fake_helper = types.ModuleType("helper_types")
+fake_helper.RequestOptions = MagicMock()
+fake_types.helper_types = fake_helper
+fake_types.BrokenResponseError = type("BrokenResponseError", (Exception,), {})
+fake_types.IncompleteIterationError = type("IncompleteIterationError", (Exception,), {})
+fake_genai.types = fake_types
 fake_google.generativeai = fake_genai
 
 sys.modules.setdefault("pyautogui", fake_pyautogui)
@@ -37,6 +44,8 @@ sys.modules.setdefault("transformers", fake_transformers)
 sys.modules.setdefault("keyboard", fake_keyboard)
 sys.modules.setdefault("google", fake_google)
 sys.modules.setdefault("google.generativeai", fake_genai)
+sys.modules.setdefault("google.generativeai.types", fake_types)
+sys.modules.setdefault("google.generativeai.types.helper_types", fake_helper)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
@@ -146,6 +155,13 @@ def setup_app(monkeypatch):
     fake_genai = types.ModuleType("generativeai")
     fake_genai.configure = lambda api_key=None: None
     fake_genai.GenerativeModel = MagicMock()
+    fake_types = types.ModuleType("types")
+    fake_helper = types.ModuleType("helper_types")
+    fake_helper.RequestOptions = MagicMock()
+    fake_types.helper_types = fake_helper
+    fake_types.BrokenResponseError = type("BrokenResponseError", (Exception,), {})
+    fake_types.IncompleteIterationError = type("IncompleteIterationError", (Exception,), {})
+    fake_genai.types = fake_types
     fake_google.generativeai = fake_genai
 
     monkeypatch.setitem(sys.modules, "pyautogui", fake_pyautogui)
@@ -157,6 +173,12 @@ def setup_app(monkeypatch):
     monkeypatch.setitem(sys.modules, "keyboard", fake_keyboard)
     monkeypatch.setitem(sys.modules, "google", fake_google)
     monkeypatch.setitem(sys.modules, "google.generativeai", fake_genai)
+    monkeypatch.setitem(sys.modules, "google.generativeai.types", fake_types)
+    monkeypatch.setitem(
+        sys.modules,
+        "google.generativeai.types.helper_types",
+        fake_helper,
+    )
 
     monkeypatch.setattr(core_module, "AudioHandler", DummyAudioHandler)
     monkeypatch.setattr(core_module, "TranscriptionHandler", DummyTranscriptionHandler)

--- a/tests/test_is_any_operation_running.py
+++ b/tests/test_is_any_operation_running.py
@@ -26,6 +26,13 @@ def setup_fake_modules(monkeypatch):
     fake_keyboard = types.ModuleType("keyboard")
     fake_google = types.ModuleType("google")
     fake_genai = types.ModuleType("generativeai")
+    fake_types = types.ModuleType("types")
+    fake_helper = types.ModuleType("helper_types")
+    fake_helper.RequestOptions = MagicMock()
+    fake_types.helper_types = fake_helper
+    fake_types.BrokenResponseError = type("BrokenResponseError", (Exception,), {})
+    fake_types.IncompleteIterationError = type("IncompleteIterationError", (Exception,), {})
+    fake_genai.types = fake_types
     fake_google.generativeai = fake_genai
 
     monkeypatch.setitem(sys.modules, "pyautogui", fake_pyautogui)
@@ -38,6 +45,12 @@ def setup_fake_modules(monkeypatch):
     monkeypatch.setitem(sys.modules, "keyboard", fake_keyboard)
     monkeypatch.setitem(sys.modules, "google", fake_google)
     monkeypatch.setitem(sys.modules, "google.generativeai", fake_genai)
+    monkeypatch.setitem(sys.modules, "google.generativeai.types", fake_types)
+    monkeypatch.setitem(
+        sys.modules,
+        "google.generativeai.types.helper_types",
+        fake_helper,
+    )
 
 
 class DummyAudioHandler:

--- a/tests/test_temp_recording_cleanup.py
+++ b/tests/test_temp_recording_cleanup.py
@@ -37,6 +37,13 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
     fake_keyboard = types.ModuleType("keyboard")
     fake_google = types.ModuleType("google")
     fake_genai = types.ModuleType("generativeai")
+    fake_types = types.ModuleType("types")
+    fake_helper = types.ModuleType("helper_types")
+    fake_helper.RequestOptions = MagicMock()
+    fake_types.helper_types = fake_helper
+    fake_types.BrokenResponseError = type("BrokenResponseError", (Exception,), {})
+    fake_types.IncompleteIterationError = type("IncompleteIterationError", (Exception,), {})
+    fake_genai.types = fake_types
     fake_google.generativeai = fake_genai
 
     monkeypatch.setitem(sys.modules, "pyautogui", fake_pyautogui)
@@ -49,6 +56,12 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
     monkeypatch.setitem(sys.modules, "keyboard", fake_keyboard)
     monkeypatch.setitem(sys.modules, "google", fake_google)
     monkeypatch.setitem(sys.modules, "google.generativeai", fake_genai)
+    monkeypatch.setitem(sys.modules, "google.generativeai.types", fake_types)
+    monkeypatch.setitem(
+        sys.modules,
+        "google.generativeai.types.helper_types",
+        fake_helper,
+    )
 
     from src import core as core_module
 


### PR DESCRIPTION
## Summary
- enable passing a timeout for Gemini API requests
- forward timeout via `RequestOptions`
- handle Gemini specific exceptions
- add tests covering timeout logic
- update existing tests to stub `google.generativeai.types`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d69ae58b083308632f6ca3c19cb33