### PR TITLE
Fix explicit VAD disable and checks

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -49,7 +49,7 @@ class AudioHandler:
         if status:
             logging.warning(f"Audio callback status: {status}")
         if self.is_recording:
-            if self.use_vad:
+            if self.use_vad and self.vad_manager and self.vad_manager.enabled:
                 is_speech = self.vad_manager.is_speech(indata[:, 0])
                 if is_speech:
                     self._vad_silence_counter = 0.0
@@ -139,14 +139,14 @@ class AudioHandler:
         self.start_time = time.time()
         self.recording_data.clear()
 
-        if self.use_vad and self.vad_manager:
+        if self.use_vad and self.vad_manager and self.vad_manager.enabled:
             self.vad_manager.reset_states()
         self._vad_silence_counter = 0.0
         logging.debug("VAD reiniciado e contador de silêncio zerado para nova gravação.")
 
         self.on_recording_state_change_callback("RECORDING")
 
-        if self.use_vad and self.vad_manager:
+        if self.use_vad and self.vad_manager and self.vad_manager.enabled:
             self.vad_manager.reset_states()
             logging.debug("Estados do VAD reiniciados.")
 
@@ -169,7 +169,7 @@ class AudioHandler:
         if self._record_thread and self._record_thread.is_alive():
             self._record_thread.join(timeout=2.0)
 
-        if self.use_vad and self.vad_manager:
+        if self.use_vad and self.vad_manager and self.vad_manager.enabled:
             self.vad_manager.reset_states()
         self._vad_silence_counter = 0.0
         logging.debug("VAD reiniciado e contador de silêncio zerado ao parar a gravação.")

--- a/src/vad_manager.py
+++ b/src/vad_manager.py
@@ -33,6 +33,7 @@ class VADManager:
         if onnxruntime is None:
             logging.warning("onnxruntime indispon\u00edvel. VAD desativado.")
             self.session = None
+            self.enabled = False
             return
 
         if not MODEL_PATH.exists():
@@ -41,6 +42,7 @@ class VADManager:
                 MODEL_PATH,
             )
             self.session = None
+            self.enabled = False
             return
 
         try:

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -413,4 +413,4 @@ def test_optimization_fallback_callback(monkeypatch):
     handler._load_model_task()
 
     assert messages
-    assert "otimização 'Turbo'" in messages[0]
+    assert "Falha ao aplicar Flash Attention 2" in messages[0]


### PR DESCRIPTION
## Summary
- disable VAD explicitly when ONNX or model file missing
- check `vad_manager.enabled` before using VAD in `AudioHandler`
- adjust fallback optimization test to new log message

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861458caf808330b382b30d5b3a5172