### PR TITLE
Use async correction in openrouter

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -218,7 +218,13 @@ class TranscriptionHandler:
                     prompt = self.config_manager.get(OPENROUTER_PROMPT_CONFIG_KEY)
 
                 model = self.config_manager.get(OPENROUTER_MODEL_CONFIG_KEY)
-                future = self.executor.submit(self.openrouter_api.correct_text, corrected, prompt, api_key, model)
+                future = self.executor.submit(
+                    self.openrouter_api.correct_text_async,
+                    corrected,
+                    prompt,
+                    api_key,
+                    model,
+                )
                 corrected = future.result()
             else:
                 logging.error(f"Provedor de IA desconhecido: {active_provider}")

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -151,7 +151,7 @@ def test_async_text_correction_service_selection(monkeypatch):
     monkeypatch.setattr(handler.gemini_api, "correct_text_async", MagicMock())
     monkeypatch.setattr(
         handler.openrouter_api,
-        "correct_text",
+        "correct_text_async",
         MagicMock(),
     )
 


### PR DESCRIPTION
## Summary
- utilize `correct_text_async` para correções OpenRouter
- ajuste os testes para monitorar `correct_text_async`

## Testing
- `pytest -q` *(falhou: SyntaxError em test_keyboard_hotkey_manager.py e IndentationError em src/ui_manager.py)*

------
https://chatgpt.com/codex/tasks/task_e_685daaebc2a88330b30baca898266b59