### PR TITLE
Corrige aplicação do BetterTransformer com checagem de disponibilidade

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -425,15 +425,16 @@ class TranscriptionHandler:
                             cap = torch.cuda.get_device_capability(self.gpu_index)
                             if cap[0] < 8:
                                 warn_msg = (
-                                    f"{OPTIMIZATION_TURBO_FALLBACK_MSG} Motivo: {exc}"
+                                    f"{OPTIMIZATION_TURBO_FALLBACK_MSG} Motivo: GPU com compute capability {cap} não atende ao requisito mínimo (8.0)."
                                 )
                                 logging.warning(warn_msg)
                                 if self.on_optimization_fallback_callback:
                                     self.on_optimization_fallback_callback(warn_msg)
-                            self.transcription_pipeline.model = (
-                                self.transcription_pipeline.model.to_bettertransformer()
-                            )
-                            logging.info("Flash Attention 2 aplicada com sucesso.")
+                            else:
+                                self.transcription_pipeline.model = (
+                                    self.transcription_pipeline.model.to_bettertransformer()
+                                )
+                                logging.info("Flash Attention 2 aplicada com sucesso.")
                         except Exception as exc:
                             warn_msg = (
                                 f"{OPTIMIZATION_TURBO_FALLBACK_MSG} Motivo: {exc}"


### PR DESCRIPTION
## Resumo
- ajusta `_load_model_task` para aplicar `to_bettertransformer()` somente quando
  `BETTERTRANSFORMER_AVAILABLE` é `True`
- adiciona checagem de compute capability e nova mensagem de fallback
- mantém captura de exceção com mensagem padronizada

## Testes
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686188e1ddec8330875122246808a57a