### PR TITLE
Adicionar Playwright e ignorar diretório de sessão do navegador

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ Whisper.bat
 start_whisper.bat
 Whisper ADMIN.lnk
 .gitignore
+# Diretório de dados de sessão do navegador para automação web
+/user_data/

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ keyboard==0.13.5
 soundfile==0.13.1
 onnxruntime==1.22.0
 bitsandbytes
+playwright==1.44.0


### PR DESCRIPTION
## Resumo
- incluir Playwright como dependência para automação web
- ignorar diretório user_data usado para sessões do navegador

## Testes
- `flake8` (falhou: múltiplas violações de estilo em arquivos existentes)
- `git status --short` após criar `user_data/` para validar ignorância do diretório

------
https://chatgpt.com/codex/tasks/task_e_689738c096c483309cb409d025cf411d