### PR TITLE
Atualiza instruções do Turbo Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ With your virtual environment activated, install the main dependencies with:
 pip install --upgrade torch transformers optimum
 ```
 
-These packages provide everything required to run the application. **Turbo Mode** leverages `BetterTransformer`, which is already included and does not require any additional pip extras. Enable Turbo Mode by setting `use_turbo` to `true` (and keeping `use_flash_attention_2` enabled) in the settings.
+These packages provide everything required to run the application. **Turbo Mode** needs at least `torch>=1.13`, `transformers>=4.49` and `optimum>=1.14`, which already bundle `BetterTransformer`, so no extra pip options are necessary. Enable Turbo Mode by setting `use_turbo` to `true` (and keeping `use_flash_attention_2` enabled) in the settings.
 
 ### Step 5: Run the Application
 
@@ -236,7 +236,7 @@ To access and change settings:
 
 ### Turbo Mode
 
-When `use_turbo` is set to `true`, the model is converted using `BetterTransformer` for extra speed. This optimization is ready out of the box—no pip extras required. An NVIDIA Ampere or newer GPU is still needed for effective acceleration.
+When `use_turbo` is set to `true`, the model is converted using `BetterTransformer` for extra speed. Starting from `torch` 1.13, `transformers` 4.49 and `optimum` 1.14, this transformer is integrated directly into the packages, so no pip extras are required. An NVIDIA Ampere or newer GPU is still needed for effective acceleration.
 
 ### Flash Attention 2
 


### PR DESCRIPTION
## Summary
- documenta versões mínimas de torch, transformers e optimum necessárias para o Turbo Mode
- explica que BetterTransformer já vem embutido nessas versões

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686294a807008330bb7b0cfa6e41ac03