### PR TITLE
Remove storage_mode from hotkey config

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,19 @@ To access and change settings:
 
 Set `display_transcripts_in_terminal` to `true` in `config.json` or toggle the option in the settings window to print the full transcript in the terminal after each recording.
 
+
+### Hotkey Config File
+
+Hotkey settings are stored in `hotkey_config.json`. Only the following keys are recognized:
+
+```json
+{
+    "record_key": "f3",
+    "agent_key": "f4",
+    "record_mode": "toggle"
+}
+```
+
 Remember to save your changes in the settings window.
 
 ## How to Use the App

--- a/hotkey_config.json
+++ b/hotkey_config.json
@@ -1,6 +1,5 @@
 {
     "record_key": "f3",
     "agent_key": "f4",
-    "record_mode": "toggle",
-    "storage_mode": "auto"
+    "record_mode": "toggle"
 }


### PR DESCRIPTION
## Summary
- update hotkey_config.json to include only used keys
- document valid hotkey_config.json keys in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837c4723548330a32165af0eb42efc