### PR TITLE
Atualizar testes para _transcribe_audio_chunk

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -316,10 +316,10 @@ class TranscriptionHandler:
             logging.info("Modelo carregado. Prosseguindo com a transcrição.")
 
         self.transcription_future = self.transcription_executor.submit(
-            self._transcription_task, audio_input, agent_mode
+            self._transcribe_audio_chunk, audio_input, agent_mode
         )
 
-    def _transcription_task(self, audio_input: np.ndarray, agent_mode: bool) -> None:
+    def _transcribe_audio_chunk(self, audio_input: np.ndarray, agent_mode: bool) -> None:
         if self.transcription_cancel_event.is_set():
             logging.info("Transcrição interrompida por stop signal antes do início do processamento.")
             return

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -88,7 +88,7 @@ class DummyPipe:
         return {"text": "dummy"}
 
 
-def test_transcription_task_handles_missing_callback(monkeypatch):
+def test_transcribe_audio_chunk_handles_missing_callback(monkeypatch):
     cfg = DummyConfig()
     results = []
     mock_on_model_error = MagicMock()
@@ -123,7 +123,7 @@ def test_transcription_task_handles_missing_callback(monkeypatch):
 
     monkeypatch.setattr(handler, "_async_text_correction", fake_correction)
 
-    handler._transcription_task(None, agent_mode=False)
+    handler._transcribe_audio_chunk(None, agent_mode=False)
 
     mock_on_model_error.assert_called_once() # Assert that the error callback was called
     assert not results # No transcription result should be appended
@@ -270,9 +270,9 @@ def test_transcribe_audio_segment_waits_for_model(monkeypatch):
     handler.pipe = DummyPipe()
     handler.model_loaded_event.clear() # Ensure it's not set
 
-    # Mock the transcription task to check if it's called
-    mock_transcription_task = MagicMock()
-    monkeypatch.setattr(handler, "_transcription_task", mock_transcription_task)
+    # Mock the transcription function to check if it's called
+    mock_transcribe_audio_chunk = MagicMock()
+    monkeypatch.setattr(handler, "_transcribe_audio_chunk", mock_transcribe_audio_chunk)
 
     # Start transcription in a separate thread, it should block
     transcription_thread = threading.Thread(
@@ -284,14 +284,14 @@ def test_transcribe_audio_segment_waits_for_model(monkeypatch):
 
     # Give it a moment to potentially block
     time.sleep(0.1)
-    assert not mock_transcription_task.called # Should not be called yet
+    assert not mock_transcribe_audio_chunk.called # Should not be called yet
 
     # Now, simulate model loading completion
     handler.model_loaded_event.set()
 
     # Give it a moment to unblock and call the task
     time.sleep(0.1)
-    assert mock_transcription_task.called # Should be called now
+    assert mock_transcribe_audio_chunk.called # Should be called now
 
     transcription_thread.join(timeout=1) # Clean up the thread
 


### PR DESCRIPTION
## Summary
- renomear `_transcription_task` para `_transcribe_audio_chunk`
- ajustar testes que chamavam a função antiga

## Testing
- `pytest -q` *(falhou: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685e9c5570f48330aee4a7ceaaed1b26