### PR TITLE
Fix optimum version detection in dependency checker

### DIFF
--- a/src/utils/dependency_checker.py
+++ b/src/utils/dependency_checker.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.metadata as importlib_metadata
 import subprocess
 import sys
 from packaging import version
@@ -67,7 +68,11 @@ def ensure_dependencies() -> None:
         if trans_ver >= version.parse("4.49"):
             try:
                 import optimum
-                opt_ver = version.parse(optimum.__version__)
+                try:
+                    opt_ver_str = getattr(optimum, "__version__", None) or importlib_metadata.version("optimum")
+                except Exception:
+                    opt_ver_str = "0"
+                opt_ver = version.parse(opt_ver_str)
                 if opt_ver < version.parse("1.26.1"):
                     missing_or_old.append("optimum>=1.26.1")
             except ImportError:


### PR DESCRIPTION
## Summary
- add `importlib.metadata` usage
- fallback to 0 when optimum version cannot be obtained

## Testing
- `pytest tests/test_turbo_mode.py::test_mensagem_quando_bettertransformer_indisponivel -q`
- `pytest -q` *(fails: test_mensagem_quando_bettertransformer_indisponivel)*

------
https://chatgpt.com/codex/tasks/task_e_6863de0cd3348330ab3951d7731ebd63