### PR TITLE
Add GPU cache cleanup on startup and shutdown

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -751,6 +751,12 @@ class AppCore:
         except Exception as e:
             logging.error(f"Error during hotkey cleanup in shutdown: {e}")
 
+        if self.transcription_handler:
+            try:
+                self.transcription_handler.shutdown()
+            except Exception as e:
+                logging.error(f"Error shutting down TranscriptionHandler executor: {e}")
+
         if self.ui_manager and getattr(self.ui_manager, "tray_icon", None):
             try:
                 self.ui_manager.tray_icon.stop()
@@ -774,12 +780,6 @@ class AppCore:
                 except Exception as e:
                     logging.error(f"Error stopping audio stream on close: {e}")
             self.audio_handler.recording_data.clear()
-
-        if self.transcription_handler:
-            try:
-                self.transcription_handler.shutdown()
-            except Exception as e:
-                logging.error(f"Error shutting down TranscriptionHandler executor: {e}")
 
         if hasattr(self.audio_handler, "cleanup"):
             try:

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -124,6 +124,8 @@ class TranscriptionHandler:
         # Este método será chamado para orquestrar o carregamento do modelo e a criação da pipeline
         # Ele será chamado por start_model_loading
         try:
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
             model, processor = self._load_model_task()
             if model and processor:
                 device = f"cuda:{self.gpu_index}" if self.gpu_index >= 0 and torch.cuda.is_available() else "cpu"
@@ -463,3 +465,6 @@ class TranscriptionHandler:
             self.transcription_executor.shutdown(wait=False, cancel_futures=True)
         except Exception as e:
             logging.error(f"Erro ao encerrar o executor de transcrição: {e}")
+        finally:
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()


### PR DESCRIPTION
## Summary
- free GPU cache when initializing the transcription pipeline
- clear GPU cache when shutting down the transcriber
- ensure TranscriptionHandler shutdown is invoked early during Core shutdown

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687942c05db483309648b45df69258aa