### PR TITLE
Remove unused correction helpers

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -162,20 +162,6 @@ class TranscriptionHandler:
         if self.text_correction_service == SERVICE_GEMINI and self.gemini_client and self.gemini_client.is_valid: return SERVICE_GEMINI
         return SERVICE_NONE
 
-    def _correct_text_with_openrouter(self, text):
-        if not self.openrouter_client or not text: return text
-        try: return self.openrouter_client.correct_text(text)
-        except Exception as e: logging.error(f"Error correcting text with OpenRouter API: {e}"); return text
-
-    def _correct_text_with_gemini(self, text: str) -> str:
-        """Chama o novo método de correção da API Gemini."""
-        if not self.gemini_client or not text or not self.gemini_client.is_valid:
-            return text
-        try:
-            return self.gemini_client.get_correction(text)
-        except Exception as e:
-            logging.error(f"Erro ao chamar get_correction da API Gemini: {e}")
-            return text
 
     def _async_text_correction(self, text: str, is_agent_mode: bool, gemini_prompt: str, openrouter_prompt: str, was_transcribing_when_started: bool):
         if not self.text_correction_enabled:

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -104,12 +104,6 @@ class UIManager:
     def _update_live_transcription_threadsafe(self, text):
         self.main_tk_root.after(0, lambda: self._update_live_transcription(text))
 
-            # Assign methods to the instance
-            self.show_live_transcription_window = self._show_live_transcription_window
-            self.update_live_transcription = self._update_live_transcription
-            self.close_live_transcription_window = self._close_live_transcription_window
-            self.update_live_transcription_threadsafe = self._update_live_transcription_threadsafe
-
     # Thread-safe method to update live transcription
     def update_live_transcription_threadsafe(self, text):
         self.main_tk_root.after(0, lambda: self._update_live_transcription(text))

--- a/tests/test_keyboard_hotkey_manager.py
+++ b/tests/test_keyboard_hotkey_manager.py
@@ -54,9 +54,11 @@ class KeyboardHotkeyManagerFailureTests(unittest.TestCase):
         self.assertFalse(self.manager.is_running)
 
     def test_restart_calls_unhook_and_sleep(self):
-        with patch('src.keyboard_hotkey_manager.keyboard.unhook_all') as mock_unhook_all,
-             patch('src.keyboard_hotkey_manager.time.sleep') as mock_sleep,
-             patch.object(self.manager, "_register_hotkeys", return_value=True):
+        with (
+            patch('src.keyboard_hotkey_manager.keyboard.unhook_all') as mock_unhook_all,
+            patch('src.keyboard_hotkey_manager.time.sleep') as mock_sleep,
+            patch.object(self.manager, "_register_hotkeys", return_value=True)
+        ):
             
             self.manager.restart()
             


### PR DESCRIPTION
## Summary
- remove leftover correction helper methods
- fix syntax in keyboard hotkey manager tests
- clean up UI manager indentation

## Testing
- `pytest -q` *(fails: AudioHandlerTest and others)*

------
https://chatgpt.com/codex/tasks/task_e_685daaf3497883308b8bddccfa86a332