### PR TITLE
Adicionar suporte opcional ao Flash Attention 2

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -42,6 +42,7 @@ DEFAULT_CONFIG = {
     "gemini_api_key": "",
     "gemini_model": "gemini-2.5-flash-lite-preview-06-17",
     "gemini_agent_model": "gemini-2.5-flash-lite-preview-06-17",
+    "use_flash_attention_2": False,
     "ai_provider": "gemini",
     "openrouter_agent_prompt": "",
     "openrouter_prompt": "",
@@ -109,6 +110,7 @@ GEMINI_API_KEY_CONFIG_KEY = "gemini_api_key"
 GEMINI_MODEL_CONFIG_KEY = "gemini_model"
 GEMINI_AGENT_MODEL_CONFIG_KEY = "gemini_agent_model"
 GEMINI_MODEL_OPTIONS_CONFIG_KEY = "gemini_model_options"
+USE_FLASH_ATTENTION_2_CONFIG_KEY = "use_flash_attention_2"
 AI_PROVIDER_CONFIG_KEY = TEXT_CORRECTION_SERVICE_CONFIG_KEY
 GEMINI_AGENT_PROMPT_CONFIG_KEY = "prompt_agentico"
 OPENROUTER_PROMPT_CONFIG_KEY = "openrouter_agent_prompt"
@@ -418,6 +420,13 @@ class ConfigManager:
             self.config.get(USE_VAD_CONFIG_KEY, self.default_config[USE_VAD_CONFIG_KEY]),
             default=self.default_config[USE_VAD_CONFIG_KEY],
         )
+        self.config[USE_FLASH_ATTENTION_2_CONFIG_KEY] = _parse_bool(
+            self.config.get(
+                USE_FLASH_ATTENTION_2_CONFIG_KEY,
+                self.default_config[USE_FLASH_ATTENTION_2_CONFIG_KEY],
+            ),
+            default=self.default_config[USE_FLASH_ATTENTION_2_CONFIG_KEY],
+        )
         self.config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY] = _parse_bool(
             self.config.get(
                 DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY,
@@ -578,3 +587,12 @@ class ConfigManager:
 
     def set_save_temp_recordings(self, value: bool):
         self.config[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = bool(value)
+
+    def get_use_flash_attention_2(self):
+        return self.config.get(
+            USE_FLASH_ATTENTION_2_CONFIG_KEY,
+            self.default_config[USE_FLASH_ATTENTION_2_CONFIG_KEY],
+        )
+
+    def set_use_flash_attention_2(self, value: bool):
+        self.config[USE_FLASH_ATTENTION_2_CONFIG_KEY] = bool(value)

--- a/src/core.py
+++ b/src/core.py
@@ -561,6 +561,7 @@ class AppCore:
                 "new_save_temp_recordings": SAVE_TEMP_RECORDINGS_CONFIG_KEY,
                 "new_gemini_model_options": "gemini_model_options",
                 "new_use_vad": "use_vad",
+                "new_use_flash_attention_2": "use_flash_attention_2",
                 "new_vad_threshold": "vad_threshold",
                 "new_vad_silence_duration": "vad_silence_duration",
                 "new_display_transcripts_in_terminal": "display_transcripts_in_terminal"
@@ -591,7 +592,15 @@ class AppCore:
             self._apply_initial_config_to_core_attributes() # Re-aplicar configs ao AppCore
             self.audio_handler.config_manager = self.config_manager # Atualizar referência
             self.transcription_handler.config_manager = self.config_manager # Atualizar referência
-            if any(key in kwargs for key in ["new_use_vad", "new_vad_threshold", "new_vad_silence_duration"]):
+            if any(
+                key in kwargs
+                for key in [
+                    "new_use_vad",
+                    "new_use_flash_attention_2",
+                    "new_vad_threshold",
+                    "new_vad_silence_duration",
+                ]
+            ):
                 self.audio_handler.update_config()
             self.transcription_handler.update_config() # Chamar para recarregar configs específicas do handler
             # Re-inicializar clientes API existentes em vez de recriá-los
@@ -663,7 +672,13 @@ class AppCore:
         self._apply_initial_config_to_core_attributes()
 
         # Propagar para TranscriptionHandler se for uma configuração relevante
-        if key in ["batch_size_mode", "manual_batch_size", "gpu_index", "min_transcription_duration"]:
+        if key in [
+            "batch_size_mode",
+            "manual_batch_size",
+            "gpu_index",
+            "min_transcription_duration",
+            "use_flash_attention_2",
+        ]:
             self.transcription_handler.config_manager = self.config_manager # Garantir que a referência esteja atualizada
             self.transcription_handler.update_config()
             logging.info(f"TranscriptionHandler: Configurações de transcrição atualizadas via update_setting para '{key}'.")

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -23,6 +23,7 @@ from .config_manager import (
     DISPLAY_TRANSCRIPTS_KEY,  # Nova constante
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
     TEXT_CORRECTION_TIMEOUT_CONFIG_KEY,
+    USE_FLASH_ATTENTION_2_CONFIG_KEY,
 )
 
 class TranscriptionHandler:
@@ -87,6 +88,9 @@ class TranscriptionHandler:
         self.min_transcription_duration = self.config_manager.get(
             MIN_TRANSCRIPTION_DURATION_CONFIG_KEY
         )
+        self.use_flash_attention_2 = self.config_manager.get(
+            USE_FLASH_ATTENTION_2_CONFIG_KEY
+        )
 
         self.openrouter_client = None
         # self.gemini_api é injetado
@@ -130,6 +134,9 @@ class TranscriptionHandler:
         )
         self.min_transcription_duration = self.config_manager.get(
             MIN_TRANSCRIPTION_DURATION_CONFIG_KEY
+        )
+        self.use_flash_attention_2 = self.config_manager.get(
+            USE_FLASH_ATTENTION_2_CONFIG_KEY
         )
         logging.info("TranscriptionHandler: Configurações atualizadas.")
 
@@ -330,13 +337,14 @@ class TranscriptionHandler:
                 logging.info("Nenhuma GPU detectada ou selecionada, usando torch.float32 (CPU).")
 
             logging.info(f"Carregando modelo {model_id}...")
-            
+
             model = AutoModelForSpeechSeq2Seq.from_pretrained(
                 model_id,
                 torch_dtype=torch_dtype_local,
                 low_cpu_mem_usage=True, # Ajuda a reduzir o uso de RAM durante o carregamento
                 use_safetensors=True,
-                device_map={'': device} # Especifica que todo o modelo vai para o dispositivo alvo
+                device_map={'': device}, # Especifica que todo o modelo vai para o dispositivo alvo
+                attn_implementation="flash_attention_2" if self.use_flash_attention_2 else None,
             )
             
             # Retorna o modelo e o processador para que a pipeline seja criada fora desta função


### PR DESCRIPTION
## Resumo
- inclusão da chave `use_flash_attention_2` na configuração padrão
- criação da constante `USE_FLASH_ATTENTION_2_CONFIG_KEY`
- novos métodos de acesso para a flag de Flash Attention 2
- recarga da flag nas funções `update_config`
- ajuste do carregamento do modelo para usar Flash Attention 2 quando ativado
- propagação da nova configuração na camada Core

## Testes
- `pytest -q` *(falhou: distutils, numpy e outros pacotes ausentes)*

------
https://chatgpt.com/codex/tasks/task_e_685db917ece48330be03e987bc998d10