### PR TITLE
Fix min_record_duration handling and update UI

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -299,6 +299,9 @@ class AudioHandler:
 
         recording_duration = time.time() - self.start_time
         if self._sample_count == 0 or recording_duration < self.min_record_duration:
+            logging.info(
+                f"Dura\u00e7\u00e3o gravada {recording_duration:.2f}s abaixo do m\u00ednimo configurado {self.min_record_duration}s. Descartando."
+            )
             logging.warning(
                 f"Grava\u00e7\u00e3o muito curta (< {self.min_record_duration}s) ou vazia. Descartando."
             )

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -354,6 +354,23 @@ class ConfigManager:
             logging.warning(f"Invalid min_transcription_duration value '{self.config.get(MIN_TRANSCRIPTION_DURATION_CONFIG_KEY)}' in config. Falling back to default ({self.default_config[MIN_TRANSCRIPTION_DURATION_CONFIG_KEY]}).")
             self.config[MIN_TRANSCRIPTION_DURATION_CONFIG_KEY] = self.default_config[MIN_TRANSCRIPTION_DURATION_CONFIG_KEY]
 
+        # Validação para min_record_duration
+        try:
+            raw_min_rec_val = loaded_config.get(MIN_RECORDING_DURATION_CONFIG_KEY, self.default_config[MIN_RECORDING_DURATION_CONFIG_KEY])
+            min_rec_val = float(raw_min_rec_val)
+            if not (0.1 <= min_rec_val <= 10.0):
+                logging.warning(
+                    f"Invalid min_record_duration '{min_rec_val}'. Must be between 0.1 and 10.0. Using default ({self.default_config[MIN_RECORDING_DURATION_CONFIG_KEY]})."
+                )
+                self.config[MIN_RECORDING_DURATION_CONFIG_KEY] = self.default_config[MIN_RECORDING_DURATION_CONFIG_KEY]
+            else:
+                self.config[MIN_RECORDING_DURATION_CONFIG_KEY] = min_rec_val
+        except (ValueError, TypeError):
+            logging.warning(
+                f"Invalid min_record_duration value '{self.config.get(MIN_RECORDING_DURATION_CONFIG_KEY)}' in config. Falling back to default ({self.default_config[MIN_RECORDING_DURATION_CONFIG_KEY]})."
+            )
+            self.config[MIN_RECORDING_DURATION_CONFIG_KEY] = self.default_config[MIN_RECORDING_DURATION_CONFIG_KEY]
+
         # Lógica para uso do VAD
         self.config[USE_VAD_CONFIG_KEY] = _parse_bool(
             self.config.get(USE_VAD_CONFIG_KEY, self.default_config[USE_VAD_CONFIG_KEY])
@@ -601,4 +618,18 @@ class ConfigManager:
         except (ValueError, TypeError):
             self.config[CHUNK_LENGTH_SEC_CONFIG_KEY] = self.default_config[
                 CHUNK_LENGTH_SEC_CONFIG_KEY
+            ]
+
+    def get_min_record_duration(self):
+        return self.config.get(
+            MIN_RECORDING_DURATION_CONFIG_KEY,
+            self.default_config[MIN_RECORDING_DURATION_CONFIG_KEY],
+        )
+
+    def set_min_record_duration(self, value: float | int):
+        try:
+            self.config[MIN_RECORDING_DURATION_CONFIG_KEY] = float(value)
+        except (ValueError, TypeError):
+            self.config[MIN_RECORDING_DURATION_CONFIG_KEY] = self.default_config[
+                MIN_RECORDING_DURATION_CONFIG_KEY
             ]

--- a/src/core.py
+++ b/src/core.py
@@ -578,6 +578,7 @@ class AppCore:
                 "new_batch_size": "batch_size", "new_gpu_index": "gpu_index",
                 "new_hotkey_stability_service_enabled": "hotkey_stability_service_enabled", # Nova configuração unificada
                 "new_min_transcription_duration": "min_transcription_duration",
+                "new_min_record_duration": "min_record_duration",
                 "new_save_temp_recordings": SAVE_TEMP_RECORDINGS_CONFIG_KEY,
                 "new_record_to_memory": "record_to_memory",
                 "new_max_memory_seconds_mode": "max_memory_seconds_mode",
@@ -627,6 +628,7 @@ class AppCore:
                     "new_vad_silence_duration",
                     "new_record_storage_mode",
                     "new_record_storage_limit",
+                    "new_min_record_duration",
                 ]
             ):
                 self.audio_handler.update_config()
@@ -675,6 +677,11 @@ class AppCore:
                     self.config_manager.set('min_transcription_duration', kwargs['new_min_transcription_duration'])
                     logging.info(f"Configuração 'min_transcription_duration' alterada para: {kwargs['new_min_transcription_duration']}")
 
+            if kwargs.get('new_min_record_duration') is not None:
+                if self.config_manager.get('min_record_duration') != kwargs['new_min_record_duration']:
+                    self.config_manager.set('min_record_duration', kwargs['new_min_record_duration'])
+                    logging.info(f"Configuração 'min_record_duration' alterada para: {kwargs['new_min_record_duration']}")
+
             self._log_status("Configurações atualizadas.")
         else:
             logging.info("Nenhuma configuração alterada.")
@@ -705,6 +712,11 @@ class AppCore:
             self.transcription_handler.config_manager = self.config_manager # Garantir que a referência esteja atualizada
             self.transcription_handler.update_config()
             logging.info(f"TranscriptionHandler: Configurações de transcrição atualizadas via update_setting para '{key}'.")
+
+        if key in ["min_record_duration", "use_vad", "vad_threshold", "vad_silence_duration", "record_storage_mode", "record_storage_limit"]:
+            self.audio_handler.config_manager = self.config_manager
+            self.audio_handler.update_config()
+            logging.info(f"AudioHandler: Configurações atualizadas via update_setting para '{key}'.")
 
         # Re-inicializar clientes API se a chave ou modelo mudou
         if key in ["gemini_api_key", "gemini_model", "gemini_agent_model", "openrouter_api_key", "openrouter_model"]:

--- a/src/gemini_api.py
+++ b/src/gemini_api.py
@@ -67,9 +67,8 @@ class GeminiAPI:
         critério de reinicialização.
         """
         # Prioriza a chave da API passada no construtor, depois a do config
-        self.current_api_key = (
-            self.last_api_key
-            or self.config_manager.get("gemini_api_key")
+        self.current_api_key = self.last_api_key or self.config_manager.get(
+            "gemini_api_key"
         )
         self.current_model_id = self.config_manager.get('gemini_model')
         self.current_prompt = self.config_manager.get(GEMINI_PROMPT_CONFIG_KEY)
@@ -77,8 +76,7 @@ class GeminiAPI:
         # A reinicialização considera apenas chave e modelo. O prompt é lido a
         # cada chamada pública, portanto não dispara reload.
         config_changed = (
-            self.current_api_key != self.last_api_key
-            or self.current_model_id != self.last_model_id
+            self.current_api_key != self.last_api_key or self.current_model_id != self.last_model_id
         )
 
         if self.model is None or config_changed:

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -226,6 +226,7 @@ class UIManager:
                 agent_model_var = ctk.StringVar(value=self.config_manager.get("gemini_agent_model"))
                 hotkey_stability_service_enabled_var = ctk.BooleanVar(value=self.config_manager.get("hotkey_stability_service_enabled")) # Nova variável unificada
                 min_transcription_duration_var = ctk.DoubleVar(value=self.config_manager.get("min_transcription_duration")) # Nova variável
+                min_record_duration_var = ctk.DoubleVar(value=self.config_manager.get("min_record_duration"))
                 sound_enabled_var = ctk.BooleanVar(value=self.config_manager.get("sound_enabled"))
                 sound_frequency_var = ctk.StringVar(value=str(self.config_manager.get("sound_frequency")))
                 sound_duration_var = ctk.StringVar(value=str(self.config_manager.get("sound_duration")))
@@ -319,6 +320,9 @@ class UIManager:
                     min_transcription_duration_to_apply = self._safe_get_float(min_transcription_duration_var, "Duração Mínima", settings_win)
                     if min_transcription_duration_to_apply is None:
                         return
+                    min_record_duration_to_apply = self._safe_get_float(min_record_duration_var, "Duração Mínima da Gravação", settings_win)
+                    if min_record_duration_to_apply is None:
+                        return
                     use_vad_to_apply = use_vad_var.get()
                     vad_threshold_to_apply = self._safe_get_float(vad_threshold_var, "Limiar do VAD", settings_win)
                     if vad_threshold_to_apply is None:
@@ -375,6 +379,7 @@ class UIManager:
                         new_gpu_index=gpu_index_to_apply,
                         new_hotkey_stability_service_enabled=hotkey_stability_service_enabled_to_apply, # Nova configuração unificada
                         new_min_transcription_duration=min_transcription_duration_to_apply,
+                        new_min_record_duration=min_record_duration_to_apply,
                         new_save_temp_recordings=save_temp_recordings_to_apply,
                         new_record_storage_mode=record_storage_mode_var.get(),
                         new_record_to_memory=(record_storage_mode_var.get() == "memory"),
@@ -405,6 +410,7 @@ class UIManager:
                     agent_model_var.set(DEFAULT_CONFIG["gemini_agent_model"])
                     hotkey_stability_service_enabled_var.set(DEFAULT_CONFIG["hotkey_stability_service_enabled"])
                     min_transcription_duration_var.set(DEFAULT_CONFIG["min_transcription_duration"])
+                    min_record_duration_var.set(DEFAULT_CONFIG["min_record_duration"])
                     sound_enabled_var.set(DEFAULT_CONFIG["sound_enabled"])
                     sound_frequency_var.set(str(DEFAULT_CONFIG["sound_frequency"]))
                     sound_duration_var.set(str(DEFAULT_CONFIG["sound_duration"]))
@@ -639,6 +645,13 @@ class UIManager:
                 min_transcription_duration_entry = ctk.CTkEntry(min_transcription_duration_frame, textvariable=min_transcription_duration_var, width=80)
                 min_transcription_duration_entry.pack(side="left", padx=5)
                 Tooltip(min_transcription_duration_entry, "Discard segments shorter than this.")
+
+                min_record_duration_frame = ctk.CTkFrame(transcription_frame)
+                min_record_duration_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(min_record_duration_frame, text="Minimum Record Duration (sec):").pack(side="left", padx=(5, 10))
+                min_record_duration_entry = ctk.CTkEntry(min_record_duration_frame, textvariable=min_record_duration_var, width=80)
+                min_record_duration_entry.pack(side="left", padx=5)
+                Tooltip(min_record_duration_entry, "Discard recordings shorter than this.")
 
                 vad_enable_frame = ctk.CTkFrame(transcription_frame)
                 vad_enable_frame.pack(fill="x", pady=5)


### PR DESCRIPTION
## Summary
- validate `min_record_duration` in `ConfigManager`
- expose getter and setter for the value
- load and store the value in `UIManager`
- allow editing the value via settings UI
- propagate config changes through `AppCore`
- log current limit when discarding short recordings
- fix style warnings in `gemini_api`

## Testing
- `flake8 src/gemini_api.py src/openrouter_api.py`

------
https://chatgpt.com/codex/tasks/task_e_688a3bfe9f148330bc0777a6be6acf42