### PR TITLE
Show recording time in tooltip

### DIFF
--- a/tests/test_ui_manager_validation.py
+++ b/tests/test_ui_manager_validation.py
@@ -59,3 +59,9 @@ def test_safe_get_float_valid(monkeypatch):
     monkeypatch.setattr('src.ui_manager.messagebox.showerror', mock_error)
     assert manager._safe_get_float(var, "Teste", None) == 3.14
     mock_error.assert_not_called()
+
+
+def test_format_elapsed():
+    manager = _make_manager()
+    assert manager._format_elapsed(11) == "00:11"
+    assert manager._format_elapsed(73) == "01:13"


### PR DESCRIPTION
## Summary
- display elapsed recording time in system tray tooltip
- test time formatting helper for tooltip

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793a57f6e88330997160c58c7bd7d9