### PR TITLE
Adiciona onnxruntime à verificação de dependências

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ pip install --upgrade torch transformers optimum
 
 These packages provide everything required to run the application. **Turbo Mode** needs at least `torch>=1.13`, `transformers>=4.49` and `optimum>=1.14`, which already bundle `BetterTransformer`, so no extra pip options are necessary. Enable Turbo Mode by setting `use_turbo` to `true` (and keeping `use_flash_attention_2` enabled) in the settings.
 
-`ensure_dependencies()` will check these packages when the application starts. If any are missing or outdated, you will be asked for permission to install or upgrade them automatically.
+`ensure_dependencies()` will check `torch`, `transformers`, `optimum`, `numpy`, `onnxruntime` and `soundfile` when the application starts. If any of these packages are missing or outdated, you will be asked for permission to install or upgrade them automatically.
 
 ### Step 5: Run the Application
 

--- a/src/utils/dependency_checker.py
+++ b/src/utils/dependency_checker.py
@@ -16,6 +16,7 @@ REQUIRED_VERSIONS = {
     "optimum": "1.26.1",
     "numpy": "2.3.0",
     "soundfile": "0.13.1",
+    "onnxruntime": "1.22.0",
 }
 
 

--- a/tests/test_dependency_checker.py
+++ b/tests/test_dependency_checker.py
@@ -23,3 +23,45 @@ def test_optimum_without_version(monkeypatch):
     sys.modules.pop("optimum", None)
     if previous is not None:
         sys.modules["optimum"] = previous
+
+
+def test_missing_soundfile_prompts_install(monkeypatch):
+    """A ausência de ``soundfile`` deve acionar o prompt."""
+    dep_module = importlib.reload(importlib.import_module("utils.dependency_checker"))
+
+    orig_import = importlib.import_module
+
+    def fake_import(name, package=None):
+        if name == "soundfile":
+            raise ImportError
+        return orig_import(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    prompts = []
+    monkeypatch.setattr(dep_module, "_prompt_user", lambda msg: prompts.append(msg) or False)
+    monkeypatch.setattr(dep_module.subprocess, "check_call", lambda *a, **k: None)
+
+    dep_module.ensure_dependencies()
+
+    assert any("soundfile" in m for m in prompts)
+
+
+def test_missing_onnxruntime_prompts_install(monkeypatch):
+    """A ausência de ``onnxruntime`` deve acionar o prompt."""
+    dep_module = importlib.reload(importlib.import_module("utils.dependency_checker"))
+
+    orig_import = importlib.import_module
+
+    def fake_import(name, package=None):
+        if name == "onnxruntime":
+            raise ImportError
+        return orig_import(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    prompts = []
+    monkeypatch.setattr(dep_module, "_prompt_user", lambda msg: prompts.append(msg) or False)
+    monkeypatch.setattr(dep_module.subprocess, "check_call", lambda *a, **k: None)
+
+    dep_module.ensure_dependencies()
+
+    assert any("onnxruntime" in m for m in prompts)


### PR DESCRIPTION
## Resumo
- verifica `onnxruntime` em `ensure_dependencies`
- testa ausência de `soundfile` e `onnxruntime`
- documenta dependências adicionais no README

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f8bef5088330ad259f2ec2390148