### PR TITLE
Atualizar README com record_to_memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ To access and change settings:
 *   **Gemini Models (one per line):** Manage the list of available Gemini models in the dropdown.
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
 *   **Batch Size:** Configure the batch size for transcription.
-*   **Save Temporary Recordings:** When enabled, the captured audio is stored as `temp_recording_<timestamp>.wav` in the application folder. This temporary file is automatically deleted once transcription completes.
+*   **Record to Memory:** Keep the captured audio only in memory instead of creating a temporary file (default `false`). When enabled, the **Save Temporary Recordings** option is ignored.
+*   **Save Temporary Recordings:** When enabled, the captured audio is stored as `temp_recording_<timestamp>.wav` in the application folder. This temporary file is automatically deleted once transcription completes. This setting has no effect when **Record to Memory** is active.
 *   **Display Transcript in Terminal:** Show the final text in the terminal window after each recording.
 *   **Use VAD:** enables silence removal without automatically stopping the recording.
 *   **VAD Threshold:** sensitivity of voice detection.


### PR DESCRIPTION
## Summary
- document `record_to_memory` option in config section
- note how it interacts with `save_temp_recordings`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc1c3d7548330991bf8badc94fb10