### PR TITLE
Refatorar gravação para arquivo temporário

### DIFF
--- a/tests/test_appcore_state.py
+++ b/tests/test_appcore_state.py
@@ -3,7 +3,6 @@ import time
 import threading
 import os
 import sys
-import numpy as np
 from unittest.mock import MagicMock
 
 # Stub external dependencies before importing core module
@@ -90,8 +89,7 @@ class DummyAudioHandler:
     def stop_recording(self):
         self.is_recording = False
         self.on_recording_state_change_callback(core_module.STATE_TRANSCRIBING)
-        audio = np.zeros(1600, dtype=np.float32)
-        self.on_audio_segment_ready_callback(audio)
+        self.on_audio_segment_ready_callback("dummy.wav")
 
 class DummyTranscriptionHandler:
     def __init__(self, config_manager, gemini_api_client, on_model_ready_callback,
@@ -105,7 +103,7 @@ class DummyTranscriptionHandler:
     def start_model_loading(self):
         pass
 
-    def transcribe_audio_segment(self, audio_data, agent_mode=False):
+    def transcribe_audio_segment(self, audio_file_path, agent_mode=False):
         if self.config_manager.get(TEXT_CORRECTION_ENABLED_CONFIG_KEY):
             def _run():
                 time.sleep(0.01)

--- a/tests/test_audio_handler.py
+++ b/tests/test_audio_handler.py
@@ -73,15 +73,16 @@ class AudioHandlerTest(unittest.TestCase):
     def test_start_and_stop_recording_success(self):
         results = []
 
-        def on_ready(audio):
-            results.append(audio)
+        def on_ready(path):
+            results.append(path)
 
         handler = AudioHandler(self.config, on_ready, lambda *_: None)
 
         def fake_record_audio_task(self):
             self.stream_started = True
             while not self._stop_event.is_set() and self.is_recording:
-                self.recording_data.append(np.zeros((2, 1), dtype=np.float32))
+                self._sf_writer.write(np.zeros((2, 1), dtype=np.float32))
+                self._sample_count += 2
                 time.sleep(0.01)
             self.stream_started = False
             self._stop_event.clear()
@@ -97,6 +98,7 @@ class AudioHandlerTest(unittest.TestCase):
         self.assertTrue(started)
         self.assertTrue(stopped)
         self.assertTrue(len(results) == 1)
+        self.assertTrue(os.path.exists(results[0]))
         mock_warn.assert_not_called()
 
     def test_temp_recording_saved_and_cleanup(self):
@@ -108,7 +110,8 @@ class AudioHandlerTest(unittest.TestCase):
         def fake_record_audio_task(self):
             self.stream_started = True
             while not self._stop_event.is_set() and self.is_recording:
-                self.recording_data.append(np.zeros((2, 1), dtype=np.float32))
+                self._sf_writer.write(np.zeros((2, 1), dtype=np.float32))
+                self._sample_count += 2
                 time.sleep(0.01)
             self.stream_started = False
             self._stop_event.clear()
@@ -142,7 +145,8 @@ class AudioHandlerTest(unittest.TestCase):
         def fake_record_audio_task(self):
             self.stream_started = True
             while not self._stop_event.is_set() and self.is_recording:
-                self.recording_data.append(np.zeros((2, 1), dtype=np.float32))
+                self._sf_writer.write(np.zeros((2, 1), dtype=np.float32))
+                self._sample_count += 2
                 time.sleep(0.01)
             self.stream_started = False
             self._stop_event.clear()

--- a/tests/test_temp_recording_cleanup.py
+++ b/tests/test_temp_recording_cleanup.py
@@ -90,8 +90,7 @@ def test_temp_recording_cleanup(tmp_path, monkeypatch):
             path = tmp_path / "temp_recording_test.wav"
             path.write_text("data")
             self.temp_file_path = str(path)
-            audio = np.zeros(1600, dtype=np.float32)
-            self.on_audio_segment_ready_callback(audio)
+            self.on_audio_segment_ready_callback(str(path))
 
     class DummyTranscriptionHandler:
         def __init__(self, *a, **k):


### PR DESCRIPTION
## Resumo
- refatora `AudioHandler` para gravar diretamente em arquivo temporário
- adapta `AppCore` e `TranscriptionHandler` para receber caminho de áudio
- ajusta testes para nova interface

## Testes
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879429cab58833083f1bc5b0d631bd3