### PR TITLE
Fix audio stop join and update Turbo message

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -176,8 +176,6 @@ class AudioHandler:
 
         threading.Thread(target=self._play_generated_tone_stream, kwargs={"is_start": False}, daemon=True, name="StopSoundThread").start()
 
-        if self._record_thread:
-            self._record_thread.join(timeout=2)
 
         if not stream_was_started:
             logging.warning("Stop recording called but audio stream never started. Ignoring data.")

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -377,7 +377,7 @@ class TranscriptionHandler:
                         )
                         logging.info("Flash Attention 2 aplicada com sucesso.")
                     except Exception as exc:
-                        warn_msg = f"Falha ao aplicar Flash Attention 2: {exc}"
+                        warn_msg = f"Falha ao aplicar a otimização 'Turbo': {exc}"
                         logging.warning(warn_msg)
                         if self.on_optimization_fallback_callback:
                             self.on_optimization_fallback_callback(warn_msg)


### PR DESCRIPTION
## Summary
- remove redundant thread join from `stop_recording`
- adjust fallback warning message for Turbo optimization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686145b58a1c83309db4f7fe098deca2