### PR TITLE
Remover duplicações no método __init__ de TranscriptionHandler

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -90,8 +90,6 @@ class TranscriptionHandler:
         self.chunk_length_sec = self.config_manager.get(CHUNK_LENGTH_SEC_CONFIG_KEY)
         self.chunk_length_mode = self.config_manager.get("chunk_length_mode", "manual")
         self.enable_torch_compile = bool(self.config_manager.get("enable_torch_compile", False))
-        self.chunk_length_mode = self.config_manager.get("chunk_length_mode", "manual")
-        self.enable_torch_compile = bool(self.config_manager.get("enable_torch_compile", False))
 
         self.openrouter_client = None
         # self.gemini_client é injetado


### PR DESCRIPTION
## Resumo
- eliminar atribuições redundantes de `chunk_length_mode` e `enable_torch_compile` em `__init__`

## Testes
- `flake8 src/transcription_handler.py` *(falhou: vários avisos e erros existentes)*
- `python -m py_compile src/transcription_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_6897387b1ccc8330948e6608402f8418