### PR TITLE
Implement BetterTransformer flag and tests

### DIFF
--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -25,6 +25,13 @@ fake_transformers.AutoProcessor = MagicMock()
 fake_transformers.AutoModelForSpeechSeq2Seq = MagicMock()
 sys.modules["transformers"] = fake_transformers
 
+# Stub para optimum.bettertransformer
+fake_optimum = types.ModuleType("optimum")
+fake_bt = types.ModuleType("optimum.bettertransformer")
+fake_bt.BetterTransformer = object
+sys.modules["optimum"] = fake_optimum
+sys.modules["optimum.bettertransformer"] = fake_bt
+
 if "src.transcription_handler" in sys.modules:
     importlib.reload(sys.modules["src.transcription_handler"])
 


### PR DESCRIPTION
## Summary
- add optional import for `optimum.bettertransformer`
- guard Flash Attention conversion with `BETTERTRANSFORMER_AVAILABLE`
- fix `_load_model_task` logic
- stub `optimum` in tests and add new coverage for missing library

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615ae2e3108330bbe2ea66681e4440