### PR TITLE
Fix multiline with in hotkey manager tests

### DIFF
--- a/tests/test_keyboard_hotkey_manager.py
+++ b/tests/test_keyboard_hotkey_manager.py
@@ -54,14 +54,16 @@ class KeyboardHotkeyManagerFailureTests(unittest.TestCase):
         self.assertFalse(self.manager.is_running)
 
     def test_restart_calls_unhook_and_sleep(self):
-        with patch('src.keyboard_hotkey_manager.keyboard.unhook_all') as mock_unhook_all,
-             patch('src.keyboard_hotkey_manager.time.sleep') as mock_sleep,
-             patch.object(self.manager, "_register_hotkeys", return_value=True):
-            
+        with (
+            patch('src.keyboard_hotkey_manager.keyboard.unhook_all') as mock_unhook_all,
+            patch('src.keyboard_hotkey_manager.time.sleep') as mock_sleep,
+            patch.object(self.manager, "_register_hotkeys", return_value=True),
+        ):
+
             self.manager.restart()
-            
+
             mock_unhook_all.assert_called()
-            self.assertEqual(mock_sleep.call_count, 2) # Two sleep calls in restart
+            self.assertEqual(mock_sleep.call_count, 2)  # Two sleep calls in restart
 
     def test_start_success(self):
         patcher = patch.object(self.manager, "_register_hotkeys", return_value=True)


### PR DESCRIPTION
## Summary
- fix multiline with statement in `tests/test_keyboard_hotkey_manager.py`

## Testing
- `python -m py_compile tests/test_keyboard_hotkey_manager.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685dacc32b7c8330bd9b2f0a8d726906