### PR TITLE
Evita limpar GPU a cada transcrição

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -471,9 +471,12 @@ class TranscriptionHandler:
                 else:
                     self.on_transcription_result_callback(text_result, text_result)
 
+            # Mantemos a VRAM em cache para acelerar transcrições consecutivas.
+            # A limpeza completa ocorre somente no shutdown.
             if torch.cuda.is_available():
-                torch.cuda.empty_cache()
-                logging.debug("Cache da GPU limpo após tarefa de transcrição.")
+                logging.debug(
+                    "Cache da GPU preservado para transcrições consecutivas."
+                )
 
     def shutdown(self) -> None:
         """Encerra o executor de transcrição."""
@@ -492,3 +495,6 @@ class TranscriptionHandler:
         finally:
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
+                logging.debug(
+                    "Cache da GPU liberado no encerramento do aplicativo."
+                )


### PR DESCRIPTION
## Resumo
- mantém a VRAM alocada entre transcrições
- libera a memória da GPU somente no encerramento do aplicativo

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a2ee07f7883309b95d57413c7c946