### PR TITLE
Add storage mode settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ To access and change settings:
 *   **Gemini Models (one per line):** Manage the list of available Gemini models in the dropdown.
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
 *   **Batch Size:** Configure the batch size for transcription.
+*   **Record Storage Mode:** Determines where recordings are kept. Use `auto` (default) to keep audio in memory while there are at least `min_free_ram_mb` megabytes free and the duration is below `max_in_memory_seconds`. Choose `memory` to always keep data in RAM or `disk` to always save a temporary file.
+*   **Max In-Memory Seconds:** Maximum duration stored in RAM when using `auto`.
+*   **Min Free RAM (MB):** Minimum available memory required for in-memory storage when `record_storage_mode` is `auto`.
 *   **Record to Memory:** Keep the captured audio only in memory instead of creating a temporary file (default `false`). When enabled, the **Save Temporary Recordings** option is ignored.
 *   **Save Temporary Recordings:** When enabled, the captured audio is stored as `temp_recording_<timestamp>.wav` in the application folder. This temporary file is automatically deleted once transcription completes. This setting has no effect when **Record to Memory** is active.
 *   **Display Transcript in Terminal:** Show the final text in the terminal window after each recording.

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -63,3 +63,59 @@ def test_parse_bool_values(tmp_path, monkeypatch, value, expected):
     assert cm.get(config_manager.SAVE_TEMP_RECORDINGS_CONFIG_KEY) is expected
     assert cm.get(config_manager.USE_VAD_CONFIG_KEY) is expected
     assert cm.get_record_to_memory() is expected
+
+
+def test_new_keys_defaults(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    secrets_path = tmp_path / "secrets.json"
+    cfg_path.write_text("{}")
+    monkeypatch.setattr(config_manager, "SECRETS_FILE", str(secrets_path))
+
+    cm = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+
+    assert cm.get_record_storage_mode() == config_manager.DEFAULT_CONFIG[
+        "record_storage_mode"
+    ]
+    assert cm.get_max_in_memory_seconds() == config_manager.DEFAULT_CONFIG[
+        "max_in_memory_seconds"
+    ]
+    assert cm.get_min_free_ram_mb() == config_manager.DEFAULT_CONFIG[
+        "min_free_ram_mb"
+    ]
+
+
+@pytest.mark.parametrize("legacy_val,expected", [(True, "memory"), (False, "disk")])
+def test_migrate_record_to_memory(tmp_path, monkeypatch, legacy_val, expected):
+    cfg_path = tmp_path / "config.json"
+    secrets_path = tmp_path / "secrets.json"
+    cfg_path.write_text(json.dumps({"record_to_memory": legacy_val}))
+    monkeypatch.setattr(config_manager, "SECRETS_FILE", str(secrets_path))
+
+    cm = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+
+    assert cm.get_record_storage_mode() == expected
+
+
+def test_setters_for_new_keys(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    secrets_path = tmp_path / "secrets.json"
+    monkeypatch.setattr(config_manager, "SECRETS_FILE", str(secrets_path))
+
+    cm = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+
+    cm.set_record_storage_mode("memory")
+    cm.set_max_in_memory_seconds(99)
+    cm.set_min_free_ram_mb(123)
+
+    assert cm.get_record_storage_mode() == "memory"
+    assert cm.get_max_in_memory_seconds() == 99
+    assert cm.get_min_free_ram_mb() == 123


### PR DESCRIPTION
## Summary
- add new configuration keys for record storage
- migrate legacy `record_to_memory`
- update tests for ConfigManager
- document storage mode settings in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d6440349483309181badeae346dcb