### PR TITLE
Fix flash attention config validation

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -68,7 +68,6 @@ Transcribed speech: {text}""",
     # Duração máxima da pausa preservada antes que o silêncio seja descartado
     "vad_silence_duration": 1.0,
     "display_transcripts_in_terminal": False,
-    "use_flash_attention_2": False,
     "gemini_model_options": [
         "gemini-2.5-flash-lite-preview-06-17",
         "gemini-2.5-flash",
@@ -77,7 +76,6 @@ Transcribed speech: {text}""",
     "text_correction_timeout": 30,
     "save_temp_recordings": False,
     "min_transcription_duration": 1.0, # Nova configuração
-    "use_flash_attention_2": False
 }
 
 # Outras constantes de configuração (movidas de whisper_tkinter.py)
@@ -100,7 +98,6 @@ DISPLAY_TRANSCRIPTS_KEY = "display_transcripts_in_terminal"
 USE_VAD_CONFIG_KEY = "use_vad"
 VAD_THRESHOLD_CONFIG_KEY = "vad_threshold"
 VAD_SILENCE_DURATION_CONFIG_KEY = "vad_silence_duration"
-USE_FLASH_ATTENTION_2_CONFIG_KEY = "use_flash_attention_2"
 DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY = DISPLAY_TRANSCRIPTS_KEY
 KEYBOARD_LIBRARY_CONFIG_KEY = "keyboard_library"
 KEYBOARD_LIB_WIN32 = "win32"
@@ -116,14 +113,12 @@ GEMINI_API_KEY_CONFIG_KEY = "gemini_api_key"
 GEMINI_MODEL_CONFIG_KEY = "gemini_model"
 GEMINI_AGENT_MODEL_CONFIG_KEY = "gemini_agent_model"
 GEMINI_MODEL_OPTIONS_CONFIG_KEY = "gemini_model_options"
-USE_FLASH_ATTENTION_2_CONFIG_KEY = "use_flash_attention_2"
 AI_PROVIDER_CONFIG_KEY = TEXT_CORRECTION_SERVICE_CONFIG_KEY
 GEMINI_AGENT_PROMPT_CONFIG_KEY = "prompt_agentico"
 OPENROUTER_PROMPT_CONFIG_KEY = "openrouter_agent_prompt"
 OPENROUTER_AGENT_PROMPT_CONFIG_KEY = OPENROUTER_PROMPT_CONFIG_KEY
 GEMINI_PROMPT_CONFIG_KEY = "gemini_prompt"
 TEXT_CORRECTION_TIMEOUT_CONFIG_KEY = "text_correction_timeout"
-USE_FLASH_ATTENTION_2_CONFIG_KEY = "use_flash_attention_2"
 SETTINGS_WINDOW_GEOMETRY = "550x700"
 REREGISTER_INTERVAL_SECONDS = 60
 MAX_HOTKEY_FAILURES = 3
@@ -379,6 +374,13 @@ class ConfigManager:
             ),
             default=self.default_config[USE_FLASH_ATTENTION_2_CONFIG_KEY],
         )
+        if not isinstance(self.config.get(USE_FLASH_ATTENTION_2_CONFIG_KEY), bool):
+            logging.warning(
+                f"Invalid type for '{USE_FLASH_ATTENTION_2_CONFIG_KEY}'. Must be a boolean. Using default."
+            )
+            self.config[USE_FLASH_ATTENTION_2_CONFIG_KEY] = self.default_config[
+                USE_FLASH_ATTENTION_2_CONFIG_KEY
+            ]
     
         # Para gpu_index_specified e batch_size_specified
         self.config["batch_size_specified"] = BATCH_SIZE_CONFIG_KEY in loaded_config
@@ -443,26 +445,12 @@ class ConfigManager:
             self.config.get(USE_VAD_CONFIG_KEY, self.default_config[USE_VAD_CONFIG_KEY]),
             default=self.default_config[USE_VAD_CONFIG_KEY],
         )
-        self.config[USE_FLASH_ATTENTION_2_CONFIG_KEY] = _parse_bool(
-            self.config.get(
-                USE_FLASH_ATTENTION_2_CONFIG_KEY,
-                self.default_config[USE_FLASH_ATTENTION_2_CONFIG_KEY],
-            ),
-            default=self.default_config[USE_FLASH_ATTENTION_2_CONFIG_KEY],
-        )
         self.config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY] = _parse_bool(
             self.config.get(
                 DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY,
                 self.default_config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY],
             ),
             default=self.default_config[DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY],
-        )
-        self.config[USE_FLASH_ATTENTION_2_CONFIG_KEY] = _parse_bool(
-            self.config.get(
-                USE_FLASH_ATTENTION_2_CONFIG_KEY,
-                self.default_config[USE_FLASH_ATTENTION_2_CONFIG_KEY],
-            ),
-            default=self.default_config[USE_FLASH_ATTENTION_2_CONFIG_KEY],
         )
         try:
             raw_threshold = self.config.get(VAD_THRESHOLD_CONFIG_KEY, self.default_config[VAD_THRESHOLD_CONFIG_KEY])


### PR DESCRIPTION
## Summary
- sanitize duplicated config entries for `use_flash_attention_2`
- centralize validation logic for `use_flash_attention_2` in a single block

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685dd4926150833080d356f67c3ae620