### PR TITLE
Fix callback on text correction early return

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -231,6 +231,8 @@ class TranscriptionHandler:
             active_provider = self._get_text_correction_service()
             if active_provider == SERVICE_NONE:
                 logging.info("Correção de texto desativada ou provedor indisponível.")
+                self.correction_in_progress = False
+                self.on_transcription_result_callback(text, text)
                 return
 
             api_key = self.config_manager.get_api_key(active_provider)
@@ -239,6 +241,8 @@ class TranscriptionHandler:
                 logging.warning(
                     f"Nenhuma chave de API encontrada para o provedor {active_provider}. Pulando correção de texto."
                 )
+                self.correction_in_progress = False
+                self.on_transcription_result_callback(text, text)
                 return
 
             if active_provider == "gemini":


### PR DESCRIPTION
## Summary
- call on_transcription_result_callback when text correction service is disabled or API key missing
- mark correction as not in progress in these cases

## Testing
- `PYTHONPATH=$PWD:$PWD/src pytest -q tests/test_transcription_handler_callback.py::test_async_text_correction_service_selection tests/test_transcription_handler_callback.py::test_text_correction_timeout`

------
https://chatgpt.com/codex/tasks/task_e_6861395c502c8330b1d4a0b4bc22d479