### PR TITLE
fix: assegurar Path para ChatGPTAutomator

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -647,9 +647,16 @@ class AppCore:
             if service == "chatgpt_web" and self.chatgpt_automator is None:
                 logging.info("Iniciando o ChatGPT Automator devido à mudança de configuração.")
                 user_data_path = Path("user_data/playwright")
+                if not isinstance(user_data_path, Path):
+                    user_data_path = Path(user_data_path)
+                user_data_path.mkdir(parents=True, exist_ok=True)
                 self.chatgpt_automator = ChatGPTAutomator(
                     user_data_dir=user_data_path,
                     config_manager=self.config_manager,
+                )
+                logging.info(
+                    "ChatGPTAutomator initialized with user_data_dir=%s",
+                    user_data_path,
                 )
                 threading.Thread(
                     target=self.chatgpt_automator.start,


### PR DESCRIPTION
## Resumo
- garantir `Path` consistente ao iniciar o ChatGPT Automator
- registrar diretório de dados do usuário durante a inicialização

## Testes
- `python src/main.py --dry-run`
- trecho em Python validando tipo `Path` e existência do diretório

------
https://chatgpt.com/codex/tasks/task_e_68a5f04cf19c8330a0f8e4ba743f8e72