### PR TITLE
Add note on installing test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Before running the tests, install the dependencies:
 ```bash
 pip install -r requirements-test.txt
 ```
-The testing requirements file also lists `optimum==1.26.1`.
+This step must be run before invoking `pytest` to avoid missing packages.
 
 Run the suite with:
 


### PR DESCRIPTION
## Summary
- clarify that `pip install -r requirements-test.txt` must run before executing tests

## Testing
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686294b8e840833088b76db9752bf1fd