### PR TITLE
feat: aceitar áudio em memória no ChatGPT Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A lightweight, high-performance desktop tool for Windows that turns your speech 
     *   Supports both **Toggle Mode** (press once to start, press again to stop) and **Hold Mode** (record only while the key is held down).
     *   Dedicated "Agent Mode" hotkey for special commands.
 *   **AI-Powered Text Correction (Optional):**
-    *   Integrates with **Google Gemini** or **OpenRouter** to automatically correct punctuation, grammar, and remove speech disfluencies.
+    *   Integrates with **Google Gemini**, **OpenRouter**, or **ChatGPT Web** to automatically correct punctuation, grammar, and remove speech disfluencies. ChatGPT Web also accepts in-memory audio by internally writing a temporary WAV file.
     *   Prompts are fully customizable through the settings GUI.
 *   **Agent Mode:** Use a separate hotkey to process your speech with a different, customizable prompt (e.g., "translate this to English", "summarize this text").
 *   **User-Friendly Interface:**


### PR DESCRIPTION
## Resumo
- permite que o modo ChatGPT Web receba áudio em memória, criando um WAV temporário
- documenta a compatibilidade do ChatGPT Web com arrays de áudio

## Testes
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5df0459d8833084c3d156a068ce96