### PR TITLE
Adiciona opções de VRAM via bitsandbytes e flash-attn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ customtkinter==5.2.2
 keyboard==0.13.5
 soundfile==0.13.1
 onnxruntime==1.22.0
+bitsandbytes
+flash-attn

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -309,10 +309,12 @@ class TranscriptionHandler:
             
             model = AutoModelForSpeechSeq2Seq.from_pretrained(
                 model_id,
-                torch_dtype=torch_dtype_local,
-                low_cpu_mem_usage=True, # Ajuda a reduzir o uso de RAM durante o carregamento
+                torch_dtype=torch.float16, # Necessário para Flash Attention 2
+                low_cpu_mem_usage=True,
                 use_safetensors=True,
-                device_map={'': device} # Especifica que todo o modelo vai para o dispositivo alvo
+                device_map={'': device},
+                load_in_8bit=True,  # Novo parâmetro para reduzir VRAM
+                attn_implementation="flash_attention_2"  # Novo parâmetro para aceleração
             )
             
             # Retorna o modelo e o processador para que a pipeline seja criada fora desta função


### PR DESCRIPTION
## Resumo
- inclui `bitsandbytes` e `flash-attn` em `requirements.txt`
- habilita load em 8 bits e Flash Attention 2 na carga do modelo

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687942911d74833086d9c3683f587df0