### PR TITLE
feat: tornar Playwright lazy e parametrizar headless

### DIFF
--- a/src/chatgpt_automator.py
+++ b/src/chatgpt_automator.py
@@ -1,7 +1,9 @@
 import logging
 from pathlib import Path
-from playwright.sync_api import sync_playwright, Page, BrowserContext, Playwright
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - usado apenas em tempo de tipo
+    from playwright.sync_api import Page, BrowserContext, Playwright
 
 class ChatGPTAutomator:
     """
@@ -10,18 +12,21 @@ class ChatGPTAutomator:
     def __init__(self, user_data_dir: Path, config_manager):
         self.user_data_dir = user_data_dir
         self.config_manager = config_manager
-        self.playwright: Optional[Playwright] = None
-        self.browser: Optional[BrowserContext] = None
-        self.page: Optional[Page] = None
+        self.playwright: Optional["Playwright"] = None
+        self.browser: Optional["BrowserContext"] = None
+        self.page: Optional["Page"] = None
 
     def start(self):
         """Inicia o Playwright e abre o navegador com um contexto persistente."""
         try:
+            from playwright.sync_api import sync_playwright
+
             self.user_data_dir.mkdir(parents=True, exist_ok=True)
+            headless = self.config_manager.get("chatgpt_headless", False)
             self.playwright = sync_playwright().start()
             self.browser = self.playwright.chromium.launch_persistent_context(
                 self.user_data_dir,
-                headless=False,
+                headless=headless,
                 slow_mo=50
             )
             self.page = self.browser.pages[0] if self.browser.pages else self.browser.new_page()

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -92,6 +92,7 @@ Transcribed speech: {text}""",
     "clear_gpu_cache": True,
     # Configurações específicas para automação do ChatGPT
     "chatgpt_url": "https://chatgpt.com/",
+    "chatgpt_headless": False,
     "chatgpt_selectors": {
         "textarea": "textarea[data-id='root']",
         "file_input": "input[type=file]",
@@ -153,6 +154,7 @@ HOTKEY_HEALTH_CHECK_INTERVAL = 10
 CLEAR_GPU_CACHE_CONFIG_KEY = "clear_gpu_cache"
 CHATGPT_URL_CONFIG_KEY = "chatgpt_url"
 CHATGPT_SELECTORS_CONFIG_KEY = "chatgpt_selectors"
+CHATGPT_HEADLESS_CONFIG_KEY = "chatgpt_headless"
 
 class ConfigManager:
     def __init__(self, config_file=CONFIG_FILE, default_config=DEFAULT_CONFIG):


### PR DESCRIPTION
## Resumo
- Adiciona lazy import do Playwright dentro de `start`, evitando carregamento antecipado
- Permite configurar o modo headless via `chatgpt_headless` no arquivo de configuração

## Testes
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5dee4fc888330bc869241383bdcf3