### PR TITLE
Implement dynamic token limit for OpenRouter async method

### DIFF
--- a/src/openrouter_api.py
+++ b/src/openrouter_api.py
@@ -202,7 +202,7 @@ class OpenRouterAPI:
                 {"role": "user", "content": user_message},
             ],
             "temperature": 0.0,
-            "max_tokens": 10000,
+            "max_tokens": self.max_tokens,
         }
 
         for attempt in range(3):

--- a/tests/test_openrouter_api.py
+++ b/tests/test_openrouter_api.py
@@ -91,4 +91,5 @@ def test_correct_text_async_custom_prompt():
             "additional comments"
         )
         assert sent_payload['messages'][1]['content'] == 'Corrija o texto: texto original'
+        assert sent_payload['max_tokens'] == api.max_tokens
         assert kwargs['headers']['Authorization'] == 'Bearer newkey'

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -413,4 +413,4 @@ def test_optimization_fallback_callback(monkeypatch):
     handler._load_model_task()
 
     assert messages
-    assert "otimização 'Turbo'" in messages[0]
+    assert "Falha ao aplicar Flash Attention 2" in messages[0]


### PR DESCRIPTION
## Summary
- use `self.max_tokens` when calling OpenRouter for async corrections
- expect payload's `max_tokens` in async correction tests
- update fallback optimization test to reflect new warning message

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686145abaa708330936c9ec7a4adbb82