### PR TITLE
Implement turbo mode gating

### DIFF
--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -12,7 +12,10 @@ from unittest.mock import MagicMock
 fake_torch = types.ModuleType("torch")
 fake_torch.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
 fake_torch.__version__ = "0.0"
-fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+fake_torch.cuda = types.SimpleNamespace(
+    is_available=lambda: False,
+    empty_cache=lambda: None,
+)
 
 sys.modules["torch"] = fake_torch
 
@@ -40,6 +43,7 @@ from src.config_manager import (  # noqa: E402
     OPENROUTER_MODEL_CONFIG_KEY,
     GEMINI_API_KEY_CONFIG_KEY,
     USE_FLASH_ATTENTION_2_CONFIG_KEY,
+    USE_TURBO_CONFIG_KEY,
     TEXT_CORRECTION_TIMEOUT_CONFIG_KEY,
     MIN_TRANSCRIPTION_DURATION_CONFIG_KEY,
     DISPLAY_TRANSCRIPTS_KEY,
@@ -58,7 +62,7 @@ class DummyConfig:
             "gpu_index_specified": False,
             TEXT_CORRECTION_ENABLED_CONFIG_KEY: False,
             TEXT_CORRECTION_SERVICE_CONFIG_KEY: SERVICE_NONE,
-            "use_turbo": False,
+            USE_TURBO_CONFIG_KEY: False,
             OPENROUTER_API_KEY_CONFIG_KEY: "dummy",
             OPENROUTER_MODEL_CONFIG_KEY: "",
             GEMINI_API_KEY_CONFIG_KEY: "dummy",
@@ -372,6 +376,7 @@ def test_transcribe_audio_chunk_uses_audio_input(monkeypatch):
 def test_optimization_fallback_callback(monkeypatch):
     cfg = DummyConfig()
     cfg.data[USE_FLASH_ATTENTION_2_CONFIG_KEY] = True
+    cfg.data[USE_TURBO_CONFIG_KEY] = True
     cfg.data[GPU_INDEX_CONFIG_KEY] = 0
 
     messages = []
@@ -413,4 +418,4 @@ def test_optimization_fallback_callback(monkeypatch):
     handler._load_model_task()
 
     assert messages
-    assert "otimização 'Turbo'" in messages[0]
+    assert "Falha ao aplicar Flash Attention 2" in messages[0]

--- a/tests/test_turbo_mode.py
+++ b/tests/test_turbo_mode.py
@@ -1,0 +1,142 @@
+import importlib.machinery
+import importlib
+import types
+import sys
+from unittest.mock import MagicMock
+
+# Stubs básicos para torch e transformers
+fake_torch = types.ModuleType("torch")
+fake_torch.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
+fake_torch.__version__ = "0.0"
+fake_torch.cuda = types.SimpleNamespace(
+    is_available=lambda: True,
+    get_device_capability=lambda _=0: (8, 0),
+)
+fake_torch.float16 = 1
+fake_torch.float32 = 2
+sys.modules["torch"] = fake_torch
+
+fake_transformers = types.ModuleType("transformers")
+fake_transformers.pipeline = MagicMock()
+fake_transformers.AutoProcessor = MagicMock()
+fake_transformers.AutoModelForSpeechSeq2Seq = MagicMock()
+sys.modules["transformers"] = fake_transformers
+
+if "src.transcription_handler" in sys.modules:
+    importlib.reload(sys.modules["src.transcription_handler"])
+
+from src.transcription_handler import TranscriptionHandler  # noqa: E402
+from src.config_manager import (  # noqa: E402
+    BATCH_SIZE_CONFIG_KEY,
+    BATCH_SIZE_MODE_CONFIG_KEY,
+    MANUAL_BATCH_SIZE_CONFIG_KEY,
+    GPU_INDEX_CONFIG_KEY,
+    TEXT_CORRECTION_ENABLED_CONFIG_KEY,
+    TEXT_CORRECTION_SERVICE_CONFIG_KEY,
+    SERVICE_NONE,
+    OPENROUTER_API_KEY_CONFIG_KEY,
+    OPENROUTER_MODEL_CONFIG_KEY,
+    GEMINI_API_KEY_CONFIG_KEY,
+    USE_FLASH_ATTENTION_2_CONFIG_KEY,
+    USE_TURBO_CONFIG_KEY,
+    TEXT_CORRECTION_TIMEOUT_CONFIG_KEY,
+    MIN_TRANSCRIPTION_DURATION_CONFIG_KEY,
+    DISPLAY_TRANSCRIPTS_KEY,
+    SAVE_TEMP_RECORDINGS_CONFIG_KEY,
+)
+
+
+class DummyConfig:
+    def __init__(self):
+        self.data = {
+            BATCH_SIZE_CONFIG_KEY: 16,
+            BATCH_SIZE_MODE_CONFIG_KEY: "auto",
+            MANUAL_BATCH_SIZE_CONFIG_KEY: 8,
+            GPU_INDEX_CONFIG_KEY: 0,
+            "batch_size_specified": False,
+            "gpu_index_specified": False,
+            TEXT_CORRECTION_ENABLED_CONFIG_KEY: False,
+            TEXT_CORRECTION_SERVICE_CONFIG_KEY: SERVICE_NONE,
+            USE_TURBO_CONFIG_KEY: False,
+            OPENROUTER_API_KEY_CONFIG_KEY: "",
+            OPENROUTER_MODEL_CONFIG_KEY: "",
+            GEMINI_API_KEY_CONFIG_KEY: "",
+            "gemini_agent_model": "",
+            "gemini_prompt": "",
+            MIN_TRANSCRIPTION_DURATION_CONFIG_KEY: 1.0,
+            DISPLAY_TRANSCRIPTS_KEY: False,
+            SAVE_TEMP_RECORDINGS_CONFIG_KEY: False,
+            USE_FLASH_ATTENTION_2_CONFIG_KEY: True,
+            TEXT_CORRECTION_TIMEOUT_CONFIG_KEY: 30,
+        }
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+
+def noop(*_a, **_k):
+    return None
+
+
+def _create_handler(cfg):
+    return TranscriptionHandler(
+        cfg,
+        gemini_api_client=None,
+        on_model_ready_callback=noop,
+        on_model_error_callback=noop,
+        on_optimization_fallback_callback=lambda *_: None,
+        on_transcription_result_callback=noop,
+        on_agent_result_callback=noop,
+        on_segment_transcribed_callback=None,
+        is_state_transcribing_fn=lambda: False,
+    )
+
+
+def test_bettertransformer_aplicado_quando_turbo(monkeypatch):
+    cfg = DummyConfig()
+    cfg.data[USE_TURBO_CONFIG_KEY] = True
+
+    import src.transcription_handler as th_module
+
+    called = {"flag": False}
+
+    class DummyModel:
+        def to_bettertransformer(self):
+            called["flag"] = True
+            return self
+
+    class DummyPipeline:
+        def __init__(self):
+            self.model = DummyModel()
+
+    monkeypatch.setattr(th_module, "pipeline", lambda *a, **k: DummyPipeline())
+
+    handler = _create_handler(cfg)
+    handler._load_model_task()
+
+    assert called["flag"]
+
+
+def test_bettertransformer_ignorado_sem_turbo(monkeypatch):
+    cfg = DummyConfig()
+    cfg.data[USE_TURBO_CONFIG_KEY] = False
+
+    import src.transcription_handler as th_module
+
+    called = {"flag": 0}
+
+    class DummyModel:
+        def to_bettertransformer(self):
+            called["flag"] += 1
+            return self
+
+    class DummyPipeline:
+        def __init__(self):
+            self.model = DummyModel()
+
+    monkeypatch.setattr(th_module, "pipeline", lambda *a, **k: DummyPipeline())
+
+    handler = _create_handler(cfg)
+    handler._load_model_task()
+
+    assert called["flag"] == 0


### PR DESCRIPTION
## Summary
- add conditional Flash Attention 2 usage when Turbo Mode is on
- prevent CUDA cache cleanup errors when torch stub lacks `empty_cache`
- adjust callback test for new warning message
- add tests ensuring Turbo Mode applies or ignores BetterTransformer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861398953488330b5518671258d471e