### PR TITLE
Corrige métodos em UIManager

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -55,11 +55,6 @@ class UIManager:
         self.live_textbox = None
 
 
-        # Assign methods to the instance
-        self.show_live_transcription_window = self._show_live_transcription_window
-        self.update_live_transcription = self._update_live_transcription
-        self.close_live_transcription_window = self._close_live_transcription_window
-        self.update_live_transcription_threadsafe = self._update_live_transcription_threadsafe
 
         # State mapping to icon colors (moved from global)
         self.ICON_COLORS = {
@@ -103,12 +98,6 @@ class UIManager:
     
     def _update_live_transcription_threadsafe(self, text):
         self.main_tk_root.after(0, lambda: self._update_live_transcription(text))
-
-            # Assign methods to the instance
-            self.show_live_transcription_window = self._show_live_transcription_window
-            self.update_live_transcription = self._update_live_transcription
-            self.close_live_transcription_window = self._close_live_transcription_window
-            self.update_live_transcription_threadsafe = self._update_live_transcription_threadsafe
 
     # Thread-safe method to update live transcription
     def update_live_transcription_threadsafe(self, text):

--- a/tests/test_keyboard_hotkey_manager.py
+++ b/tests/test_keyboard_hotkey_manager.py
@@ -54,9 +54,11 @@ class KeyboardHotkeyManagerFailureTests(unittest.TestCase):
         self.assertFalse(self.manager.is_running)
 
     def test_restart_calls_unhook_and_sleep(self):
-        with patch('src.keyboard_hotkey_manager.keyboard.unhook_all') as mock_unhook_all,
-             patch('src.keyboard_hotkey_manager.time.sleep') as mock_sleep,
-             patch.object(self.manager, "_register_hotkeys", return_value=True):
+        with (
+            patch('src.keyboard_hotkey_manager.keyboard.unhook_all') as mock_unhook_all,
+            patch('src.keyboard_hotkey_manager.time.sleep') as mock_sleep,
+            patch.object(self.manager, "_register_hotkeys", return_value=True),
+        ):
             
             self.manager.restart()
             


### PR DESCRIPTION
## Descrição
- remove atribuições redundantes no `UIManager`
- ajusta sintaxe de teste de hotkeys para Python atual

## Testes
- `pytest -q` *(falha: 5 testes ainda apresentam problemas)*

------
https://chatgpt.com/codex/tasks/task_e_685daaeb868c833081292c58f1109d0e