### PR TITLE
Atualizar dependências de teste e corrigir teste

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,6 +11,7 @@ pyperclip
 requests>=2.32.4
 google-generativeai
 keyboard
+setuptools
 soundfile>=0.13.1
 onnxruntime
 optimum

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -124,6 +124,9 @@ def test_transcribe_audio_chunk_handles_missing_callback(monkeypatch):
 
     monkeypatch.setattr(handler, "_async_text_correction", fake_correction)
 
+    # Garante que o evento esteja acionado para simular modelo previamente carregado
+    handler.model_loaded_event.set()
+
     handler._transcribe_audio_chunk(None, agent_mode=False)
 
     mock_on_model_error.assert_called_once()  # Callback should notify about the missing model


### PR DESCRIPTION
## Summary
- adicionar `setuptools` ao `requirements-test.txt`
- ajustar teste `test_transcription_handler_callback` para inicializar o evento `model_loaded_event`

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff3cd158883308ca29aadb8822106