### PR TITLE
Fix UIManager method reassignment

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -104,12 +104,6 @@ class UIManager:
     def _update_live_transcription_threadsafe(self, text):
         self.main_tk_root.after(0, lambda: self._update_live_transcription(text))
 
-            # Assign methods to the instance
-            self.show_live_transcription_window = self._show_live_transcription_window
-            self.update_live_transcription = self._update_live_transcription
-            self.close_live_transcription_window = self._close_live_transcription_window
-            self.update_live_transcription_threadsafe = self._update_live_transcription_threadsafe
-
     # Thread-safe method to update live transcription
     def update_live_transcription_threadsafe(self, text):
         self.main_tk_root.after(0, lambda: self._update_live_transcription(text))


### PR DESCRIPTION
## Summary
- remove duplicated method reassignments in `_update_live_transcription_threadsafe`
- keep method assignments only in `__init__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685dacc031f083308f9dc3628757d782