### PR TITLE
Remove pipe attribute

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -58,7 +58,6 @@ class TranscriptionHandler:
         self.correction_thread = None
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
-        self.pipe = None
         self.transcription_pipeline = None
         self.is_model_loading = False
         # Futura tarefa de transcrição em andamento
@@ -307,7 +306,6 @@ class TranscriptionHandler:
                 torch_dtype=torch_dtype,
                 device=device,
             )
-            self.pipe = self.transcription_pipeline
             if self.config_manager.get(USE_FLASH_ATTENTION_2_CONFIG_KEY):
                 try:
                     self.transcription_pipeline.model = self.transcription_pipeline.model.to_bettertransformer()

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -107,7 +107,8 @@ def test_transcribe_audio_chunk_handles_missing_callback(monkeypatch):
         on_segment_transcribed_callback=None,
         is_state_transcribing_fn=lambda: True,
     )
-    handler.pipe = None # Simulate missing pipe
+    handler.transcription_pipeline = None  # Simulate missing pipeline
+    handler.model_loaded_event.set()
     handler.transcription_executor = concurrent.futures.ThreadPoolExecutor(
         max_workers=1
     )
@@ -268,7 +269,7 @@ def test_transcribe_audio_segment_waits_for_model(monkeypatch):
         on_segment_transcribed_callback=noop,
         is_state_transcribing_fn=lambda: True,
     )
-    handler.pipe = DummyPipe()
+    handler.transcription_pipeline = DummyPipe()
     handler.model_loaded_event.clear() # Ensure it's not set
 
     # Mock the transcription function to check if it's called


### PR DESCRIPTION
## Summary
- drop `self.pipe` from TranscriptionHandler
- update tests to avoid `pipe` references

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff37c74b08330b76466a89c00fa87