### PR TITLE
Implementação de cálculo automático de áudio em RAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The application features a flexible automatic approach to storing captured audio
 ### Configuration Parameters
 
 * `record_storage_mode` – Choose `"memory"`, `"disk"`, or `"auto"` (default). Auto uses memory whenever possible and falls back to the file system when limits are exceeded.
+* `max_memory_seconds_mode` – `"manual"` (default) uses the value of `max_memory_seconds`. Set to `"auto"` to compute a limit based on free RAM at the start of each recording.
 * `max_memory_seconds` – Maximum length of audio (in seconds) to keep in RAM before switching to disk.
 * `min_free_ram_mb` – Minimum free RAM required to continue storing audio in memory. If available memory drops below this value, the app writes new chunks directly to disk until memory usage is safe again.
 * `record_storage_limit` – Maximum number of temporary recordings to keep. Older recordings are deleted when this limit is exceeded.
@@ -109,6 +110,7 @@ The application features a flexible automatic approach to storing captured audio
 ```json
 {
     "record_storage_mode": "auto",
+    "max_memory_seconds_mode": "auto",
     "max_memory_seconds": 30,
     "min_free_ram_mb": 1000
 }
@@ -259,6 +261,7 @@ To access and change settings:
 *   **Batch Size:** Configure the batch size for transcription.
 *   **Record Storage Mode:** Choose between always using memory, always using disk, or automatically selecting based on free RAM.
 *   **Minimum Free RAM (MB):** Threshold used in auto mode to decide when audio can be stored in memory.
+*   **Max Memory Seconds Mode:** Set to "auto" to adjust the retention limit dynamically or "manual" to use a fixed value.
 *   **Max Memory Seconds:** Limits the amount of audio kept in RAM when auto mode is active.
 *   **Record to Memory:** Keep the captured audio only in memory instead of creating a temporary file (default `false`). When enabled, the **Save Temporary Recordings** option is ignored.
 *   **Storage Strategy:** Select "File" to always store audio as a temporary WAV file or "Memory" to keep it directly in RAM.

--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -33,7 +33,10 @@ class AudioHandler:
         self.record_storage_mode = "auto"
         self.record_storage_limit = 0
         self.in_memory_mode = False
+        self.max_memory_seconds_mode = "manual"
         self.max_memory_seconds = 30
+        self.current_max_memory_seconds = 30
+        self._memory_limit_samples = int(AUDIO_SAMPLE_RATE * self.current_max_memory_seconds)
         self.min_free_ram_mb = 1000
         self.sound_enabled = True
         self.sound_frequency = 400
@@ -95,9 +98,11 @@ class AudioHandler:
                     self._memory_samples += len(write_data)
 
                     # Verifica se é necessário mover para o disco
-                    max_samples = int(self.max_memory_seconds * AUDIO_SAMPLE_RATE)
+                    max_samples = self._memory_limit_samples
                     if self.record_storage_mode == 'auto' and self._memory_samples > max_samples:
-                        logging.info(f"Duração da gravação excedeu {self.max_memory_seconds}s. Migrando da RAM para o disco.")
+                        logging.info(
+                            f"Duração da gravação excedeu {self.current_max_memory_seconds}s. Migrando da RAM para o disco."
+                        )
                         self._migrate_to_file()
                 else:
                     if self._sf_writer:
@@ -179,6 +184,7 @@ class AudioHandler:
             data = np.concatenate(self._audio_frames, axis=0)
             self._sf_writer.write(data)
             self._audio_frames = []
+        self._memory_samples = 0
         self.in_memory_mode = False
 
     def start_recording(self):
@@ -212,6 +218,12 @@ class AudioHandler:
             self.in_memory_mode,
             reason,
         )
+
+        if self.max_memory_seconds_mode == "auto":
+            self.current_max_memory_seconds = self._calculate_auto_memory_seconds()
+        else:
+            self.current_max_memory_seconds = self.max_memory_seconds
+        self._memory_limit_samples = int(self.current_max_memory_seconds * AUDIO_SAMPLE_RATE)
 
         with self.storage_lock:
             self.is_recording = True
@@ -311,8 +323,11 @@ class AudioHandler:
                             os.remove(filename)
                     except Exception:
                         pass
-                    self.temp_file_path = None
+                    self.temp_file_path = filename
             self.on_audio_segment_ready_callback(self.temp_file_path)
+
+        if not self.config_manager.get(SAVE_TEMP_RECORDINGS_CONFIG_KEY):
+            self._cleanup_temp_file()
 
         # Clear in-memory data; temporary file is kept for downstream processing
         self._audio_frames = []
@@ -406,6 +421,7 @@ class AudioHandler:
         """Carrega ou atualiza as configurações a partir do ConfigManager."""
         self.record_storage_mode = self.config_manager.get("record_storage_mode", "auto")
         self.record_storage_limit = self.config_manager.get("record_storage_limit", 0)
+        self.max_memory_seconds_mode = self.config_manager.get("max_memory_seconds_mode", "manual")
         self.max_memory_seconds = self.config_manager.get("max_memory_seconds", 30)
         self.min_free_ram_mb = self.config_manager.get("min_free_ram_mb", 1000)
 
@@ -436,6 +452,19 @@ class AudioHandler:
             self.record_storage_mode,
             self.record_storage_limit,
         )
+
+    def _calculate_auto_memory_seconds(self) -> float:
+        """Calcula o tempo máximo em memória baseado na RAM livre."""
+        available_mb = get_available_memory_mb()
+        usable_mb = max(0, available_mb - self.min_free_ram_mb)
+        bytes_per_sec_mb = 64 / 1024  # 64 KB em MB
+        seconds = usable_mb / bytes_per_sec_mb if bytes_per_sec_mb else 0
+        logging.debug(
+            "Limite automático calculado: %.1fs (RAM livre %.0fMB)",
+            seconds,
+            available_mb,
+        )
+        return max(0.0, seconds)
 
     def _cleanup_temp_file(self):
         with self.storage_lock:

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -72,6 +72,7 @@ Transcribed speech: {text}""",
     "record_to_memory": False,
     "record_storage_mode": "auto",
     "record_storage_limit": 0,
+    "max_memory_seconds_mode": "manual",
     "max_memory_seconds": 30,
     "min_free_ram_mb": 1000,
     "min_transcription_duration": 1.0 # Nova configuração
@@ -94,6 +95,7 @@ SAVE_TEMP_RECORDINGS_CONFIG_KEY = "save_temp_recordings"
 RECORD_TO_MEMORY_CONFIG_KEY = "record_to_memory"
 RECORD_STORAGE_MODE_CONFIG_KEY = "record_storage_mode"
 RECORD_STORAGE_LIMIT_CONFIG_KEY = "record_storage_limit"
+MAX_MEMORY_SECONDS_MODE_CONFIG_KEY = "max_memory_seconds_mode"
 DISPLAY_TRANSCRIPTS_KEY = "display_transcripts_in_terminal"
 USE_VAD_CONFIG_KEY = "use_vad"
 VAD_THRESHOLD_CONFIG_KEY = "vad_threshold"
@@ -270,6 +272,21 @@ class ConfigManager:
         except (ValueError, TypeError):
             self.config[RECORD_STORAGE_LIMIT_CONFIG_KEY] = self.default_config[
                 RECORD_STORAGE_LIMIT_CONFIG_KEY
+            ]
+
+        self.config[MAX_MEMORY_SECONDS_MODE_CONFIG_KEY] = str(
+            self.config.get(
+                MAX_MEMORY_SECONDS_MODE_CONFIG_KEY,
+                self.default_config[MAX_MEMORY_SECONDS_MODE_CONFIG_KEY],
+            )
+        ).lower()
+        if self.config[MAX_MEMORY_SECONDS_MODE_CONFIG_KEY] not in ["manual", "auto"]:
+            logging.warning(
+                f"Invalid max_memory_seconds_mode '{self.config[MAX_MEMORY_SECONDS_MODE_CONFIG_KEY]}'. "
+                f"Falling back to '{self.default_config[MAX_MEMORY_SECONDS_MODE_CONFIG_KEY]}'."
+            )
+            self.config[MAX_MEMORY_SECONDS_MODE_CONFIG_KEY] = self.default_config[
+                MAX_MEMORY_SECONDS_MODE_CONFIG_KEY
             ]
 
         try:
@@ -517,6 +534,20 @@ class ConfigManager:
         except (ValueError, TypeError):
             self.config[RECORD_STORAGE_LIMIT_CONFIG_KEY] = self.default_config[
                 RECORD_STORAGE_LIMIT_CONFIG_KEY
+            ]
+
+    def get_max_memory_seconds_mode(self):
+        return self.config.get(
+            MAX_MEMORY_SECONDS_MODE_CONFIG_KEY,
+            self.default_config[MAX_MEMORY_SECONDS_MODE_CONFIG_KEY],
+        )
+
+    def set_max_memory_seconds_mode(self, value: str):
+        if value in ["manual", "auto"]:
+            self.config[MAX_MEMORY_SECONDS_MODE_CONFIG_KEY] = value
+        else:
+            self.config[MAX_MEMORY_SECONDS_MODE_CONFIG_KEY] = self.default_config[
+                MAX_MEMORY_SECONDS_MODE_CONFIG_KEY
             ]
 
     def get_max_memory_seconds(self):

--- a/src/core.py
+++ b/src/core.py
@@ -571,6 +571,7 @@ class AppCore:
                 "new_min_transcription_duration": "min_transcription_duration",
                 "new_save_temp_recordings": SAVE_TEMP_RECORDINGS_CONFIG_KEY,
                 "new_record_to_memory": "record_to_memory",
+                "new_max_memory_seconds_mode": "max_memory_seconds_mode",
                 "new_max_memory_seconds": "max_memory_seconds",
                 "new_gemini_model_options": "gemini_model_options",
                 "new_use_vad": "use_vad",
@@ -681,7 +682,7 @@ class AppCore:
         self._apply_initial_config_to_core_attributes()
 
         # Propagar para TranscriptionHandler se for uma configuração relevante
-        if key in ["batch_size_mode", "manual_batch_size", "gpu_index", "min_transcription_duration", "record_to_memory", "max_memory_seconds"]:
+        if key in ["batch_size_mode", "manual_batch_size", "gpu_index", "min_transcription_duration", "record_to_memory", "max_memory_seconds", "max_memory_seconds_mode"]:
             self.transcription_handler.config_manager = self.config_manager # Garantir que a referência esteja atualizada
             self.transcription_handler.update_config()
             logging.info(f"TranscriptionHandler: Configurações de transcrição atualizadas via update_setting para '{key}'.")

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -245,6 +245,9 @@ class UIManager:
                 storage_strategy_var = ctk.StringVar(
                     value="Memory" if self.config_manager.get_record_to_memory() else "File"
                 )
+                max_memory_seconds_mode_var = ctk.StringVar(
+                    value=self.config_manager.get("max_memory_seconds_mode", "manual")
+                )
                 max_memory_seconds_var = ctk.DoubleVar(
                     value=self.config_manager.get("max_memory_seconds")
                 )
@@ -324,6 +327,7 @@ class UIManager:
                         return
                     save_temp_recordings_to_apply = save_temp_recordings_var.get()
                     display_transcripts_to_apply = display_transcripts_var.get()
+                    max_memory_seconds_mode_to_apply = max_memory_seconds_mode_var.get()
                     max_memory_seconds_to_apply = self._safe_get_float(max_memory_seconds_var, "Max Memory Retention", settings_win)
                     if max_memory_seconds_to_apply is None:
                         return
@@ -372,6 +376,7 @@ class UIManager:
                         new_min_transcription_duration=min_transcription_duration_to_apply,
                         new_save_temp_recordings=save_temp_recordings_to_apply,
                         new_record_to_memory=(storage_strategy_var.get() == "Memory"),
+                        new_max_memory_seconds_mode=max_memory_seconds_mode_to_apply,
                         new_max_memory_seconds=max_memory_seconds_to_apply,
                         new_use_vad=use_vad_to_apply,
                         new_vad_threshold=vad_threshold_to_apply,
@@ -439,6 +444,7 @@ class UIManager:
                     display_transcripts_var.set(DEFAULT_CONFIG["display_transcripts_in_terminal"])
                     storage_strategy_var.set("Memory" if DEFAULT_CONFIG["record_to_memory"] else "File")
                     max_memory_seconds_var.set(DEFAULT_CONFIG["max_memory_seconds"])
+                    max_memory_seconds_mode_var.set(DEFAULT_CONFIG["max_memory_seconds_mode"])
 
                     self.config_manager.save_config()
 
@@ -660,6 +666,14 @@ class UIManager:
                 mem_time_entry = ctk.CTkEntry(mem_time_frame, textvariable=max_memory_seconds_var, width=60)
                 mem_time_entry.pack(side="left", padx=5)
                 Tooltip(mem_time_entry, "Limit for in-memory recordings.")
+                mem_mode_menu = ctk.CTkOptionMenu(
+                    mem_time_frame,
+                    variable=max_memory_seconds_mode_var,
+                    values=["manual", "auto"],
+                    width=80,
+                )
+                mem_mode_menu.pack(side="left", padx=5)
+                Tooltip(mem_mode_menu, "Choose manual or auto calculation.")
 
                 display_transcripts_frame = ctk.CTkFrame(transcription_frame)
                 display_transcripts_frame.pack(fill="x", pady=5)

--- a/tests/test_audio_handler.py
+++ b/tests/test_audio_handler.py
@@ -229,6 +229,7 @@ class AudioHandlerTest(unittest.TestCase):
         self.assertFalse(os.path.exists(results[0]))
         self.assertFalse(handler.in_memory_mode)
         self.assertEqual(handler._audio_frames, [])
+        self.assertEqual(handler._memory_samples, 0)
 
     def test_record_to_memory_returns_flat_array(self):
         results = []
@@ -297,6 +298,15 @@ class AudioHandlerTest(unittest.TestCase):
         alive_after = t.is_alive()
         t.join()
         self.assertTrue(alive_after)
+
+    def test_calculate_auto_memory_seconds(self):
+        self.config.data["max_memory_seconds_mode"] = "auto"
+        self.config.data["min_free_ram_mb"] = 100
+        handler = AudioHandler(self.config, lambda *_: None, lambda *_: None)
+        with patch("src.audio_handler.get_available_memory_mb", return_value=160):
+            secs = handler._calculate_auto_memory_seconds()
+        expected = (160 - 100) / (64 / 1024)
+        self.assertAlmostEqual(secs, expected)
 
 
 if __name__ == '__main__':

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -80,3 +80,18 @@ def test_hybrid_storage_mode_maps_to_auto(tmp_path, monkeypatch):
     )
 
     assert cm.get_record_storage_mode() == "auto"
+
+
+def test_max_memory_seconds_mode(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    secrets_path = tmp_path / "secrets.json"
+
+    cfg_path.write_text(json.dumps({"max_memory_seconds_mode": "auto"}))
+    monkeypatch.setattr(config_manager, "SECRETS_FILE", str(secrets_path))
+
+    cm = config_manager.ConfigManager(
+        config_file=str(cfg_path),
+        default_config=config_manager.DEFAULT_CONFIG,
+    )
+
+    assert cm.get_max_memory_seconds_mode() == "auto"


### PR DESCRIPTION
## Summary
- adiciona modo `max_memory_seconds_mode` ao ConfigManager
- atualiza AudioHandler para calcular tempo na RAM dinamicamente
- inclui controles no UI para o novo modo
- documenta a configuração no README
- ajusta tests para novo comportamento
- zera contador de memória ao migrar para arquivo temporário

## Testing
- `pip install -r requirements-test.txt`
- `pip install setuptools`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e59ae410883309b40a4fa0cce5b55