### PR TITLE
fix: avoid NumPy scalar conversion warning in VADManager

### DIFF
--- a/src/vad_manager.py
+++ b/src/vad_manager.py
@@ -88,6 +88,6 @@ class VADManager:
             "sr": np.array([self.sr], dtype=np.int64),
         }
         outs = self.session.run(None, ort_inputs)
-        speech_prob = float(outs[0][0][0])
+        speech_prob = outs[0][0][0].item()
         self._state = outs[1] # Atualiza o estado com a saída do modelo
         return speech_prob > self.threshold


### PR DESCRIPTION
## Summary
- prevent numpy array to float implicit conversion warning by extracting scalar via `.item()` in `VADManager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0323dd1e08330ad15115f70103c43