### PR TITLE
Add chunk length config

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ To access and change settings:
 *   **Gemini Models (one per line):** Manage the list of available Gemini models in the dropdown.
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
 *   **Batch Size:** Configure the batch size for transcription.
+*   **Chunk Length (s):** Controls how long each audio segment sent to Whisper is. Smaller values reduce memory use but may slow processing.
 *   **Record Storage Mode:** Choose between always using memory, always using disk, or automatically selecting based on free RAM.
 *   **Minimum Free RAM (MB):** Threshold used in auto mode to decide when audio can be stored in memory.
 *   **Max Memory Seconds Mode:** Set to "auto" to adjust the retention limit dynamically or "manual" to use a fixed value.
@@ -271,6 +272,8 @@ To access and change settings:
 *   **Use VAD:** enables silence removal without automatically stopping the recording.
 *   **VAD Threshold:** sensitivity of voice detection.
 *   **VAD Silence Duration (s):** maximum pause length to keep; longer silences are trimmed.
+
+Using a shorter **Chunk Length** lowers GPU memory usage but increases overhead because more segments need to be processed. Longer chunks speed up transcription at the cost of higher memory consumption.
 
 
 ### Displaying Transcripts in the Terminal

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -75,6 +75,7 @@ Transcribed speech: {text}""",
     "max_memory_seconds": 30,
     "min_free_ram_mb": 1000,
     "min_transcription_duration": 1.0, # Nova configuração
+    "chunk_length_sec": 30,
     "launch_at_startup": False
 }
 
@@ -99,6 +100,7 @@ DISPLAY_TRANSCRIPTS_KEY = "display_transcripts_in_terminal"
 USE_VAD_CONFIG_KEY = "use_vad"
 VAD_THRESHOLD_CONFIG_KEY = "vad_threshold"
 VAD_SILENCE_DURATION_CONFIG_KEY = "vad_silence_duration"
+CHUNK_LENGTH_SEC_CONFIG_KEY = "chunk_length_sec"
 LAUNCH_AT_STARTUP_CONFIG_KEY = "launch_at_startup"
 DISPLAY_TRANSCRIPTS_IN_TERMINAL_CONFIG_KEY = DISPLAY_TRANSCRIPTS_KEY
 KEYBOARD_LIBRARY_CONFIG_KEY = "keyboard_library"
@@ -308,6 +310,18 @@ class ConfigManager:
             )
         except (ValueError, TypeError):
             self.config["min_free_ram_mb"] = self.default_config["min_free_ram_mb"]
+
+        try:
+            self.config[CHUNK_LENGTH_SEC_CONFIG_KEY] = float(
+                self.config.get(
+                    CHUNK_LENGTH_SEC_CONFIG_KEY,
+                    self.default_config[CHUNK_LENGTH_SEC_CONFIG_KEY],
+                )
+            )
+        except (ValueError, TypeError):
+            self.config[CHUNK_LENGTH_SEC_CONFIG_KEY] = self.default_config[
+                CHUNK_LENGTH_SEC_CONFIG_KEY
+            ]
     
         # Para gpu_index_specified e batch_size_specified
         self.config["batch_size_specified"] = BATCH_SIZE_CONFIG_KEY in loaded_config
@@ -574,3 +588,17 @@ class ConfigManager:
 
     def set_launch_at_startup(self, value: bool):
         self.config[LAUNCH_AT_STARTUP_CONFIG_KEY] = bool(value)
+
+    def get_chunk_length_sec(self):
+        return self.config.get(
+            CHUNK_LENGTH_SEC_CONFIG_KEY,
+            self.default_config[CHUNK_LENGTH_SEC_CONFIG_KEY],
+        )
+
+    def set_chunk_length_sec(self, value: float | int):
+        try:
+            self.config[CHUNK_LENGTH_SEC_CONFIG_KEY] = float(value)
+        except (ValueError, TypeError):
+            self.config[CHUNK_LENGTH_SEC_CONFIG_KEY] = self.default_config[
+                CHUNK_LENGTH_SEC_CONFIG_KEY
+            ]

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -28,6 +28,7 @@ from .config_manager import (
     OPENROUTER_PROMPT_CONFIG_KEY,
     MIN_TRANSCRIPTION_DURATION_CONFIG_KEY, DISPLAY_TRANSCRIPTS_KEY, # Nova constante
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
+    CHUNK_LENGTH_SEC_CONFIG_KEY,
 )
 
 class TranscriptionHandler:
@@ -86,6 +87,7 @@ class TranscriptionHandler:
         self.gemini_agent_model = self.config_manager.get('gemini_agent_model')
         self.gemini_prompt = self.config_manager.get(GEMINI_PROMPT_CONFIG_KEY)
         self.min_transcription_duration = self.config_manager.get(MIN_TRANSCRIPTION_DURATION_CONFIG_KEY)
+        self.chunk_length_sec = self.config_manager.get(CHUNK_LENGTH_SEC_CONFIG_KEY)
 
         self.openrouter_client = None
         # self.gemini_client é injetado
@@ -125,6 +127,7 @@ class TranscriptionHandler:
         self.gemini_agent_model = self.config_manager.get('gemini_agent_model')
         self.gemini_prompt = self.config_manager.get(GEMINI_PROMPT_CONFIG_KEY)
         self.min_transcription_duration = self.config_manager.get(MIN_TRANSCRIPTION_DURATION_CONFIG_KEY)
+        self.chunk_length_sec = self.config_manager.get(CHUNK_LENGTH_SEC_CONFIG_KEY)
         logging.info("TranscriptionHandler: Configurações atualizadas.")
 
     def _initialize_model_and_processor(self):
@@ -146,7 +149,7 @@ class TranscriptionHandler:
                     model=model,
                     tokenizer=processor.tokenizer,
                     feature_extractor=processor.feature_extractor,
-                    chunk_length_s=30,
+                    chunk_length_s=self.chunk_length_sec,
                     batch_size=self.batch_size, # Usar o batch_size configurado
                     torch_dtype=torch.float16 if device.startswith("cuda") else torch.float32,
                     generate_kwargs=generate_kwargs_init
@@ -380,7 +383,7 @@ class TranscriptionHandler:
 
             result = self.pipe(
                 audio_source,
-                chunk_length_s=30,
+                chunk_length_s=self.chunk_length_sec,
                 batch_size=dynamic_batch_size,
                 return_timestamps=False,
                 generate_kwargs=generate_kwargs


### PR DESCRIPTION
## Summary
- add chunk_length_sec default config and constant
- expose getters and setters for chunk length
- leverage configurable chunk length in pipeline setup and transcription
- document chunk length option and its effect on performance

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a2ed81b6c8330aafc80002a2228c4