### PR TITLE
fix dependency check

### DIFF
--- a/src/utils/dependency_checker.py
+++ b/src/utils/dependency_checker.py
@@ -4,6 +4,10 @@
 from __future__ import annotations
 
 import importlib
+from importlib.metadata import (
+    PackageNotFoundError,
+    version as pkg_version,
+)
 import subprocess
 import sys
 from packaging import version
@@ -67,7 +71,13 @@ def ensure_dependencies() -> None:
         if trans_ver >= version.parse("4.49"):
             try:
                 import optimum
-                opt_ver = version.parse(optimum.__version__)
+                opt_ver_str = getattr(optimum, "__version__", None)
+                if opt_ver_str is None:
+                    try:
+                        opt_ver_str = pkg_version("optimum")
+                    except PackageNotFoundError:
+                        opt_ver_str = "0"
+                opt_ver = version.parse(opt_ver_str)
                 if opt_ver < version.parse("1.26.1"):
                     missing_or_old.append("optimum>=1.26.1")
             except ImportError:


### PR DESCRIPTION
## Summary
- handle optimum version retrieval better when `__version__` is missing
- import `pkg_version` and `PackageNotFoundError` for fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', 'optimum', 'requests', 'setuptools')*

------
https://chatgpt.com/codex/tasks/task_e_6863dc92f418833092b8e1d3f4c3b014