### PR TITLE
Corrige verificação do pipeline e adiciona teste de persistência

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -340,20 +340,23 @@ class TranscriptionHandler:
 
     def _transcribe_audio_chunk(self, audio_input: np.ndarray, agent_mode: bool) -> None:
         if self.transcription_cancel_event.is_set():
-            logging.info("Transcrição interrompida por stop signal antes do início do processamento.")
+            logging.info(
+                "Transcrição interrompida por stop signal antes do início do processamento."
+            )
             return
 
         text_result = None
         try:
-            if self.transcription_pipeline is None:
-                error_message = "Pipeline de transcrição indisponível. Modelo não carregado ou falhou."
-                logging.error(error_message)
-                self.on_model_error_callback(error_message)  # Notify UI of the error
+            pipeline = self.transcription_pipeline or self.pipe
+            if pipeline is None:
+                logging.error(
+                    "Pipeline de transcrição indisponível. Modelo não carregado ou falhou."
+                )
                 return
             logging.debug(
-                f"Transcrevendo áudio de {len(audio_data)/16000:.2f} segundos."
+                f"Transcrevendo áudio de {len(audio_input)/16000:.2f} segundos."
             )
-            result = self.transcription_pipeline(audio_data.copy())
+            result = pipeline(audio_input.copy())
             transcription = result["text"].strip()
             logging.info(f"Transcrição recebida: {transcription}")
             if self.on_transcription_result_callback:

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -116,6 +116,25 @@ def test_use_flash_attention_invalid_fallback(tmp_path, monkeypatch):
     assert cm.get(config_manager.USE_FLASH_ATTENTION_2_CONFIG_KEY) is False
 
 
+def test_flash_attention_persistence(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    secrets_path = tmp_path / "secrets.json"
+    monkeypatch.setattr(config_manager, "SECRETS_FILE", str(secrets_path))
+
+    cm = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+    cm.set_use_flash_attention_2(True)
+    cm.save_config()
+
+    cm_reloaded = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+    assert cm_reloaded.get(config_manager.USE_FLASH_ATTENTION_2_CONFIG_KEY) is True
+
+
 def test_config_validation_and_fallback(tmp_path, monkeypatch):
     cfg_path = tmp_path / "config.json"
     secrets_path = tmp_path / "secrets.json"


### PR DESCRIPTION
## Resumo
- evita acionar callback de erro quando o pipeline de transcrição está ausente
- ajusta `_transcribe_audio_chunk` para usar `self.pipe` caso `self.transcription_pipeline` não esteja disponível
- adiciona teste garantindo que `use_flash_attention_2` é persistido ao salvar e recarregar o arquivo de configuração

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea2f5e48c8330b2b7cceb7a8edc11