### PR TITLE
Atualiza checagem de modelo carregado

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -474,7 +474,7 @@ class AppCore:
                 if self.current_state == STATE_TRANSCRIBING:
                     self._log_status("Cannot record: Transcription running.", error=True)
                     return
-                if self.transcription_handler.pipe is None or self.current_state == STATE_LOADING_MODEL:
+                if not self.transcription_handler.is_model_loaded() or self.current_state == STATE_LOADING_MODEL:
                     self._log_status("Cannot record: Model not loaded.", error=True)
                     return
                 if self.current_state.startswith("ERROR"):
@@ -526,7 +526,7 @@ class AppCore:
             if self.current_state == STATE_TRANSCRIBING:
                 self._log_status("Cannot start command: transcription in progress.", error=True)
                 return
-            if self.transcription_handler.pipe is None or self.current_state == STATE_LOADING_MODEL:
+            if not self.transcription_handler.is_model_loaded() or self.current_state == STATE_LOADING_MODEL:
                 self._log_status("Model not loaded.", error=True)
                 return
             if self.current_state.startswith("ERROR"):

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -385,6 +385,10 @@ class TranscriptionHandler:
         """Indica se há correção de texto em andamento."""
         return self.correction_in_progress
 
+    def is_model_loaded(self) -> bool:
+        """Indica se o modelo Whisper já foi carregado."""
+        return self.transcription_pipeline is not None
+
     def stop_transcription(self) -> None:
         """Sinaliza que a transcrição em andamento deve ser cancelada."""
         self.transcription_cancel_event.set()

--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -101,9 +101,12 @@ class DummyTranscriptionHandler:
                  on_transcription_result_callback,
                  on_agent_result_callback, on_segment_transcribed_callback,
                  is_state_transcribing_fn):
-        self.pipe = True
+        self.transcription_pipeline = True
         self.on_transcription_result_callback = on_transcription_result_callback
         self.config_manager = config_manager
+
+    def is_model_loaded(self):
+        return self.transcription_pipeline is not None
 
     def start_model_loading(self):
         pass

--- a/tests/test_temp_recording_cleanup.py
+++ b/tests/test_temp_recording_cleanup.py
@@ -96,8 +96,11 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
 
     class DummyTranscriptionHandler:
         def __init__(self, *a, **k):
-            self.pipe = True
+            self.transcription_pipeline = True
             self.transcription_future = None
+
+        def is_model_loaded(self):
+            return self.transcription_pipeline is not None
 
         def start_model_loading(self):
             pass


### PR DESCRIPTION
## Summary
- rename `pipe` to `transcription_pipeline` usage in AppCore
- add `is_model_loaded` method to `TranscriptionHandler`
- use `is_model_loaded` in `AppCore.start_recording` and `start_agent_command`
- adjust dummy handlers in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f8be811c8330aae544e073a2273b