### PR TITLE
Allow hybrid record storage mode

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -248,7 +248,10 @@ class ConfigManager:
                 self.default_config[RECORD_STORAGE_MODE_CONFIG_KEY],
             )
         ).lower()
-        allowed_storage_modes = ["disk", "memory", "auto"]
+        if self.config[RECORD_STORAGE_MODE_CONFIG_KEY] == "hybrid":
+            logging.info("record_storage_mode 'hybrid' mapeado para 'auto'.")
+            self.config[RECORD_STORAGE_MODE_CONFIG_KEY] = "auto"
+        allowed_storage_modes = ["disk", "memory", "auto", "hybrid"]
         if self.config[RECORD_STORAGE_MODE_CONFIG_KEY] not in allowed_storage_modes:
             logging.warning(
                 f"Invalid record_storage_mode '{self.config[RECORD_STORAGE_MODE_CONFIG_KEY]}'. "

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -65,3 +65,18 @@ def test_parse_bool_values(tmp_path, monkeypatch, value, expected):
     assert cm.get(config_manager.USE_VAD_CONFIG_KEY) is expected
     assert cm.get_record_to_memory() is expected
     assert cm.get_max_memory_seconds() == 5
+
+
+def test_hybrid_storage_mode_maps_to_auto(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    secrets_path = tmp_path / "secrets.json"
+
+    cfg_path.write_text(json.dumps({"record_storage_mode": "hybrid"}))
+    monkeypatch.setattr(config_manager, "SECRETS_FILE", str(secrets_path))
+
+    cm = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+
+    assert cm.get_record_storage_mode() == "auto"


### PR DESCRIPTION
## Summary
- accept `hybrid` in record storage mode config
- normalize `hybrid` to `auto`
- test that `hybrid` is treated as `auto`

## Testing
- `pytest -q` *(fails: AudioHandlerTest.test_in_memory_migrate_to_file, AudioHandlerTest.test_start_and_stop_recording_success, AudioHandlerTest.test_temp_recording_saved_and_cleanup)*

------
https://chatgpt.com/codex/tasks/task_e_687e52fea8808330809286a46705b66b