### PR TITLE
Adiciona import de time em transcription_handler

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 import concurrent.futures
+import time
 import numpy as np
 import torch
 from transformers import pipeline, AutoProcessor, AutoModelForSpeechSeq2Seq


### PR DESCRIPTION
## Resumo
- Garante disponibilidade do módulo `time` para chamadas como `time.perf_counter`

## Testes
- `python -m py_compile src/transcription_handler.py`
- `rg -n "time\." src/transcription_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_6897361ea6a88330acdee7d7219f1d65