### PR TITLE
Update Turbo Mode documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ A lightweight, high-performance desktop tool for Windows that turns your speech 
 
 *   **High-Quality Transcription:** Powered by the `openai/whisper-large-v3` model for state-of-the-art speech recognition.
 *   **GPU Acceleration:** Automatically utilizes your NVIDIA GPU (if available) for significantly faster transcriptions, with fallback to CPU.
-*   **Turbo Mode:** When enabled, loads `openai/whisper-large-v3-turbo` for even faster processing. Requires an NVIDIA Ampere or newer GPU.
-*   **Flash Attention 2:** Disabled by default. Provides optional acceleration with optimized kernels. Enable by setting `use_flash_attention_2` to `true` in `config.json`.
+*   **Turbo Mode:** Applies Flash Attention 2 through `BetterTransformer` for faster processing. Requires an NVIDIA Ampere or newer GPU.
+*   **Flash Attention 2:** Disabled by default. Provides optional acceleration with optimized kernels. Toggle the setting in the GUI or set `use_flash_attention_2` in `config.json`.
 *   **Dynamic Performance:** Intelligently adjusts batch sizes based on available VRAM for optimal performance.
 *   **Customizable Hotkeys:**
     *   Activate recording with a global hotkey that works anywhere in Windows.
@@ -181,7 +181,7 @@ With your virtual environment activated, you can now install the libraries the a
     ```
 The `pip` command is Python's package installer. The `-r requirements.txt` part tells pip to install everything listed in that file. This step will download and install all necessary packages, including large ones like `torch` and `transformers`. This might take several minutes depending on your internet speed.
 
-These dependencies now include `optimum[bettertransformer]` and `accelerate`, which enable **Turbo Mode** with Flash Attention 2 for faster transcriptions. This feature is disabled by default; activate it by setting `use_flash_attention_2` to `true` in the settings.
+These dependencies now include `optimum[bettertransformer]` and `accelerate`. **Turbo Mode** uses Flash Attention 2 through `BetterTransformer` to speed up inference. The feature is disabled by default; enable it by setting `use_flash_attention_2` to `true` in the settings.
 
 2.  **Optional: Install PyTorch with CUDA (For GPU Acceleration):**
     The `requirements.txt` includes a basic installation of PyTorch. However, if you have a compatible NVIDIA graphics card, you can significantly speed up the transcription process by installing a version of PyTorch that uses your GPU (CUDA).
@@ -242,7 +242,7 @@ To access and change settings:
 *   **Agent Mode Prompt:** Customize the prompt sent to Gemini when using "Agent Mode".
 *   **Gemini Models (one per line):** Manage the list of available Gemini models in the dropdown.
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
-*   **Turbo Mode:** Use the optimized Turbo model when you have an Ampere or newer NVIDIA GPU.
+*   **Turbo Mode:** Uses Flash Attention 2 via `BetterTransformer` when you have an Ampere or newer NVIDIA GPU.
 *   **Flash Attention 2:** Disabled by default; speeds up inference with optimized kernels. Equivalent to setting `use_flash_attention_2` to `true` in `config.json`.
 *   **Batch Size:** Configure the batch size for transcription.
 *   **Save Temporary Recordings:** When enabled, the captured audio is stored as `temp_recording_<timestamp>.wav` in the application folder. This temporary file is automatically deleted once transcription completes.
@@ -257,6 +257,16 @@ To access and change settings:
 Flash Attention 2 is an optimized attention kernel that reduces memory consumption and accelerates inference. It requires an NVIDIA GPU from the Ampere generation or newer.
 
 You can toggle this feature in the settings window under **Flash Attention 2** or by setting `use_flash_attention_2` to `true` or `false` in `config.json`.
+
+Example `config.json` snippet:
+
+```json
+{
+    "use_flash_attention_2": true
+}
+```
+
+Set the value to `false` to disable the feature.
 
 #### Checking Performance
 


### PR DESCRIPTION
## Summary
- clarify that Turbo Mode speedup comes from Flash Attention 2 via BetterTransformer
- remove claim about `openai/whisper-large-v3-turbo`
- document how to toggle Flash Attention 2 in `config.json`

## Testing
- `pytest -q` *(fails: test_transcribe_audio_chunk_handles_missing_callback)*

------
https://chatgpt.com/codex/tasks/task_e_685ff3b7cb348330956eb370ebf17531