### PR TITLE
Atualização de README sobre Turbo Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A lightweight, high-performance desktop tool for Windows that turns your speech 
 
 *   **High-Quality Transcription:** Powered by the `openai/whisper-large-v3` model for state-of-the-art speech recognition.
 *   **GPU Acceleration:** Automatically utilizes your NVIDIA GPU (if available) for significantly faster transcriptions, with fallback to CPU.
-*   **Turbo Mode:** Applies Flash Attention 2 through `BetterTransformer` for faster processing. Requires an NVIDIA Ampere or newer GPU.
+*   **Turbo Mode (disabled by default):** Applies Flash Attention 2 through `BetterTransformer` for faster processing when `use_turbo` is set to `true`. Requires an NVIDIA Ampere or newer GPU.
 *   **Flash Attention 2:** Enabled by default. Provides optional acceleration with optimized kernels. Toggle the setting in the GUI or set `use_flash_attention_2` in `config.json`.
 *   **Dynamic Performance:** Intelligently adjusts batch sizes based on available VRAM for optimal performance.
 *   **Customizable Hotkeys:**
@@ -181,7 +181,7 @@ With your virtual environment activated, you can now install the libraries the a
     ```
 The `pip` command is Python's package installer. The `-r requirements.txt` part tells pip to install everything listed in that file. This step will download and install all necessary packages, including large ones like `torch` and `transformers`. This might take several minutes depending on your internet speed.
 
-These dependencies now include `optimum[bettertransformer]` and `accelerate`. **Turbo Mode** uses Flash Attention 2 through `BetterTransformer` to speed up inference. The feature is enabled by default; disable it by setting `use_flash_attention_2` to `false` in the settings.
+These dependencies now include `optimum[bettertransformer]` and `accelerate`. **Turbo Mode** uses Flash Attention 2 through `BetterTransformer` to speed up inference. The feature is disabled by default; enable it by setting `use_turbo` to `true` (and keeping `use_flash_attention_2` enabled) in the settings.
 
 2.  **Optional: Install PyTorch with CUDA (For GPU Acceleration):**
     The `requirements.txt` includes a basic installation of PyTorch. However, if you have a compatible NVIDIA graphics card, you can significantly speed up the transcription process by installing a version of PyTorch that uses your GPU (CUDA).
@@ -242,7 +242,7 @@ To access and change settings:
 *   **Agent Mode Prompt:** Customize the prompt sent to Gemini when using "Agent Mode".
 *   **Gemini Models (one per line):** Manage the list of available Gemini models in the dropdown.
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
-*   **Turbo Mode:** Uses Flash Attention 2 via `BetterTransformer` when you have an Ampere or newer NVIDIA GPU.
+*   **Turbo Mode:** Uses Flash Attention 2 via `BetterTransformer` when you set `use_turbo` to `true` and have an Ampere or newer NVIDIA GPU.
 *   **Flash Attention 2:** Enabled by default; speeds up inference with optimized kernels. Equivalent to setting `use_flash_attention_2` to `true` in `config.json`.
 *   **Batch Size:** Configure the batch size for transcription.
 *   **Save Temporary Recordings:** When enabled, the captured audio is stored as `temp_recording_<timestamp>.wav` in the application folder. This temporary file is automatically deleted once transcription completes.
@@ -254,7 +254,7 @@ To access and change settings:
 
 ### Flash Attention 2
 
-Flash Attention 2 is an optimized attention kernel that reduces memory consumption and accelerates inference. It requires an NVIDIA GPU from the Ampere generation or newer and is enabled by default.
+Flash Attention 2 is an optimized attention kernel that reduces memory consumption and accelerates inference. It requires an NVIDIA GPU from the Ampere generation or newer and is enabled by default. The optimization is only applied when **Turbo Mode** is also enabled (`use_turbo: true`).
 
 You can toggle this feature in the settings window under **Flash Attention 2** or by setting `use_flash_attention_2` to `true` or `false` in `config.json`.
 


### PR DESCRIPTION
## Summary
- clarify how to enable Turbo Mode using `use_turbo: true`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68615ae4349c8330828783b7cf92eae4