### PR TITLE
Atualizar aviso do BetterTransformer

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -400,7 +400,7 @@ class TranscriptionHandler:
                 if device.startswith("cuda"):
                     if not BETTERTRANSFORMER_AVAILABLE:
                         warn_msg = (
-                            f"{OPTIMIZATION_TURBO_FALLBACK_MSG} Motivo: BetterTransformer indisponível."
+                            f"{OPTIMIZATION_TURBO_FALLBACK_MSG} Motivo: BetterTransformer indisponível. Verifique se as versões de Transformers e Optimum são compatíveis"
                         )
                         logging.warning(warn_msg)
                         if self.on_optimization_fallback_callback:

--- a/tests/test_transcription_handler_callback.py
+++ b/tests/test_transcription_handler_callback.py
@@ -510,4 +510,7 @@ def test_warn_msg_indica_instalacao_manual(monkeypatch):
     handler._load_model_task()
 
     assert messages
-    assert "BetterTransformer indisponível" in messages[0]
+    assert (
+        "BetterTransformer indisponível. Verifique se as versões de Transformers e Optimum são compatíveis"
+        in messages[0]
+    )


### PR DESCRIPTION
## Summary
- ajustar mensagem de fallback quando o BetterTransformer não está disponível
- atualizar teste para refletir a nova mensagem

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686193e89f1c8330ad54023ae90a53d8