### PR TITLE
Standardize Turbo optimization warning and update tests

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -35,6 +35,11 @@ from .config_manager import (
     TEXT_CORRECTION_TIMEOUT_CONFIG_KEY,
 )
 
+# Mensagem padronizada para falhas na otimização Turbo/Flash Attention 2
+OPTIMIZATION_TURBO_FALLBACK_MSG = (
+    "Falha ao aplicar otimização 'Turbo Mode' (Flash Attention 2)."
+)
+
 
 class TranscriptionHandler:
     def __init__(
@@ -367,7 +372,7 @@ class TranscriptionHandler:
                         )
                         if cap[0] < 8:
                             warn_msg = (
-                                f"GPU com compute capability {cap} não atende ao requisito mínimo (8.0) para Flash Attention 2."
+                                f"{OPTIMIZATION_TURBO_FALLBACK_MSG} Motivo: GPU com compute capability {cap} não atende ao requisito mínimo (8.0)."
                             )
                             logging.warning(warn_msg)
                             if self.on_optimization_fallback_callback:
@@ -377,13 +382,15 @@ class TranscriptionHandler:
                         )
                         logging.info("Flash Attention 2 aplicada com sucesso.")
                     except Exception as exc:
-                        warn_msg = f"Falha ao aplicar Flash Attention 2: {exc}"
+                        warn_msg = (
+                            f"{OPTIMIZATION_TURBO_FALLBACK_MSG} Motivo: {exc}"
+                        )
                         logging.warning(warn_msg)
                         if self.on_optimization_fallback_callback:
                             self.on_optimization_fallback_callback(warn_msg)
                 else:
                     warn_msg = (
-                        "Flash Attention 2 solicitada, mas nenhum GPU foi detectado. Desative ou ajuste as configurações."
+                        f"{OPTIMIZATION_TURBO_FALLBACK_MSG} Motivo: nenhum GPU foi detectado. Desative ou ajuste as configurações."
                     )
                     logging.warning(warn_msg)
                     if self.on_optimization_fallback_callback:

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -25,7 +25,10 @@ sys.modules["transformers"] = fake_transformers
 if "src.transcription_handler" in sys.modules:
     importlib.reload(sys.modules["src.transcription_handler"])
 
-from src.transcription_handler import TranscriptionHandler  # noqa: E402
+from src.transcription_handler import (
+    TranscriptionHandler,
+    OPTIMIZATION_TURBO_FALLBACK_MSG,
+)
 from src.config_manager import (  # noqa: E402
     BATCH_SIZE_CONFIG_KEY,
     BATCH_SIZE_MODE_CONFIG_KEY,
@@ -413,4 +416,4 @@ def test_optimization_fallback_callback(monkeypatch):
     handler._load_model_task()
 
     assert messages
-    assert "otimização 'Turbo'" in messages[0]
+    assert messages[0].startswith(OPTIMIZATION_TURBO_FALLBACK_MSG)


### PR DESCRIPTION
## Summary
- centralize message for Turbo Mode/Flash Attention 2 failures
- integrate new message in `_load_model_task`
- align `test_optimization_fallback_callback` with the standardized text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861469d6da8833080deb2f44c45b9a9