### PR TITLE
Implement dynamic OpenRouter client initialization

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -184,6 +184,24 @@ class TranscriptionHandler:
         self.use_flash_attention_2 = self.config_manager.get("use_flash_attention_2")
         logging.info("TranscriptionHandler: Configurações atualizadas.")
 
+        if (
+            self.text_correction_enabled
+            and self.text_correction_service == SERVICE_OPENROUTER
+            and self.openrouter_api_key
+            and self.openrouter_client is None
+            and OpenRouterAPI
+        ):
+            try:
+                self.openrouter_client = OpenRouterAPI(
+                    api_key=self.openrouter_api_key, model_id=self.openrouter_model
+                )
+                self.openrouter_api = self.openrouter_client
+                logging.info(
+                    "OpenRouter API client initialized via update_config."
+                )
+            except Exception as e:
+                logging.error(f"Error initializing OpenRouter API client: {e}")
+
     def _get_device_and_dtype(self):
         """Define o dispositivo e o dtype ideais para o modelo."""
         device = (
@@ -377,7 +395,7 @@ class TranscriptionHandler:
                         )
                         logging.info("Flash Attention 2 aplicada com sucesso.")
                     except Exception as exc:
-                        warn_msg = f"Falha ao aplicar Flash Attention 2: {exc}"
+                        warn_msg = f"Falha na otimização 'Turbo': {exc}"
                         logging.warning(warn_msg)
                         if self.on_optimization_fallback_callback:
                             self.on_optimization_fallback_callback(warn_msg)

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -195,6 +195,36 @@ def test_async_text_correction_service_selection(monkeypatch):
             assert not handler.openrouter_api.correct_text.called
 
 
+def test_update_config_initializes_openrouter_client():
+    cfg = DummyConfig()
+    handler = TranscriptionHandler(
+        cfg,
+        gemini_api_client=None,
+        on_model_ready_callback=noop,
+        on_model_error_callback=noop,
+        on_optimization_fallback_callback=lambda *_: None,
+        on_transcription_result_callback=noop,
+        on_agent_result_callback=noop,
+        on_segment_transcribed_callback=None,
+        is_state_transcribing_fn=lambda: False,
+    )
+
+    assert handler.openrouter_client is None
+
+    cfg.data[TEXT_CORRECTION_ENABLED_CONFIG_KEY] = True
+    cfg.data[TEXT_CORRECTION_SERVICE_CONFIG_KEY] = SERVICE_OPENROUTER
+    cfg.data[OPENROUTER_API_KEY_CONFIG_KEY] = "newkey"
+    cfg.data[OPENROUTER_MODEL_CONFIG_KEY] = "model1"
+
+    handler.update_config()
+
+    from src.openrouter_api import OpenRouterAPI
+
+    assert isinstance(handler.openrouter_client, OpenRouterAPI)
+    assert handler.openrouter_client.api_key == "newkey"
+    assert handler.openrouter_client.model_id == "model1"
+
+
 def test_get_dynamic_batch_size_for_cpu_and_gpu(monkeypatch):
     cfg = DummyConfig()
     cfg.data[GPU_INDEX_CONFIG_KEY] = 0


### PR DESCRIPTION
## Summary
- update `TranscriptionHandler.update_config` to instantiate OpenRouter API client when required
- adjust flash attention fallback message
- ensure client creation is tested

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686139a4292883309b5d8bd2776f3664