### PR TITLE
Ativar Flash Attention 2 por padrão

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A lightweight, high-performance desktop tool for Windows that turns your speech 
 *   **High-Quality Transcription:** Powered by the `openai/whisper-large-v3` model for state-of-the-art speech recognition.
 *   **GPU Acceleration:** Automatically utilizes your NVIDIA GPU (if available) for significantly faster transcriptions, with fallback to CPU.
 *   **Turbo Mode:** When enabled, loads `openai/whisper-large-v3-turbo` for even faster processing. Requires an NVIDIA Ampere or newer GPU.
-*   **Flash Attention 2:** Disabled by default. Provides optional acceleration with optimized kernels. Enable by setting `use_flash_attention_2` to `true` in `config.json`.
+*   **Flash Attention 2:** Enabled by default. Requires an NVIDIA Ampere or newer GPU and provides accelerated inference using optimized kernels. Disable by setting `use_flash_attention_2` to `false` in `config.json` if your hardware is incompatible.
 *   **Dynamic Performance:** Intelligently adjusts batch sizes based on available VRAM for optimal performance.
 *   **Customizable Hotkeys:**
     *   Activate recording with a global hotkey that works anywhere in Windows.
@@ -181,7 +181,7 @@ With your virtual environment activated, you can now install the libraries the a
     ```
 The `pip` command is Python's package installer. The `-r requirements.txt` part tells pip to install everything listed in that file. This step will download and install all necessary packages, including large ones like `torch` and `transformers`. This might take several minutes depending on your internet speed.
 
-These dependencies now include `optimum[bettertransformer]` and `accelerate`, which enable **Turbo Mode** with Flash Attention 2 for faster transcriptions. This feature is disabled by default; activate it by setting `use_flash_attention_2` to `true` in the settings.
+These dependencies now include `optimum[bettertransformer]` and `accelerate`, which enable **Turbo Mode** with Flash Attention 2 for faster transcriptions. This feature is enabled by default; disable it by setting `use_flash_attention_2` to `false` in the settings if necessary.
 
 2.  **Optional: Install PyTorch with CUDA (For GPU Acceleration):**
     The `requirements.txt` includes a basic installation of PyTorch. However, if you have a compatible NVIDIA graphics card, you can significantly speed up the transcription process by installing a version of PyTorch that uses your GPU (CUDA).
@@ -243,7 +243,7 @@ To access and change settings:
 *   **Gemini Models (one per line):** Manage the list of available Gemini models in the dropdown.
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
 *   **Turbo Mode:** Use the optimized Turbo model when you have an Ampere or newer NVIDIA GPU.
-*   **Flash Attention 2:** Disabled by default; speeds up inference with optimized kernels. Equivalent to setting `use_flash_attention_2` to `true` in `config.json`.
+*   **Flash Attention 2:** Enabled by default; requires an NVIDIA Ampere or newer GPU. It speeds up inference with optimized kernels. Set `use_flash_attention_2` to `false` in `config.json` to disable.
 *   **Batch Size:** Configure the batch size for transcription.
 *   **Save Temporary Recordings:** When enabled, the captured audio is stored as `temp_recording_<timestamp>.wav` in the application folder. This temporary file is automatically deleted once transcription completes.
 *   **Display Transcript in Terminal:** Show the final text in the terminal window after each recording.
@@ -254,7 +254,7 @@ To access and change settings:
 
 ### Flash Attention 2
 
-Flash Attention 2 is an optimized attention kernel that reduces memory consumption and accelerates inference. It requires an NVIDIA GPU from the Ampere generation or newer.
+Flash Attention 2 is an optimized attention kernel that reduces memory consumption and accelerates inference. It requires an NVIDIA GPU from the Ampere generation or newer and is enabled by default.
 
 You can toggle this feature in the settings window under **Flash Attention 2** or by setting `use_flash_attention_2` to `true` or `false` in `config.json`.
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -42,8 +42,8 @@ DEFAULT_CONFIG = {
     "gemini_api_key": "",
     "gemini_model": "gemini-2.5-flash-lite-preview-06-17",
     "gemini_agent_model": "gemini-2.5-flash-lite-preview-06-17",
-    # Desativado por padrão; habilite manualmente se desejar ganho de desempenho
-    "use_flash_attention_2": False,
+    # Ativado por padrão; desabilite se necessário
+    "use_flash_attention_2": True,
     "ai_provider": "gemini",
     "openrouter_agent_prompt": "",
     "openrouter_prompt": "",

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -93,7 +93,7 @@ def test_use_flash_attention_default_and_override(tmp_path, monkeypatch):
         config_file=str(cfg_path),
         default_config=config_manager.DEFAULT_CONFIG,
     )
-    assert cm_default.get(config_manager.USE_FLASH_ATTENTION_2_CONFIG_KEY) is False
+    assert cm_default.get(config_manager.USE_FLASH_ATTENTION_2_CONFIG_KEY) is True
 
     cfg_path.write_text(json.dumps({"use_flash_attention_2": True}))
     cm_override = config_manager.ConfigManager(
@@ -113,7 +113,7 @@ def test_use_flash_attention_invalid_fallback(tmp_path, monkeypatch):
         config_file=str(cfg_path),
         default_config=config_manager.DEFAULT_CONFIG,
     )
-    assert cm.get(config_manager.USE_FLASH_ATTENTION_2_CONFIG_KEY) is False
+    assert cm.get(config_manager.USE_FLASH_ATTENTION_2_CONFIG_KEY) is True
 
 
 def test_flash_attention_persistence(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- torne Flash Attention 2 ativo por padrão
- ajuste testes para refletirem a nova configuração
- atualize README explicando requisitos de hardware

## Testing
- `pytest -q` *(falha: tests/test_transcription_handler_callback.py::test_transcribe_audio_chunk_handles_missing_callback)*

------
https://chatgpt.com/codex/tasks/task_e_685ff3714f9c8330b2ed250c457c10f4