### PR TITLE
feat: add ChatGPT browser automator

### DIFF
--- a/manual_test_chatgpt_automator.py
+++ b/manual_test_chatgpt_automator.py
@@ -1,0 +1,24 @@
+"""Teste manual para o ChatGPTAutomator."""
+import logging
+import time
+
+from src.config_manager import ConfigManager
+from src.chatgpt_automator import ChatGPTAutomator
+
+
+def main() -> None:
+    """Executa um ciclo simples de abertura e fechamento do navegador."""
+    logging.basicConfig(level=logging.DEBUG)
+    cfg = ConfigManager()
+    automator = ChatGPTAutomator(cfg, user_data_dir="/tmp/chatgpt_profile", headless=True)
+    try:
+        automator.start()
+        logging.info("Navegador iniciado com sucesso. Aguardando alguns segundos...")
+        time.sleep(2)
+    finally:
+        automator.close()
+        logging.info("Navegador encerrado sem erros.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/chatgpt_automator.py
+++ b/src/chatgpt_automator.py
@@ -1,0 +1,73 @@
+import logging
+from typing import Optional
+
+from playwright.sync_api import BrowserContext, Page, sync_playwright
+
+from .config_manager import (
+    ConfigManager,
+    CHATGPT_SELECTORS_CONFIG_KEY,
+    CHATGPT_URL_CONFIG_KEY,
+)
+
+
+class ChatGPTAutomator:
+    """Automatiza interações com a interface web do ChatGPT."""
+
+    def __init__(self, config_manager: ConfigManager, user_data_dir: str, headless: bool = False) -> None:
+        """Inicializa o automator com o gerenciador de configuração."""
+        self._config_manager = config_manager
+        self._user_data_dir = user_data_dir
+        self._headless = headless
+        self._playwright = None
+        self._context: Optional[BrowserContext] = None
+        self._page: Optional[Page] = None
+        self._logger = logging.getLogger(__name__)
+
+    def start(self) -> None:
+        """Inicia o navegador persistente e garante a abertura do ChatGPT."""
+        self._logger.debug("Iniciando Playwright com user_data_dir=%s", self._user_data_dir)
+        self._playwright = sync_playwright().start()
+        self._context = self._playwright.chromium.launch_persistent_context(
+            self._user_data_dir,
+            headless=self._headless,
+        )
+        self._page = self._context.pages[0] if self._context.pages else self._context.new_page()
+        self.ensure_chatgpt_open()
+
+    def ensure_chatgpt_open(self) -> None:
+        """Garante que a página do ChatGPT esteja aberta."""
+        if not self._page:
+            raise RuntimeError("Contexto não inicializado. Chame start() antes.")
+        url = self._config_manager.config.get(CHATGPT_URL_CONFIG_KEY, "https://chatgpt.com/")
+        self._logger.debug("Acessando URL do ChatGPT: %s", url)
+        if not self._page.url.startswith(url):
+            self._page.goto(url, wait_until="domcontentloaded")
+
+    def transcribe_audio(self, audio_path: str) -> str:
+        """Envia um arquivo de áudio e retorna o texto transcrito."""
+        if not self._page:
+            raise RuntimeError("Contexto não inicializado. Chame start() antes.")
+        selectors = self._config_manager.config.get(CHATGPT_SELECTORS_CONFIG_KEY, {})
+        file_input = selectors.get("file_input")
+        response_block = selectors.get("response_block")
+        if not file_input or not response_block:
+            raise KeyError("Seletores necessários não configurados.")
+        self._logger.debug("Enviando arquivo de áudio %s", audio_path)
+        self._page.set_input_files(file_input, audio_path)
+        self._logger.debug("Aguardando transcrição...")
+        self._page.wait_for_selector(response_block)
+        texto = self._page.inner_text(response_block)
+        self._logger.debug("Transcrição recebida: %.60s", texto)
+        return texto
+
+    def close(self) -> None:
+        """Fecha o navegador e libera recursos."""
+        self._logger.debug("Encerrando contexto do navegador.")
+        if self._context:
+            self._context.close()
+            self._context = None
+        if self._playwright:
+            self._playwright.stop()
+            self._playwright = None
+        self._page = None
+        self._logger.debug("Navegador fechado com sucesso.")

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -80,7 +80,14 @@ Transcribed speech: {text}""",
     "chunk_length_mode": "manual",
     "enable_torch_compile": False,
     "launch_at_startup": False,
-    "clear_gpu_cache": True
+    "clear_gpu_cache": True,
+    # Configurações específicas para automação do ChatGPT
+    "chatgpt_url": "https://chatgpt.com/",
+    "chatgpt_selectors": {
+        "textarea": "textarea[data-id='root']",
+        "file_input": "input[type=file]",
+        "response_block": "div[data-message-author-role='assistant']"
+    }
 }
 
 # Outras constantes de configuração (movidas de whisper_tkinter.py)
@@ -134,6 +141,8 @@ REREGISTER_INTERVAL_SECONDS = 60
 MAX_HOTKEY_FAILURES = 3
 HOTKEY_HEALTH_CHECK_INTERVAL = 10
 CLEAR_GPU_CACHE_CONFIG_KEY = "clear_gpu_cache"
+CHATGPT_URL_CONFIG_KEY = "chatgpt_url"
+CHATGPT_SELECTORS_CONFIG_KEY = "chatgpt_selectors"
 
 class ConfigManager:
     def __init__(self, config_file=CONFIG_FILE, default_config=DEFAULT_CONFIG):


### PR DESCRIPTION
## Summary
- extend configuration with ChatGPT URL and selectors
- implement ChatGPTAutomator for persistent browser control and audio transcription
- add manual test script exercising start and close lifecycle

## Testing
- `flake8` *(fails: line too long, syntax errors, undefined names)*
- `pytest` *(no tests found)*
- `python manual_test_chatgpt_automator.py` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689738c5b69483309158b173c52c9a27