### PR TITLE
Add dependency check at startup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,9 @@ import logging
 import atexit
 import os # Adicionado para manipulação de caminhos
 
+# Verificação de dependências antes de carregar módulos pesados
+from src.utils import ensure_dependencies
+
 # Configuração de logging (mantida aqui para o ponto de entrada)
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stderr.reconfigure(encoding='utf-8')
@@ -13,7 +16,10 @@ logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.append(os.path.dirname(__file__))
 
-# Importar os módulos da aplicação
+# Checar dependências antes de importar módulos que as utilizam
+ensure_dependencies()
+
+# Importar os módulos da aplicação somente após a verificação
 from src.core import AppCore
 from src.ui_manager import UIManager
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,3 +1,4 @@
 from .batch_size import select_batch_size
+from .dependency_checker import ensure_dependencies
 
-__all__ = ["select_batch_size"]
+__all__ = ["select_batch_size", "ensure_dependencies"]

--- a/src/utils/dependency_checker.py
+++ b/src/utils/dependency_checker.py
@@ -1,0 +1,90 @@
+"""Funções utilitárias para verificação e instalação de dependências.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from packaging import version
+from tkinter import messagebox, Tk
+
+REQUIRED_VERSIONS = {
+    "torch": "2.7.1",
+    "transformers": "4.52.4",
+    "optimum": "1.26.1",
+    "numpy": "2.3.0",
+    "soundfile": "0.13.1",
+}
+
+
+def _prompt_user(msg: str) -> bool:
+    """Exibe um prompt no terminal ou uma janela Tkinter.
+
+    Retorna ``True`` se o usuário aceitar a instalação.
+    """
+    try:
+        root = Tk()
+        root.withdraw()
+        return messagebox.askyesno("Dependências", msg)
+    except Exception:
+        resposta = input(f"{msg} [s/N]: ").strip().lower()
+        return resposta.startswith("s") or resposta.startswith("y")
+    finally:
+        if 'root' in locals():
+            root.destroy()
+
+
+def ensure_dependencies() -> None:
+    """Verifica dependências críticas e instala versões adequadas se necessário.
+
+    Esta função checa se ``torch``, ``transformers``, ``optimum``, ``numpy`` e
+    ``soundfile`` estão instaladas com as versões mínimas especificadas em
+    ``REQUIRED_VERSIONS``. Quando alguma dependência está ausente ou com versão
+    inferior, é solicitada a permissão do usuário para executarmos ``pip
+    install`` com as versões recomendadas.
+
+    Também é verificada a compatibilidade entre ``transformers`` e ``optimum``.
+    Se ``transformers`` estiver na versão 4.49 ou superior e ``optimum`` não for
+    ao menos a versão 1.26.1, será proposto o ajuste automático.
+    """
+
+    missing_or_old = []
+
+    for pkg, min_version in REQUIRED_VERSIONS.items():
+        try:
+            module = importlib.import_module(pkg)
+            installed_version = getattr(module, "__version__", "0")
+            if version.parse(installed_version) < version.parse(min_version):
+                missing_or_old.append(f"{pkg}>={min_version}")
+        except ImportError:
+            missing_or_old.append(f"{pkg}>={min_version}")
+
+    # Checar compatibilidade transformers/optimum
+    try:
+        import transformers
+        trans_ver = version.parse(transformers.__version__)
+        if trans_ver >= version.parse("4.49"):
+            try:
+                import optimum
+                opt_ver = version.parse(optimum.__version__)
+                if opt_ver < version.parse("1.26.1"):
+                    missing_or_old.append("optimum>=1.26.1")
+            except ImportError:
+                missing_or_old.append("optimum>=1.26.1")
+    except ImportError:
+        # Caso transformers nem esteja instalado, já será capturado acima
+        pass
+
+    if not missing_or_old:
+        return
+
+    msg = (
+        "Dependências faltando ou desatualizadas: "
+        + ", ".join(missing_or_old)
+        + "\nDeseja instalar/atualizar agora?"
+    )
+    if _prompt_user(msg):
+        for pkg in missing_or_old:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+


### PR DESCRIPTION
## Summary
- add `ensure_dependencies` utility to validate critical packages
- expose `ensure_dependencies` via utils package
- call `ensure_dependencies` in main before loading heavy modules

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628f09473c8330b4f5200d1fcbf551