### PR TITLE
Fix bettertransformer check on compute capability

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -367,15 +367,16 @@ class TranscriptionHandler:
                         )
                         if cap[0] < 8:
                             warn_msg = (
-                                f"GPU com compute capability {cap} não atende ao requisito mínimo (8.0) para Flash Attention 2."
+                                f"GPU com compute capability {cap} não atende ao requisito mínimo (8.0) para Flash Attention 2. Otimização não aplicada."
                             )
                             logging.warning(warn_msg)
                             if self.on_optimization_fallback_callback:
                                 self.on_optimization_fallback_callback(warn_msg)
-                        self.transcription_pipeline.model = (
-                            self.transcription_pipeline.model.to_bettertransformer()
-                        )
-                        logging.info("Flash Attention 2 aplicada com sucesso.")
+                        else:
+                            self.transcription_pipeline.model = (
+                                self.transcription_pipeline.model.to_bettertransformer()
+                            )
+                            logging.info("Flash Attention 2 aplicada com sucesso.")
                     except Exception as exc:
                         warn_msg = f"Falha ao aplicar Flash Attention 2: {exc}"
                         logging.warning(warn_msg)

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -413,4 +413,4 @@ def test_optimization_fallback_callback(monkeypatch):
     handler._load_model_task()
 
     assert messages
-    assert "otimização 'Turbo'" in messages[0]
+    assert "Flash Attention 2" in messages[0]


### PR DESCRIPTION
## Resumo
- aplica Flash Attention 2 apenas se a compute capability da GPU for >= 8
- registra aviso quando a otimização não é aplicada
- ajusta teste relacionado ao callback de fallback

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861391ec83c83309d0800c84138309b