### PR TITLE
Fix audio_input variable bug

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -346,14 +346,14 @@ class TranscriptionHandler:
         text_result = None
         try:
             if self.transcription_pipeline is None:
-                error_message = "Pipeline de transcrição indisponível. Modelo não carregado ou falhou."
-                logging.error(error_message)
-                self.on_model_error_callback(error_message)  # Notify UI of the error
+                logging.error(
+                    "Pipeline de transcrição indisponível. Modelo não carregado ou falhou."
+                )
                 return
             logging.debug(
-                f"Transcrevendo áudio de {len(audio_data)/16000:.2f} segundos."
+                f"Transcrevendo áudio de {len(audio_input)/16000:.2f} segundos."
             )
-            result = self.transcription_pipeline(audio_data.copy())
+            result = self.transcription_pipeline(audio_input.copy())
             transcription = result["text"].strip()
             logging.info(f"Transcrição recebida: {transcription}")
             if self.on_transcription_result_callback:


### PR DESCRIPTION
## Summary
- corrigir referência à variável `audio_input` em `TranscriptionHandler._transcribe_audio_chunk`
- ajustar lógica para não acionar callback de erro de modelo quando o pipeline está ausente
- adicionar teste unitário garantindo uso de `audio_input`
- atualizar arquivo de testes com importação de `numpy`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea2e827248330a212e52d6fed42ad