### PR TITLE
Atualiza README e testes sobre Flash Attention 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A lightweight, high-performance desktop tool for Windows that turns your speech 
 *   **High-Quality Transcription:** Powered by the `openai/whisper-large-v3` model for state-of-the-art speech recognition.
 *   **GPU Acceleration:** Automatically utilizes your NVIDIA GPU (if available) for significantly faster transcriptions, with fallback to CPU.
 *   **Turbo Mode:** When enabled, loads `openai/whisper-large-v3-turbo` for even faster processing. Requires an NVIDIA Ampere or newer GPU.
+*   **Flash Attention 2:** Optional acceleration using optimized kernels. Enable by setting `use_flash_attention_2` to `true` in `config.json`.
 *   **Dynamic Performance:** Intelligently adjusts batch sizes based on available VRAM for optimal performance.
 *   **Customizable Hotkeys:**
     *   Activate recording with a global hotkey that works anywhere in Windows.
@@ -176,7 +177,7 @@ With your virtual environment activated, you can now install the libraries the a
     ```
 The `pip` command is Python's package installer. The `-r requirements.txt` part tells pip to install everything listed in that file. This step will download and install all necessary packages, including large ones like `torch` and `transformers`. This might take several minutes depending on your internet speed.
 
-These dependencies now include `optimum[bettertransformer]` and `accelerate`, which enable the optional **"Turbo"** mode via Flash Attention 2 for faster transcription.
+These dependencies now include `optimum[bettertransformer]` and `accelerate`, which enable the optional **"Turbo"** mode via Flash Attention 2 for faster transcription. Activate it by setting `use_flash_attention_2` to `true` in the settings.
 
 2.  **Optional: Install PyTorch with CUDA (For GPU Acceleration):**
     The `requirements.txt` includes a basic installation of PyTorch. However, if you have a compatible NVIDIA graphics card, you can significantly speed up the transcription process by installing a version of PyTorch that uses your GPU (CUDA).
@@ -238,6 +239,7 @@ To access and change settings:
 *   **Gemini Models (one per line):** Manage the list of available Gemini models in the dropdown.
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
 *   **Turbo Mode:** Use the optimized Turbo model when you have an Ampere or newer NVIDIA GPU.
+*   **Flash Attention 2:** Toggle this option to accelerate inference using optimized kernels. Equivalent to setting `use_flash_attention_2` to `true` in `config.json`.
 *   **Batch Size:** Configure the batch size for transcription.
 *   **Save Temporary Recordings:** When enabled, the captured audio is stored as `temp_recording_<timestamp>.wav` in the application folder. This temporary file is automatically deleted once transcription completes.
 *   **Display Transcript in Terminal:** Show the final text in the terminal window after each recording.

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -84,6 +84,38 @@ def test_use_turbo_default_and_override(tmp_path, monkeypatch):
     assert cm_override.get(config_manager.USE_TURBO_CONFIG_KEY) is True
 
 
+def test_use_flash_attention_default_and_override(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    secrets_path = tmp_path / "secrets.json"
+    monkeypatch.setattr(config_manager, "SECRETS_FILE", str(secrets_path))
+
+    cm_default = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+    assert cm_default.get(config_manager.USE_FLASH_ATTENTION_2_CONFIG_KEY) is False
+
+    cfg_path.write_text(json.dumps({"use_flash_attention_2": True}))
+    cm_override = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+    assert cm_override.get(config_manager.USE_FLASH_ATTENTION_2_CONFIG_KEY) is True
+
+
+def test_use_flash_attention_invalid_fallback(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    secrets_path = tmp_path / "secrets.json"
+    cfg_path.write_text(json.dumps({"use_flash_attention_2": "nope"}))
+    monkeypatch.setattr(config_manager, "SECRETS_FILE", str(secrets_path))
+
+    cm = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+    assert cm.get(config_manager.USE_FLASH_ATTENTION_2_CONFIG_KEY) is False
+
+
 def test_config_validation_and_fallback(tmp_path, monkeypatch):
     cfg_path = tmp_path / "config.json"
     secrets_path = tmp_path / "secrets.json"


### PR DESCRIPTION
## Summary
- document how to enable Flash Attention 2
- test ConfigManager for `use_flash_attention_2`

## Testing
- `pytest tests/test_config_manager.py::test_use_flash_attention_default_and_override -q`
- `pytest tests/test_config_manager.py::test_use_flash_attention_invalid_fallback -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd492ef408330a24263256490205d