### PR TITLE
Add Turbo mode support and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A lightweight, high-performance desktop tool for Windows that turns your speech 
 
 *   **High-Quality Transcription:** Powered by the `openai/whisper-large-v3` model for state-of-the-art speech recognition.
 *   **GPU Acceleration:** Automatically utilizes your NVIDIA GPU (if available) for significantly faster transcriptions, with fallback to CPU.
+*   **Turbo Mode:** When enabled, loads `openai/whisper-large-v3-turbo` for even faster processing. Requires an NVIDIA Ampere or newer GPU.
 *   **Dynamic Performance:** Intelligently adjusts batch sizes based on available VRAM for optimal performance.
 *   **Customizable Hotkeys:**
     *   Activate recording with a global hotkey that works anywhere in Windows.
@@ -234,6 +235,7 @@ To access and change settings:
 *   **Agent Mode Prompt:** Customize the prompt sent to Gemini when using "Agent Mode".
 *   **Gemini Models (one per line):** Manage the list of available Gemini models in the dropdown.
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
+*   **Turbo Mode:** Use the optimized Turbo model when you have an Ampere or newer NVIDIA GPU.
 *   **Batch Size:** Configure the batch size for transcription.
 *   **Save Temporary Recordings:** When enabled, the captured audio is stored as `temp_recording_<timestamp>.wav` in the application folder. This temporary file is automatically deleted once transcription completes.
 *   **Display Transcript in Terminal:** Show the final text in the terminal window after each recording.

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -60,6 +60,7 @@ Transcribed speech: {text}""",
     "batch_size_mode": "auto", # Novo: 'auto' ou 'manual'
     "manual_batch_size": 8, # Novo: Valor para o modo manual
     "gpu_index": 0,
+    "use_turbo": False,
     "hotkey_stability_service_enabled": True, # Nova configuração unificada
     "use_vad": False,
     "vad_threshold": 0.5,
@@ -89,6 +90,7 @@ BATCH_SIZE_CONFIG_KEY = "batch_size" # Agora é o batch size padrão para o modo
 BATCH_SIZE_MODE_CONFIG_KEY = "batch_size_mode" # Novo
 MANUAL_BATCH_SIZE_CONFIG_KEY = "manual_batch_size" # Novo
 GPU_INDEX_CONFIG_KEY = "gpu_index"
+USE_TURBO_CONFIG_KEY = "use_turbo"
 SAVE_TEMP_RECORDINGS_CONFIG_KEY = "save_temp_recordings"
 DISPLAY_TRANSCRIPTS_KEY = "display_transcripts_in_terminal"
 USE_VAD_CONFIG_KEY = "use_vad"
@@ -380,6 +382,13 @@ class ConfigManager:
             self.config[GPU_INDEX_CONFIG_KEY] = -1
             self.config["gpu_index_specified"] = False # Se falhou a leitura, não foi especificado corretamente
 
+        # Lógica para uso do modelo Turbo
+        turbo_val = _parse_bool(
+            self.config.get(USE_TURBO_CONFIG_KEY, self.default_config[USE_TURBO_CONFIG_KEY]),
+            default=self.default_config[USE_TURBO_CONFIG_KEY],
+        )
+        self.config[USE_TURBO_CONFIG_KEY] = turbo_val
+
         # Lógica de validação para min_transcription_duration
         try:
             raw_min_duration_val = loaded_config.get(MIN_TRANSCRIPTION_DURATION_CONFIG_KEY, self.default_config[MIN_TRANSCRIPTION_DURATION_CONFIG_KEY])
@@ -578,3 +587,9 @@ class ConfigManager:
 
     def set_save_temp_recordings(self, value: bool):
         self.config[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = bool(value)
+
+    def get_use_turbo(self):
+        return self.config.get(USE_TURBO_CONFIG_KEY, self.default_config[USE_TURBO_CONFIG_KEY])
+
+    def set_use_turbo(self, value: bool):
+        self.config[USE_TURBO_CONFIG_KEY] = bool(value)

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -20,6 +20,7 @@ from .config_manager import (
     GEMINI_PROMPT_CONFIG_KEY,
     OPENROUTER_PROMPT_CONFIG_KEY,
     MIN_TRANSCRIPTION_DURATION_CONFIG_KEY,
+    USE_TURBO_CONFIG_KEY,
     DISPLAY_TRANSCRIPTS_KEY,  # Nova constante
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
     TEXT_CORRECTION_TIMEOUT_CONFIG_KEY,
@@ -71,6 +72,7 @@ class TranscriptionHandler:
         self.batch_size_mode = self.config_manager.get(BATCH_SIZE_MODE_CONFIG_KEY) # Novo
         self.manual_batch_size = self.config_manager.get(MANUAL_BATCH_SIZE_CONFIG_KEY) # Novo
         self.gpu_index = self.config_manager.get(GPU_INDEX_CONFIG_KEY)
+        self.use_turbo = self.config_manager.get(USE_TURBO_CONFIG_KEY)
         self.batch_size_specified = self.config_manager.get("batch_size_specified") # Ainda usado para validação
         self.gpu_index_specified = self.config_manager.get("gpu_index_specified") # Ainda usado para validação
 
@@ -118,6 +120,7 @@ class TranscriptionHandler:
         self.batch_size_mode = self.config_manager.get(BATCH_SIZE_MODE_CONFIG_KEY)
         self.manual_batch_size = self.config_manager.get(MANUAL_BATCH_SIZE_CONFIG_KEY)
         self.gpu_index = self.config_manager.get(GPU_INDEX_CONFIG_KEY)
+        self.use_turbo = self.config_manager.get(USE_TURBO_CONFIG_KEY)
         self.text_correction_enabled = self.config_manager.get(TEXT_CORRECTION_ENABLED_CONFIG_KEY)
         self.text_correction_service = self.config_manager.get(TEXT_CORRECTION_SERVICE_CONFIG_KEY)
         self.openrouter_api_key = self.config_manager.get(OPENROUTER_API_KEY_CONFIG_KEY)
@@ -313,7 +316,10 @@ class TranscriptionHandler:
                         logging.info("Nenhuma GPU disponível, usando CPU.")
                         self.gpu_index = -1 # Garante que o índice seja -1 se não houver GPU
                 
-            model_id = "openai/whisper-large-v3"
+            if self.use_turbo:
+                model_id = "openai/whisper-large-v3-turbo"
+            else:
+                model_id = "openai/whisper-large-v3"
             
             logging.info(f"Carregando processador de {model_id}...")
             processor = AutoProcessor.from_pretrained(model_id)

--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -72,6 +72,7 @@ class DummyConfig:
             "min_transcription_duration": 0.0,
             TEXT_CORRECTION_ENABLED_CONFIG_KEY: True,
             TEXT_CORRECTION_SERVICE_CONFIG_KEY: SERVICE_NONE,
+            "use_turbo": False,
         }
 
     def get(self, key, default=None):

--- a/tests/test_audio_handler.py
+++ b/tests/test_audio_handler.py
@@ -39,6 +39,7 @@ class DummyConfig:
             'sound_volume': 0.5,
             'min_record_duration': 0,
             'use_vad': False,
+            'use_turbo': False,
             'vad_threshold': 0.5,
             'vad_silence_duration': 0.5,
             SAVE_TEMP_RECORDINGS_CONFIG_KEY: False,

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -65,6 +65,25 @@ def test_parse_bool_values(tmp_path, monkeypatch, value, expected):
     assert cm.get(config_manager.USE_VAD_CONFIG_KEY) is expected
 
 
+def test_use_turbo_default_and_override(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    secrets_path = tmp_path / "secrets.json"
+    monkeypatch.setattr(config_manager, "SECRETS_FILE", str(secrets_path))
+
+    cm_default = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+    assert cm_default.get(config_manager.USE_TURBO_CONFIG_KEY) is False
+
+    cfg_path.write_text(json.dumps({"use_turbo": True}))
+    cm_override = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+    assert cm_override.get(config_manager.USE_TURBO_CONFIG_KEY) is True
+
+
 def test_config_validation_and_fallback(tmp_path, monkeypatch):
     cfg_path = tmp_path / "config.json"
     secrets_path = tmp_path / "secrets.json"

--- a/tests/test_gemini_api.py
+++ b/tests/test_gemini_api.py
@@ -16,6 +16,7 @@ class DummyConfig:
             'gemini_agent_model': 'agent-model',
             'gemini_prompt': '{text}',
             'prompt_agentico': 'agent prompt',
+            'use_turbo': False,
         }
 
     def get(self, key, default=None):

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -56,6 +56,7 @@ class DummyConfig:
             "gpu_index_specified": False,
             TEXT_CORRECTION_ENABLED_CONFIG_KEY: False,
             TEXT_CORRECTION_SERVICE_CONFIG_KEY: SERVICE_NONE,
+            "use_turbo": False,
             OPENROUTER_API_KEY_CONFIG_KEY: "dummy",
             OPENROUTER_MODEL_CONFIG_KEY: "",
             GEMINI_API_KEY_CONFIG_KEY: "dummy",

--- a/tests/test_transcription_handler_shutdown.py
+++ b/tests/test_transcription_handler_shutdown.py
@@ -56,6 +56,7 @@ class DummyConfig:
             "gpu_index_specified": False,
             TEXT_CORRECTION_ENABLED_CONFIG_KEY: False,
             TEXT_CORRECTION_SERVICE_CONFIG_KEY: SERVICE_NONE,
+            "use_turbo": False,
             OPENROUTER_API_KEY_CONFIG_KEY: "",
             OPENROUTER_MODEL_CONFIG_KEY: "",
             GEMINI_API_KEY_CONFIG_KEY: "",

--- a/tests/test_transcription_handler_state.py
+++ b/tests/test_transcription_handler_state.py
@@ -58,6 +58,7 @@ class DummyConfig:
             "gpu_index_specified": False,
             TEXT_CORRECTION_ENABLED_CONFIG_KEY: False,
             TEXT_CORRECTION_SERVICE_CONFIG_KEY: SERVICE_NONE,
+            "use_turbo": False,
             OPENROUTER_API_KEY_CONFIG_KEY: "",
             OPENROUTER_MODEL_CONFIG_KEY: "",
             GEMINI_API_KEY_CONFIG_KEY: "",


### PR DESCRIPTION
## Summary
- implement `use_turbo` option in `ConfigManager`
- load Whisper Turbo model when enabled
- adjust dummies in tests for new option
- add test for Turbo default and override
- document Turbo mode in README

## Testing
- `pip install -q -r requirements-test.txt`
- `pip install -q setuptools`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db91b2690833083411733b1682422