### PR TITLE
Ajusta turbo mode e testes

### DIFF
--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -251,6 +251,8 @@ def test_get_dynamic_batch_size_for_cpu_and_gpu(monkeypatch):
     )
 
     import src.transcription_handler as th_module
+    th_module.BETTERTRANSFORMER_AVAILABLE = True
+    th_module.BETTERTRANSFORMER_AVAILABLE = True
     monkeypatch.setattr(th_module.torch.cuda, "is_available", lambda: True)
     assert handler._get_dynamic_batch_size() == 8
     monkeypatch.setattr(th_module.torch.cuda, "is_available", lambda: False)

--- a/tests/test_turbo_mode.py
+++ b/tests/test_turbo_mode.py
@@ -26,6 +26,8 @@ if "src.transcription_handler" in sys.modules:
     importlib.reload(sys.modules["src.transcription_handler"])
 
 from src.transcription_handler import TranscriptionHandler  # noqa: E402
+import src.transcription_handler as th_module  # noqa: E402
+th_module.BETTERTRANSFORMER_AVAILABLE = True
 from src.config_manager import (  # noqa: E402
     BATCH_SIZE_CONFIG_KEY,
     BATCH_SIZE_MODE_CONFIG_KEY,


### PR DESCRIPTION
## Resumo
- reorganiza o bloco de flash attention para evitar duplicações
- define `BETTERTRANSFORMER_AVAILABLE` ao importar `BetterTransformer`
- garante que `model_loaded_event` sempre seja sinalizado
- ajusta testes de callback e turbo

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615ae2d2c08330a7849a849bc398c8