### PR TITLE
Atualiza mensagem de fallback do Turbo Mode

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -410,9 +410,7 @@ class TranscriptionHandler:
                 if device.startswith("cuda"):
                     if not BETTERTRANSFORMER_AVAILABLE:
                         warn_msg = (
-                            "Pacote 'optimum[bettertransformer]' nao encontrado."
-                            " Instale manualmente com `pip install \"optimum[bettertransformer]\"`."
-                            " Modo Turbo desativado."
+                            "BetterTransformer indisponível. Turbo Mode desativado."
                         )
                         logging.warning(warn_msg)
                         if self.on_optimization_fallback_callback:

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -508,4 +508,4 @@ def test_warn_msg_indica_instalacao_manual(monkeypatch):
     handler._load_model_task()
 
     assert messages
-    assert "pip install \"optimum[bettertransformer]\"" in messages[0]
+    assert "BetterTransformer indisponível" in messages[0]


### PR DESCRIPTION
## Summary
- ajusta mensagem ao detectar BetterTransformer ausente
- atualiza teste correspondente

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686188e1aa648330912805a34bc7c8c4