### PR TITLE
Add flash attention setting

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -66,6 +66,7 @@ Transcribed speech: {text}""",
     # Duração máxima da pausa preservada antes que o silêncio seja descartado
     "vad_silence_duration": 1.0,
     "display_transcripts_in_terminal": False,
+    "use_flash_attention_2": False,
     "gemini_model_options": [
         "gemini-2.5-flash-lite-preview-06-17",
         "gemini-2.5-flash",
@@ -94,6 +95,7 @@ DISPLAY_TRANSCRIPTS_KEY = "display_transcripts_in_terminal"
 USE_VAD_CONFIG_KEY = "use_vad"
 VAD_THRESHOLD_CONFIG_KEY = "vad_threshold"
 VAD_SILENCE_DURATION_CONFIG_KEY = "vad_silence_duration"
+USE_FLASH_ATTENTION_2_CONFIG_KEY = "use_flash_attention_2"
 DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY = DISPLAY_TRANSCRIPTS_KEY
 KEYBOARD_LIBRARY_CONFIG_KEY = "keyboard_library"
 KEYBOARD_LIB_WIN32 = "win32"
@@ -425,6 +427,13 @@ class ConfigManager:
             ),
             default=self.default_config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY],
         )
+        self.config[USE_FLASH_ATTENTION_2_CONFIG_KEY] = _parse_bool(
+            self.config.get(
+                USE_FLASH_ATTENTION_2_CONFIG_KEY,
+                self.default_config[USE_FLASH_ATTENTION_2_CONFIG_KEY],
+            ),
+            default=self.default_config[USE_FLASH_ATTENTION_2_CONFIG_KEY],
+        )
         try:
             raw_threshold = self.config.get(VAD_THRESHOLD_CONFIG_KEY, self.default_config[VAD_THRESHOLD_CONFIG_KEY])
             self.config[VAD_THRESHOLD_CONFIG_KEY] = float(raw_threshold)
@@ -578,3 +587,12 @@ class ConfigManager:
 
     def set_save_temp_recordings(self, value: bool):
         self.config[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = bool(value)
+
+    def get_use_flash_attention_2(self):
+        return self.config.get(
+            USE_FLASH_ATTENTION_2_CONFIG_KEY,
+            self.default_config[USE_FLASH_ATTENTION_2_CONFIG_KEY],
+        )
+
+    def set_use_flash_attention_2(self, value: bool):
+        self.config[USE_FLASH_ATTENTION_2_CONFIG_KEY] = bool(value)

--- a/src/core.py
+++ b/src/core.py
@@ -561,6 +561,7 @@ class AppCore:
                 "new_save_temp_recordings": SAVE_TEMP_RECORDINGS_CONFIG_KEY,
                 "new_gemini_model_options": "gemini_model_options",
                 "new_use_vad": "use_vad",
+                "new_use_flash_attention_2": "use_flash_attention_2",
                 "new_vad_threshold": "vad_threshold",
                 "new_vad_silence_duration": "vad_silence_duration",
                 "new_display_transcripts_in_terminal": "display_transcripts_in_terminal"

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -23,6 +23,7 @@ from .config_manager import (
     DISPLAY_TRANSCRIPTS_KEY,  # Nova constante
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
     TEXT_CORRECTION_TIMEOUT_CONFIG_KEY,
+    USE_FLASH_ATTENTION_2_CONFIG_KEY,
 )
 
 class TranscriptionHandler:
@@ -87,6 +88,9 @@ class TranscriptionHandler:
         self.min_transcription_duration = self.config_manager.get(
             MIN_TRANSCRIPTION_DURATION_CONFIG_KEY
         )
+        self.use_flash_attention_2 = self.config_manager.get(
+            USE_FLASH_ATTENTION_2_CONFIG_KEY, False
+        )
 
         self.openrouter_client = None
         # self.gemini_api é injetado
@@ -130,6 +134,9 @@ class TranscriptionHandler:
         )
         self.min_transcription_duration = self.config_manager.get(
             MIN_TRANSCRIPTION_DURATION_CONFIG_KEY
+        )
+        self.use_flash_attention_2 = self.config_manager.get(
+            USE_FLASH_ATTENTION_2_CONFIG_KEY, False
         )
         logging.info("TranscriptionHandler: Configurações atualizadas.")
 
@@ -330,13 +337,14 @@ class TranscriptionHandler:
                 logging.info("Nenhuma GPU detectada ou selecionada, usando torch.float32 (CPU).")
 
             logging.info(f"Carregando modelo {model_id}...")
-            
+
             model = AutoModelForSpeechSeq2Seq.from_pretrained(
                 model_id,
                 torch_dtype=torch_dtype_local,
-                low_cpu_mem_usage=True, # Ajuda a reduzir o uso de RAM durante o carregamento
+                low_cpu_mem_usage=True,  # Ajuda a reduzir o uso de RAM durante o carregamento
                 use_safetensors=True,
-                device_map={'': device} # Especifica que todo o modelo vai para o dispositivo alvo
+                device_map={"": device},  # Especifica que todo o modelo vai para o dispositivo alvo
+                attn_implementation="flash_attention_2" if self.use_flash_attention_2 else None,
             )
             
             # Retorna o modelo e o processador para que a pipeline seja criada fora desta função


### PR DESCRIPTION
## Summary
- add `use_flash_attention_2` option in config
- expose getters and setters in ConfigManager
- propagate new setting through core and transcription handler
- enable Flash Attention 2 in model loading when configured

## Testing
- `pip install -q -r requirements-test.txt`
- `pip install -q setuptools`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db90094ac83309fdff1ee85e73f8e