### PR TITLE
Add device capability check with fallback

### DIFF
--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -251,6 +251,7 @@ def test_get_dynamic_batch_size_for_cpu_and_gpu(monkeypatch):
     )
 
     import src.transcription_handler as th_module
+    monkeypatch.setattr(th_module, "BETTERTRANSFORMER_AVAILABLE", True)
     monkeypatch.setattr(th_module.torch.cuda, "is_available", lambda: True)
     assert handler._get_dynamic_batch_size() == 8
     monkeypatch.setattr(th_module.torch.cuda, "is_available", lambda: False)

--- a/tests/test_turbo_mode.py
+++ b/tests/test_turbo_mode.py
@@ -97,6 +97,7 @@ def test_bettertransformer_aplicado_quando_turbo(monkeypatch):
     cfg.data[USE_TURBO_CONFIG_KEY] = True
 
     import src.transcription_handler as th_module
+    monkeypatch.setattr(th_module, "BETTERTRANSFORMER_AVAILABLE", True)
 
     called = {"flag": False}
 


### PR DESCRIPTION
## Summary
- check CUDA device capability in Turbo optimization block
- handle errors with try/except and warn user
- expose BetterTransformer availability flag
- fix tests to set capability flag

## Testing
- `pytest tests/test_turbo_mode.py tests/test_transcription_handler_callback.py -q` *(fails: module 'torch' has no attribute 'float16')*

------
https://chatgpt.com/codex/tasks/task_e_68615ae2d1f4833093b5e810b6e10c48