### PR TITLE
Add Turbo Mode option

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -386,42 +386,19 @@ class TranscriptionHandler:
             flash_enabled = self.use_turbo and self.use_flash_attention_2
             if flash_enabled:
                 if device.startswith("cuda"):
-                    if not BETTERTRANSFORMER_AVAILABLE:
-                        warn_msg = (
-                            "Pacote 'optimum[bettertransformer]' nao encontrado. Modo Turbo desativado."
-                        )
-                        logging.warning(warn_msg)
-                        if self.on_optimization_fallback_callback:
-                            self.on_optimization_fallback_callback(warn_msg)
-                    else:
-                        logging.info(
-                            "Tentando aplicar Flash Attention 2 via BetterTransformer..."
-                        )
+                    try:
+                        cap = torch.cuda.get_device_capability(0)
                         if cap[0] < 8:
                             warn_msg = (
                                 f"{OPTIMIZATION_TURBO_FALLBACK_MSG} Motivo: GPU com compute capability {cap} não atende ao requisito mínimo (8.0)."
                             )
-                            if cap[0] < 8:
-                                warn_msg = (
-                                    f"GPU com compute capability {cap} não atende ao requisito mínimo (8.0) para Flash Attention 2."
-                                )
-                                logging.warning(warn_msg)
-                                if self.on_optimization_fallback_callback:
-                                    self.on_optimization_fallback_callback(warn_msg)
-                            self.transcription_pipeline.model = (
-                                self.transcription_pipeline.model.to_bettertransformer()
-                            )
-                            logging.info("Flash Attention 2 aplicada com sucesso.")
-                        except Exception as exc:
-                            warn_msg = f"Falha ao aplicar otimização 'Turbo': {exc}"
                             logging.warning(warn_msg)
                             if self.on_optimization_fallback_callback:
                                 self.on_optimization_fallback_callback(warn_msg)
-                        else:
-                            self.transcription_pipeline.model = (
-                                self.transcription_pipeline.model.to_bettertransformer()
-                            )
-                            logging.info("Flash Attention 2 aplicada com sucesso.")
+                        self.transcription_pipeline.model = (
+                            self.transcription_pipeline.model.to_bettertransformer()
+                        )
+                        logging.info("Flash Attention 2 aplicada com sucesso.")
                     except Exception as exc:
                         warn_msg = (
                             f"{OPTIMIZATION_TURBO_FALLBACK_MSG} Motivo: {exc}"

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -192,6 +192,7 @@ class UIManager:
                 gemini_model_var = ctk.StringVar(value=self.config_manager.get("gemini_model"))
                 batch_size_var = ctk.StringVar(value=str(self.config_manager.get("batch_size")))
                 flash_attention_var = ctk.BooleanVar(value=self.config_manager.get("use_flash_attention_2"))
+                use_turbo_var = ctk.BooleanVar(value=self.config_manager.get("use_turbo"))
                 use_vad_var = ctk.BooleanVar(value=self.config_manager.get("use_vad"))
                 vad_threshold_var = ctk.DoubleVar(value=self.config_manager.get("vad_threshold"))
                 vad_silence_duration_var = ctk.DoubleVar(value=self.config_manager.get("vad_silence_duration"))
@@ -274,6 +275,7 @@ class UIManager:
                     save_temp_recordings_to_apply = save_temp_recordings_var.get()
                     display_transcripts_to_apply = display_transcripts_var.get()
                     flash_attention_to_apply = flash_attention_var.get()
+                    use_turbo_to_apply = use_turbo_var.get()
 
                     # Logic for converting UI to GPU index
                     selected_device_str = gpu_selection_var.get()
@@ -322,7 +324,8 @@ class UIManager:
                         new_vad_threshold=vad_threshold_to_apply,
                         new_vad_silence_duration=vad_silence_duration_to_apply,
                         new_display_transcripts_in_terminal=display_transcripts_to_apply,
-                        new_use_flash_attention_2=flash_attention_to_apply
+                        new_use_flash_attention_2=flash_attention_to_apply,
+                        new_use_turbo=use_turbo_to_apply
                     )
                     self._close_settings_window() # Call class method
 
@@ -363,7 +366,7 @@ class UIManager:
                     gemini_models_textbox.insert("1.0", "\n".join(DEFAULT_CONFIG["gemini_model_options"]))
                     batch_size_var.set(str(DEFAULT_CONFIG["batch_size"]))
                     flash_attention_var.set(DEFAULT_CONFIG["use_flash_attention_2"])
-                    flash_attention_var.set(DEFAULT_CONFIG["use_flash_attention_2"])
+                    use_turbo_var.set(DEFAULT_CONFIG["use_turbo"])
 
                     if DEFAULT_CONFIG["gpu_index"] == -1:
                         gpu_selection_var.set("Force CPU")
@@ -562,6 +565,12 @@ class UIManager:
                 flash_attention_checkbox = ctk.CTkCheckBox(flash_attention_frame, text="Use Flash Attention 2", variable=flash_attention_var)
                 flash_attention_checkbox.pack(side="left", padx=5)
                 Tooltip(flash_attention_checkbox, "Enable Flash Attention 2 if supported.")
+
+                turbo_frame = ctk.CTkFrame(transcription_frame)
+                turbo_frame.pack(fill="x", pady=5)
+                turbo_checkbox = ctk.CTkCheckBox(turbo_frame, text="Enable Turbo Mode", variable=use_turbo_var)
+                turbo_checkbox.pack(side="left", padx=5)
+                Tooltip(turbo_checkbox, "Use accelerated inference when possible.")
     
                 # New: Ignore Transcriptions Shorter Than
                 min_transcription_duration_frame = ctk.CTkFrame(transcription_frame)

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -135,6 +135,25 @@ def test_flash_attention_persistence(tmp_path, monkeypatch):
     assert cm_reloaded.get(config_manager.USE_FLASH_ATTENTION_2_CONFIG_KEY) is True
 
 
+def test_turbo_persistence(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    secrets_path = tmp_path / "secrets.json"
+    monkeypatch.setattr(config_manager, "SECRETS_FILE", str(secrets_path))
+
+    cm = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+    cm.set_use_turbo(True)
+    cm.save_config()
+
+    cm_reloaded = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+    assert cm_reloaded.get(config_manager.USE_TURBO_CONFIG_KEY) is True
+
+
 def test_config_validation_and_fallback(tmp_path, monkeypatch):
     cfg_path = tmp_path / "config.json"
     secrets_path = tmp_path / "secrets.json"


### PR DESCRIPTION
## Summary
- add checkbox for Turbo Mode in advanced transcription settings
- accept `new_use_turbo` in AppCore settings functions
- reload model when Turbo Mode toggled
- persist Turbo Mode via ConfigManager
- test persistence of Turbo Mode flag

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615ae4c4688330a9bffad700459121