### PR TITLE
Remover duplicação de timeout

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -81,11 +81,11 @@ class TranscriptionHandler:
         self.gemini_api_key = self.config_manager.get(GEMINI_API_KEY_CONFIG_KEY)
         self.gemini_agent_model = self.config_manager.get('gemini_agent_model')
         self.gemini_prompt = self.config_manager.get(GEMINI_PROMPT_CONFIG_KEY)
-        self.text_correction_timeout = self.config_manager.get(TEXT_CORRECTION_TIMEOUT_CONFIG_KEY, 30)
-        self.min_transcription_duration = self.config_manager.get(MIN_TRANSCRIPTION_DURATION_CONFIG_KEY)
         self.text_correction_timeout = self.config_manager.get(
-            TEXT_CORRECTION_TIMEOUT_CONFIG_KEY,
-            30,
+            TEXT_CORRECTION_TIMEOUT_CONFIG_KEY, 30
+        )
+        self.min_transcription_duration = self.config_manager.get(
+            MIN_TRANSCRIPTION_DURATION_CONFIG_KEY
         )
 
         self.openrouter_client = None
@@ -125,11 +125,11 @@ class TranscriptionHandler:
         self.gemini_api_key = self.config_manager.get(GEMINI_API_KEY_CONFIG_KEY)
         self.gemini_agent_model = self.config_manager.get('gemini_agent_model')
         self.gemini_prompt = self.config_manager.get(GEMINI_PROMPT_CONFIG_KEY)
-        self.text_correction_timeout = self.config_manager.get(TEXT_CORRECTION_TIMEOUT_CONFIG_KEY, 30)
-        self.min_transcription_duration = self.config_manager.get(MIN_TRANSCRIPTION_DURATION_CONFIG_KEY)
         self.text_correction_timeout = self.config_manager.get(
-            TEXT_CORRECTION_TIMEOUT_CONFIG_KEY,
-            30,
+            TEXT_CORRECTION_TIMEOUT_CONFIG_KEY, 30
+        )
+        self.min_transcription_duration = self.config_manager.get(
+            MIN_TRANSCRIPTION_DURATION_CONFIG_KEY
         )
         logging.info("TranscriptionHandler: Configurações atualizadas.")
 


### PR DESCRIPTION
## Summary
- remove duplicate text_correction_timeout assignments in `TranscriptionHandler`

## Testing
- `pytest -q`
- `pytest -k text_correction_timeout -q`

------
https://chatgpt.com/codex/tasks/task_e_685db466dba08330a381057d56a65cb5