### PR TITLE
Adjust VAD path resolution

### DIFF
--- a/src/vad_manager.py
+++ b/src/vad_manager.py
@@ -5,14 +5,13 @@ import onnxruntime
 import torch
 from pathlib import Path
 
-# Detecta se o aplicativo está rodando em um diretório temporário (PyInstaller)
-if hasattr(sys, "_MEIPASS"):
-    base_dir = Path(sys._MEIPASS)
-else:
-    base_dir = Path(__file__).resolve().parent
+# Caminho para o modelo ONNX do Silero VAD
+MODEL_PATH = Path(__file__).resolve().parent / "models" / "silero_vad.onnx"
 
-# Construir o caminho absoluto para o modelo ONNX
-MODEL_PATH = base_dir / "models" / "silero_vad.onnx"
+# Ajuste para execução via PyInstaller
+if hasattr(sys, "_MEIPASS"):
+    MODEL_PATH = Path(sys._MEIPASS) / "models" / "silero_vad.onnx"
+
 logging.info("VAD model path set to '%s'", MODEL_PATH)
 
 class VADManager:


### PR DESCRIPTION
## Summary
- simplify the ONNX model path in `vad_manager`
- keep PyInstaller support for bundled execution

## Testing
- `flake8 src/vad_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_688a3bec8b488330a88a777e4477e265