### PR TITLE
Corrigir indentação do bloco try/except em main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -59,18 +59,19 @@ try:
                 logging.info(f"FlashAttention 2 detectado: {has_flash_attn}")
             except Exception as el:
                 logging.warning(f"Não foi possível coletar capacidades CUDA: {el}")
-        except Exception as e:
-            # torch pode não estar instalado em alguns ambientes de teste; seguir silenciosamente
-            logging.debug(f"torch não disponível para configurar cudnn.benchmark: {e}")
-        # Log explícito de CPU quando nenhuma GPU disponível (TODO 4.3/5.2)
-        try:
-            torch_spec = importlib.util.find_spec("torch")
-            if torch_spec is not None:
-                import torch  # type: ignore
-                if not torch.cuda.is_available():
-                    logging.info("[METRIC] stage=device_select device=cpu reason=no_cuda_available")
-        except Exception:
-            pass
+except Exception as e:
+    # torch pode não estar instalado em alguns ambientes de teste; seguir silenciosamente
+    logging.debug(f"torch não disponível para configurar cudnn.benchmark: {e}")
+
+# Log explícito de CPU quando nenhuma GPU disponível (TODO 4.3/5.2)
+try:
+    torch_spec = importlib.util.find_spec("torch")
+    if torch_spec is not None:
+        import torch  # type: ignore
+        if not torch.cuda.is_available():
+            logging.info("[METRIC] stage=device_select device=cpu reason=no_cuda_available")
+except Exception:
+    pass
 
 # --- Ajuste para evitar erros "main thread is not in main loop" ao destruir
 # variáveis Tkinter quando a aplicação encerra. Mantemos o destrutor original


### PR DESCRIPTION
## Resumo
- Ajusta indentação do bloco `except` para resolver `SyntaxError` em `src/main.py`

## Testes
- `python -m py_compile src/main.py`
- `flake8 src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5c47131dc8330acb7a780694fe488