### PR TITLE
Remove repeated assignment

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -249,12 +249,6 @@ class UIManager:
                 max_memory_seconds_mode_var = ctk.StringVar(
                     value=self.config_manager.get("max_memory_seconds_mode", "manual")
                 )
-                max_memory_seconds_mode_var = ctk.StringVar(
-                    value=self.config_manager.get("max_memory_seconds_mode", "manual")
-                )
-                max_memory_seconds_mode_var = ctk.StringVar(
-                    value=self.config_manager.get("max_memory_seconds_mode", "manual")
-                )
                 max_memory_seconds_var = ctk.DoubleVar(
                     value=self.config_manager.get("max_memory_seconds")
                 )


### PR DESCRIPTION
## Summary
- remove redundant assignments to `max_memory_seconds_mode_var` in the UI manager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68837c468cbc8330a44584c982a72533