### PR TITLE
Fix duplicate config import

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -25,7 +25,6 @@ from .config_manager import (
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
     USE_FLASH_ATTENTION_2_CONFIG_KEY,
     TEXT_CORRECTION_TIMEOUT_CONFIG_KEY,
-    USE_FLASH_ATTENTION_2_CONFIG_KEY,
 )
 
 class TranscriptionHandler:


### PR DESCRIPTION
## Summary
- remove duplicate `USE_FLASH_ATTENTION_2_CONFIG_KEY` import in transcription handler

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685dd4925f208330b8aff9199617210c