### PR TITLE
Fix asynchronous text correction call

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -218,7 +218,13 @@ class TranscriptionHandler:
                     prompt = self.config_manager.get(OPENROUTER_PROMPT_CONFIG_KEY)
 
                 model = self.config_manager.get(OPENROUTER_MODEL_CONFIG_KEY)
-                future = self.executor.submit(self.openrouter_api.correct_text, corrected, prompt, api_key, model)
+                future = self.executor.submit(
+                    self.openrouter_api.correct_text_async,
+                    corrected,
+                    prompt,
+                    api_key,
+                    model,
+                )
                 corrected = future.result()
             else:
                 logging.error(f"Provedor de IA desconhecido: {active_provider}")


### PR DESCRIPTION
## Summary
- use `correct_text_async` for OpenRouter corrections
- keep future result handling

## Testing
- `pytest -q` *(fails: SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_685dacbfca5883308cb0357e961d7cf3