### PR TITLE
Refatora atributo Gemini

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -599,8 +599,8 @@ class AppCore:
                 api_key=self.config_manager.get("gemini_api_key"),
                 model_id=self.config_manager.get("gemini_model")
             ) # Re-inicializar cliente principal
-            if self.transcription_handler.gemini_client:
-                self.transcription_handler.gemini_client.reinitialize_client(
+            if self.transcription_handler.gemini_api:
+                self.transcription_handler.gemini_api.reinitialize_client(
                     api_key=self.config_manager.get("gemini_api_key"),
                     model_id=self.config_manager.get("gemini_model")
                 ) # Re-inicializar cliente Gemini do TranscriptionHandler
@@ -674,8 +674,8 @@ class AppCore:
                 api_key=self.config_manager.get("gemini_api_key"),
                 model_id=self.config_manager.get("gemini_model")
             )
-            if self.transcription_handler.gemini_client:
-                self.transcription_handler.gemini_client.reinitialize_client(
+            if self.transcription_handler.gemini_api:
+                self.transcription_handler.gemini_api.reinitialize_client(
                     api_key=self.config_manager.get("gemini_api_key"),
                     model_id=self.config_manager.get("gemini_model")
                 )

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -38,7 +38,7 @@ class TranscriptionHandler:
         is_state_transcribing_fn,
     ):
         self.config_manager = config_manager
-        self.gemini_client = gemini_api_client # Instância da API Gemini injetada
+        # Cliente Gemini injetado
         self.gemini_api = gemini_api_client
         self.on_model_ready_callback = on_model_ready_callback
         self.on_model_error_callback = on_model_error_callback
@@ -89,7 +89,7 @@ class TranscriptionHandler:
         )
 
         self.openrouter_client = None
-        # self.gemini_client é injetado
+        # self.gemini_api é injetado
         self.device_in_use = None # Nova variável para armazenar o dispositivo em uso
 
         self._init_api_clients()
@@ -170,8 +170,13 @@ class TranscriptionHandler:
     def _get_text_correction_service(self):
         if not self.text_correction_enabled: return SERVICE_NONE
         if self.text_correction_service == SERVICE_OPENROUTER and self.openrouter_client: return SERVICE_OPENROUTER
-        # Verifica se o cliente Gemini existe E se a chave é válida
-        if self.text_correction_service == SERVICE_GEMINI and self.gemini_client and self.gemini_client.is_valid: return SERVICE_GEMINI
+        # Verifica se o cliente Gemini existe e se a chave é válida
+        if (
+            self.text_correction_service == SERVICE_GEMINI
+            and self.gemini_api
+            and self.gemini_api.is_valid
+        ):
+            return SERVICE_GEMINI
         return SERVICE_NONE
 
     def _async_text_correction(self, text: str, is_agent_mode: bool, gemini_prompt: str, openrouter_prompt: str, was_transcribing_when_started: bool):
@@ -434,7 +439,7 @@ class TranscriptionHandler:
             if agent_mode:
                 try:
                     logging.info(f"Enviando texto para o modo agente: '{text_result}'")
-                    agent_response = self.gemini_client.get_agent_response(text_result)
+                    agent_response = self.gemini_api.get_agent_response(text_result)
                     logging.info(
                         f"Resposta recebida do modo agente: '{agent_response}'"
                     )

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -146,9 +146,7 @@ def test_async_text_correction_service_selection(monkeypatch):
 
     handler.openrouter_client = MagicMock()
     handler.openrouter_api = handler.openrouter_client
-    handler.gemini_client = MagicMock(is_valid=True)
-    handler.gemini_api = handler.gemini_client
-    handler.gemini_api = handler.gemini_client
+    handler.gemini_api = MagicMock(is_valid=True)
 
     monkeypatch.setattr(handler.gemini_api, "correct_text_async", MagicMock())
     monkeypatch.setattr(
@@ -227,8 +225,7 @@ def test_text_correction_preserves_result_when_state_changes(monkeypatch):
         on_segment_transcribed_callback=None,
         is_state_transcribing_fn=lambda: True,
     )
-    handler.gemini_client = MagicMock(is_valid=True)
-    handler.gemini_api = handler.gemini_client
+    handler.gemini_api = MagicMock(is_valid=True)
 
     def delayed_correct(text):
         time.sleep(0.05)
@@ -315,8 +312,7 @@ def test_text_correction_timeout(monkeypatch):
         on_segment_transcribed_callback=None,
         is_state_transcribing_fn=lambda: True,
     )
-    handler.gemini_client = MagicMock(is_valid=True)
-    handler.gemini_api = handler.gemini_client
+    handler.gemini_api = MagicMock(is_valid=True)
 
     def slow_correction(*_a, **_k):
         time.sleep(0.05)


### PR DESCRIPTION
## Resumo
- mantém apenas `gemini_api` em `TranscriptionHandler`
- ajusta referências em `core.py`
- atualiza testes que citavam `gemini_client`

## Testes
- `pytest -q` *(falha: AudioHandlerTest.test_start_and_stop_recording_success, test_config_validation_and_fallback, test_async_text_correction_service_selection)*

------
https://chatgpt.com/codex/tasks/task_e_685db46621348330811fc9709804b6e8