### PR TITLE
Melhora tratamento de erros ao registrar hotkeys

### DIFF
--- a/tests/test_keyboard_hotkey_manager.py
+++ b/tests/test_keyboard_hotkey_manager.py
@@ -70,5 +70,17 @@ class KeyboardHotkeyManagerFailureTests(unittest.TestCase):
         self.assertTrue(self.mock_save.called)
         self.assertFalse(mock_register.called)
 
+    def test_register_hotkeys_oserror(self):
+        fake_keyboard.on_press_key = MagicMock(side_effect=OSError("boom"))
+        fake_keyboard.on_release_key = MagicMock()
+        result = self.manager._register_hotkeys()
+        self.assertFalse(result)
+
+    def test_register_hotkeys_generic_exception(self):
+        fake_keyboard.on_press_key = MagicMock(side_effect=RuntimeError("fail"))
+        fake_keyboard.on_release_key = MagicMock()
+        result = self.manager._register_hotkeys()
+        self.assertFalse(result)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Resumo
- adiciona capturas específicas de `OSError` em `_register_hotkeys`
- em caso de exceção inesperada, registra erro e retorna `False`
- cria testes simulando falhas na biblioteca `keyboard`

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837c53d50483308a59a01bfba75743