### PR TITLE
Atualiza testes para novo BetterTransformer

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -5,7 +5,7 @@ import torch
 from transformers import pipeline
 
 try:
-    from optimum.bettertransformer import BetterTransformer  # noqa: F401
+    from transformers.integrations import BetterTransformer  # noqa: F401
     BETTERTRANSFORMER_AVAILABLE = True
 except Exception:
     BETTERTRANSFORMER_AVAILABLE = False
@@ -15,7 +15,7 @@ from .openrouter_api import (
 import numpy as np  # Necessário para o audio_input
 
 try:
-    from optimum.bettertransformer import BetterTransformer
+    from transformers.integrations import BetterTransformer
     BETTERTRANSFORMER_AVAILABLE = True
 except Exception:
     BETTERTRANSFORMER_AVAILABLE = True
@@ -48,7 +48,7 @@ from .config_manager import (
 )
 
 try:
-    from optimum.bettertransformer import BetterTransformer  # noqa: F401
+    from transformers.integrations import BetterTransformer  # noqa: F401
     BETTERTRANSFORMER_AVAILABLE = True
 except Exception:
     BETTERTRANSFORMER_AVAILABLE = False
@@ -410,8 +410,8 @@ class TranscriptionHandler:
                 if device.startswith("cuda"):
                     if not BETTERTRANSFORMER_AVAILABLE:
                         warn_msg = (
-                            "Pacote 'optimum[bettertransformer]' nao encontrado."
-                            " Instale manualmente com `pip install \"optimum[bettertransformer]\"`."
+                            "Pacote 'transformers' sem suporte ao BetterTransformer."
+                            " Instale manualmente com `pip install \"transformers\"`."
                             " Modo Turbo desativado."
                         )
                         logging.warning(warn_msg)

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -6,9 +6,13 @@ import threading
 import time
 import numpy as np
 import sys
+import os
 from unittest.mock import MagicMock
 
 # Stub simples de torch
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
 fake_torch = types.ModuleType("torch")
 fake_torch.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
 fake_torch.__version__ = "0.0"
@@ -25,12 +29,10 @@ fake_transformers.AutoProcessor = MagicMock()
 fake_transformers.AutoModelForSpeechSeq2Seq = MagicMock()
 sys.modules["transformers"] = fake_transformers
 
-# Stub para optimum.bettertransformer
-fake_optimum = types.ModuleType("optimum")
-fake_bt = types.ModuleType("optimum.bettertransformer")
-fake_bt.BetterTransformer = object
-sys.modules["optimum"] = fake_optimum
-sys.modules["optimum.bettertransformer"] = fake_bt
+# Stub para transformers.integrations.BetterTransformer
+fake_integrations = types.ModuleType("transformers.integrations")
+fake_integrations.BetterTransformer = object
+sys.modules["transformers.integrations"] = fake_integrations
 
 if "src.transcription_handler" in sys.modules:
     importlib.reload(sys.modules["src.transcription_handler"])
@@ -508,4 +510,4 @@ def test_warn_msg_indica_instalacao_manual(monkeypatch):
     handler._load_model_task()
 
     assert messages
-    assert "pip install \"optimum[bettertransformer]\"" in messages[0]
+    assert "pip install \"transformers\"" in messages[0]

--- a/tests/test_turbo_mode.py
+++ b/tests/test_turbo_mode.py
@@ -27,12 +27,10 @@ fake_transformers.AutoProcessor = MagicMock()
 fake_transformers.AutoModelForSpeechSeq2Seq = MagicMock()
 sys.modules["transformers"] = fake_transformers
 
-# Stub para optimum.bettertransformer
-fake_optimum = types.ModuleType("optimum")
-fake_bt = types.ModuleType("optimum.bettertransformer")
-fake_bt.BetterTransformer = object
-sys.modules["optimum"] = fake_optimum
-sys.modules["optimum.bettertransformer"] = fake_bt
+# Stub para transformers.integrations.BetterTransformer
+fake_integrations = types.ModuleType("transformers.integrations")
+fake_integrations.BetterTransformer = object
+sys.modules["transformers.integrations"] = fake_integrations
 
 if "src.transcription_handler" in sys.modules:
     importlib.reload(sys.modules["src.transcription_handler"])
@@ -161,8 +159,8 @@ def test_bettertransformer_indisponivel(monkeypatch):
     cfg = DummyConfig()
     cfg.data[USE_TURBO_CONFIG_KEY] = True
 
-    if "optimum.bettertransformer" in sys.modules:
-        del sys.modules["optimum.bettertransformer"]
+    if "transformers.integrations" in sys.modules:
+        del sys.modules["transformers.integrations"]
 
     import importlib
     import src.transcription_handler as th_module


### PR DESCRIPTION
## Resumo
- atualiza TranscriptionHandler para importar `BetterTransformer` de `transformers.integrations`
- ajusta mensagem de aviso sobre instalação manual do pacote
- adapta stubs e testes em `test_turbo_mode` e `test_transcription_handler_callback`

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686188e253988330bda1258028cae9ae