### PR TITLE
Add record_to_memory config option

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -69,6 +69,7 @@ Transcribed speech: {text}""",
         "gemini-2.5-pro"
     ],
     "save_temp_recordings": False,
+    "record_to_memory": False,
     "min_transcription_duration": 1.0 # Nova configuração
 }
 
@@ -86,6 +87,7 @@ BATCH_SIZE_MODE_CONFIG_KEY = "batch_size_mode" # Novo
 MANUAL_BATCH_SIZE_CONFIG_KEY = "manual_batch_size" # Novo
 GPU_INDEX_CONFIG_KEY = "gpu_index"
 SAVE_TEMP_RECORDINGS_CONFIG_KEY = "save_temp_recordings"
+RECORD_TO_MEMORY_CONFIG_KEY = "record_to_memory"
 DISPLAY_TRANSCRIPTS_KEY = "display_transcripts_in_terminal"
 USE_VAD_CONFIG_KEY = "use_vad"
 VAD_THRESHOLD_CONFIG_KEY = "vad_threshold"
@@ -219,6 +221,14 @@ class ConfigManager:
             self.config.get(
                 SAVE_TEMP_RECORDINGS_CONFIG_KEY,
                 self.default_config[SAVE_TEMP_RECORDINGS_CONFIG_KEY],
+            )
+        )
+
+        # Opção para gravar diretamente na memória em vez de arquivo temporário
+        self.config[RECORD_TO_MEMORY_CONFIG_KEY] = _parse_bool(
+            self.config.get(
+                RECORD_TO_MEMORY_CONFIG_KEY,
+                self.default_config[RECORD_TO_MEMORY_CONFIG_KEY],
             )
         )
     
@@ -416,3 +426,12 @@ class ConfigManager:
 
     def set_save_temp_recordings(self, value: bool):
         self.config[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = bool(value)
+
+    def get_record_to_memory(self):
+        return self.config.get(
+            RECORD_TO_MEMORY_CONFIG_KEY,
+            self.default_config[RECORD_TO_MEMORY_CONFIG_KEY],
+        )
+
+    def set_record_to_memory(self, value: bool):
+        self.config[RECORD_TO_MEMORY_CONFIG_KEY] = bool(value)

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -48,6 +48,7 @@ def test_parse_bool_values(tmp_path, monkeypatch, value, expected):
         "display_transcripts_in_terminal": value,
         "save_temp_recordings": value,
         "use_vad": value,
+        "record_to_memory": value,
     }
 
     cfg_path.write_text(json.dumps(config))
@@ -61,3 +62,4 @@ def test_parse_bool_values(tmp_path, monkeypatch, value, expected):
     assert cm.get(config_manager.DISPLAY_TRANSCRIPTS_KEY) is expected
     assert cm.get(config_manager.SAVE_TEMP_RECORDINGS_CONFIG_KEY) is expected
     assert cm.get(config_manager.USE_VAD_CONFIG_KEY) is expected
+    assert cm.get_record_to_memory() is expected


### PR DESCRIPTION
## Summary
- include `record_to_memory` in the default configuration
- validate and parse this option when loading configs
- expose helpers `get_record_to_memory` and `set_record_to_memory`
- test boolean parsing for new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc1c19f908330a552653c94e8eab8