### PR TITLE
Implement record_to_memory support in AudioHandler

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -69,6 +69,7 @@ Transcribed speech: {text}""",
         "gemini-2.5-pro"
     ],
     "save_temp_recordings": False,
+    "record_to_memory": False,
     "min_transcription_duration": 1.0 # Nova configuração
 }
 
@@ -86,6 +87,7 @@ BATCH_SIZE_MODE_CONFIG_KEY = "batch_size_mode" # Novo
 MANUAL_BATCH_SIZE_CONFIG_KEY = "manual_batch_size" # Novo
 GPU_INDEX_CONFIG_KEY = "gpu_index"
 SAVE_TEMP_RECORDINGS_CONFIG_KEY = "save_temp_recordings"
+RECORD_TO_MEMORY_CONFIG_KEY = "record_to_memory"
 DISPLAY_TRANSCRIPTS_KEY = "display_transcripts_in_terminal"
 USE_VAD_CONFIG_KEY = "use_vad"
 VAD_THRESHOLD_CONFIG_KEY = "vad_threshold"
@@ -219,6 +221,14 @@ class ConfigManager:
             self.config.get(
                 SAVE_TEMP_RECORDINGS_CONFIG_KEY,
                 self.default_config[SAVE_TEMP_RECORDINGS_CONFIG_KEY],
+            )
+        )
+
+        # Gravar áudio diretamente na memória em vez de arquivo
+        self.config[RECORD_TO_MEMORY_CONFIG_KEY] = _parse_bool(
+            self.config.get(
+                RECORD_TO_MEMORY_CONFIG_KEY,
+                self.default_config[RECORD_TO_MEMORY_CONFIG_KEY],
             )
         )
     
@@ -416,3 +426,12 @@ class ConfigManager:
 
     def set_save_temp_recordings(self, value: bool):
         self.config[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = bool(value)
+
+    def get_record_to_memory(self):
+        return self.config.get(
+            RECORD_TO_MEMORY_CONFIG_KEY,
+            self.default_config[RECORD_TO_MEMORY_CONFIG_KEY],
+        )
+
+    def set_record_to_memory(self, value: bool):
+        self.config[RECORD_TO_MEMORY_CONFIG_KEY] = bool(value)

--- a/tests/test_audio_handler.py
+++ b/tests/test_audio_handler.py
@@ -40,6 +40,7 @@ class DummyConfig:
             'use_vad': False,
             'vad_threshold': 0.5,
             'vad_silence_duration': 0.5,
+            'record_to_memory': False,
             SAVE_TEMP_RECORDINGS_CONFIG_KEY: False,
         }
 
@@ -161,6 +162,40 @@ class AudioHandlerTest(unittest.TestCase):
                         handler.stop_recording()
 
         self.assertIsNone(handler.temp_file_path)
+
+    def test_record_to_memory_mode(self):
+        self.config.data['record_to_memory'] = True
+        results = []
+
+        def on_ready(data):
+            results.append(data)
+
+        handler = AudioHandler(self.config, on_ready, lambda *_: None)
+
+        def fake_record_audio_task(self):
+            self.stream_started = True
+            while not self._stop_event.is_set() and self.is_recording:
+                if self.record_to_memory:
+                    self._frame_buffer.append(np.zeros((2, 1), dtype=np.float32))
+                else:
+                    self._sf_writer.write(np.zeros((2, 1), dtype=np.float32))
+                self._sample_count += 2
+                time.sleep(0.01)
+            self.stream_started = False
+            self._stop_event.clear()
+            self._record_thread = None
+
+        with patch.object(AudioHandler, '_record_audio_task', fake_record_audio_task):
+            with patch.object(AudioHandler, '_play_generated_tone_stream', lambda *a, **k: None):
+                started = handler.start_recording()
+                time.sleep(0.05)
+                stopped = handler.stop_recording()
+
+        self.assertTrue(started)
+        self.assertTrue(stopped)
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], np.ndarray)
+        self.assertEqual(results[0].shape[1], 1)
 
     def test_close_input_stream_thread_does_not_block(self):
         class SlowStream:


### PR DESCRIPTION
## Summary
- add `record_to_memory` setting to configuration
- support recording to memory in `AudioHandler`
- ensure cleanup works with in-memory mode
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc1c1dfbc8330a0e5e8bdfbf30b04