### PR TITLE
Atualiza imports e configuração do modelo

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -42,7 +42,8 @@ DEFAULT_CONFIG = {
     "gemini_api_key": "",
     "gemini_model": "gemini-2.5-flash-lite-preview-06-17",
     "gemini_agent_model": "gemini-2.5-flash-lite-preview-06-17",
-    "use_flash_attention_2": True,
+    "whisper_model_id": "openai/whisper-large-v3",
+    "use_flash_attention_2": False,
     "ai_provider": "gemini",
     "openrouter_agent_prompt": "",
     "openrouter_prompt": "",
@@ -112,6 +113,7 @@ OPENROUTER_MODEL_CONFIG_KEY = "openrouter_model"
 GEMINI_API_KEY_CONFIG_KEY = "gemini_api_key"
 GEMINI_MODEL_CONFIG_KEY = "gemini_model"
 GEMINI_AGENT_MODEL_CONFIG_KEY = "gemini_agent_model"
+WHISPER_MODEL_ID_CONFIG_KEY = "whisper_model_id"
 GEMINI_MODEL_OPTIONS_CONFIG_KEY = "gemini_model_options"
 AI_PROVIDER_CONFIG_KEY = TEXT_CORRECTION_SERVICE_CONFIG_KEY
 GEMINI_AGENT_PROMPT_CONFIG_KEY = "prompt_agentico"

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -2,7 +2,7 @@ import logging
 import threading
 import concurrent.futures
 import torch
-from transformers import pipeline, AutoProcessor, AutoModelForSpeechSeq2Seq
+from transformers import pipeline
 from .openrouter_api import OpenRouterAPI # Assumindo que está na raiz ou em path acessível
 import numpy as np # Necessário para o audio_input
 
@@ -20,6 +20,7 @@ from .config_manager import (
     GEMINI_PROMPT_CONFIG_KEY,
     OPENROUTER_PROMPT_CONFIG_KEY,
     MIN_TRANSCRIPTION_DURATION_CONFIG_KEY,
+    WHISPER_MODEL_ID_CONFIG_KEY,
     USE_TURBO_CONFIG_KEY,
     DISPLAY_TRANSCRIPTS_KEY,  # Nova constante
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
@@ -299,6 +300,7 @@ class TranscriptionHandler:
         # Removido: model_loaded_successfully = False
         # Removido: error_message = "Unknown error during model load."
         try:
+            from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq
             # Removido: device_param = "cpu"
             torch_dtype_local = torch.float32
 


### PR DESCRIPTION
## Resumo
- ajusta importações em `transcription_handler`
- adiciona `whisper_model_id` às configurações padrão e constante correspondente
- inclui nova constante no bloco de imports do handler
- define `use_flash_attention_2` como `False` por padrão
- importa `AutoProcessor` e `AutoModelForSpeechSeq2Seq` dentro do método

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e96e931588330b03f9daec9b4ab30