### PR TITLE
Add ASR configuration defaults and accessors

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -92,6 +92,14 @@ DEFAULT_CONFIG = {
     "enable_torch_compile": False,
     "launch_at_startup": False,
     "clear_gpu_cache": True,
+    "asr_backend": "auto",
+    "asr_model_id": "openai/whisper-large-v3-turbo",
+    "asr_compute_device": "auto",
+    "asr_dtype": "auto",
+    "asr_ct2_compute_type": "auto",
+    "asr_cache_dir": os.path.expanduser("~/.cache/whisper_models"),
+    "asr_installed_models": [],
+    "asr_curated_catalog": [],  # carregado posteriormente
 }
 
 # Outras constantes de configuração (movidas de whisper_tkinter.py)
@@ -145,6 +153,14 @@ REREGISTER_INTERVAL_SECONDS = 60
 MAX_HOTKEY_FAILURES = 3
 HOTKEY_HEALTH_CHECK_INTERVAL = 10
 CLEAR_GPU_CACHE_CONFIG_KEY = "clear_gpu_cache"
+ASR_BACKEND_CONFIG_KEY = "asr_backend"
+ASR_MODEL_ID_CONFIG_KEY = "asr_model_id"
+ASR_COMPUTE_DEVICE_CONFIG_KEY = "asr_compute_device"
+ASR_DTYPE_CONFIG_KEY = "asr_dtype"
+ASR_CT2_COMPUTE_TYPE_CONFIG_KEY = "asr_ct2_compute_type"
+ASR_CACHE_DIR_CONFIG_KEY = "asr_cache_dir"
+ASR_INSTALLED_MODELS_CONFIG_KEY = "asr_installed_models"
+ASR_CURATED_CATALOG_CONFIG_KEY = "asr_curated_catalog"
 
 class ConfigManager:
     def __init__(self, config_file=CONFIG_FILE, default_config=DEFAULT_CONFIG):
@@ -501,6 +517,40 @@ class ConfigManager:
                 self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]
             )
 
+        self.config[ASR_BACKEND_CONFIG_KEY] = str(
+            self.config.get(ASR_BACKEND_CONFIG_KEY, self.default_config[ASR_BACKEND_CONFIG_KEY])
+        )
+        self.config[ASR_MODEL_ID_CONFIG_KEY] = str(
+            self.config.get(ASR_MODEL_ID_CONFIG_KEY, self.default_config[ASR_MODEL_ID_CONFIG_KEY])
+        )
+        self.config[ASR_COMPUTE_DEVICE_CONFIG_KEY] = str(
+            self.config.get(ASR_COMPUTE_DEVICE_CONFIG_KEY, self.default_config[ASR_COMPUTE_DEVICE_CONFIG_KEY])
+        )
+        self.config[ASR_DTYPE_CONFIG_KEY] = str(
+            self.config.get(ASR_DTYPE_CONFIG_KEY, self.default_config[ASR_DTYPE_CONFIG_KEY])
+        )
+        self.config[ASR_CT2_COMPUTE_TYPE_CONFIG_KEY] = str(
+            self.config.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY, self.default_config[ASR_CT2_COMPUTE_TYPE_CONFIG_KEY])
+        )
+        self.config[ASR_CACHE_DIR_CONFIG_KEY] = os.path.expanduser(
+            self.config.get(ASR_CACHE_DIR_CONFIG_KEY, self.default_config[ASR_CACHE_DIR_CONFIG_KEY])
+        )
+        installed = self.config.get(
+            ASR_INSTALLED_MODELS_CONFIG_KEY,
+            self.default_config[ASR_INSTALLED_MODELS_CONFIG_KEY],
+        )
+        if not isinstance(installed, list):
+            installed = self.default_config[ASR_INSTALLED_MODELS_CONFIG_KEY]
+        self.config[ASR_INSTALLED_MODELS_CONFIG_KEY] = installed
+
+        curated = self.config.get(
+            ASR_CURATED_CATALOG_CONFIG_KEY,
+            self.default_config[ASR_CURATED_CATALOG_CONFIG_KEY],
+        )
+        if not isinstance(curated, list):
+            curated = self.default_config[ASR_CURATED_CATALOG_CONFIG_KEY]
+        self.config[ASR_CURATED_CATALOG_CONFIG_KEY] = curated
+
         safe_config = self.config.copy()
         safe_config.pop(GEMINI_API_KEY_CONFIG_KEY, None)
         safe_config.pop(OPENROUTER_API_KEY_CONFIG_KEY, None)
@@ -603,6 +653,88 @@ class ConfigManager:
         if provider == SERVICE_OPENROUTER:
             return self.get(OPENROUTER_API_KEY_CONFIG_KEY)
         return ""
+
+    def get_asr_backend(self):
+        return self.config.get(
+            ASR_BACKEND_CONFIG_KEY,
+            self.default_config[ASR_BACKEND_CONFIG_KEY],
+        )
+
+    def set_asr_backend(self, value: str):
+        self.config[ASR_BACKEND_CONFIG_KEY] = str(value)
+
+    def get_asr_model_id(self):
+        return self.config.get(
+            ASR_MODEL_ID_CONFIG_KEY,
+            self.default_config[ASR_MODEL_ID_CONFIG_KEY],
+        )
+
+    def set_asr_model_id(self, value: str):
+        self.config[ASR_MODEL_ID_CONFIG_KEY] = str(value)
+
+    def get_asr_compute_device(self):
+        return self.config.get(
+            ASR_COMPUTE_DEVICE_CONFIG_KEY,
+            self.default_config[ASR_COMPUTE_DEVICE_CONFIG_KEY],
+        )
+
+    def set_asr_compute_device(self, value: str):
+        self.config[ASR_COMPUTE_DEVICE_CONFIG_KEY] = str(value)
+
+    def get_asr_dtype(self):
+        return self.config.get(
+            ASR_DTYPE_CONFIG_KEY,
+            self.default_config[ASR_DTYPE_CONFIG_KEY],
+        )
+
+    def set_asr_dtype(self, value: str):
+        self.config[ASR_DTYPE_CONFIG_KEY] = str(value)
+
+    def get_asr_ct2_compute_type(self):
+        return self.config.get(
+            ASR_CT2_COMPUTE_TYPE_CONFIG_KEY,
+            self.default_config[ASR_CT2_COMPUTE_TYPE_CONFIG_KEY],
+        )
+
+    def set_asr_ct2_compute_type(self, value: str):
+        self.config[ASR_CT2_COMPUTE_TYPE_CONFIG_KEY] = str(value)
+
+    def get_asr_cache_dir(self):
+        return self.config.get(
+            ASR_CACHE_DIR_CONFIG_KEY,
+            self.default_config[ASR_CACHE_DIR_CONFIG_KEY],
+        )
+
+    def set_asr_cache_dir(self, value: str):
+        self.config[ASR_CACHE_DIR_CONFIG_KEY] = os.path.expanduser(str(value))
+
+    def get_asr_installed_models(self):
+        return self.config.get(
+            ASR_INSTALLED_MODELS_CONFIG_KEY,
+            self.default_config[ASR_INSTALLED_MODELS_CONFIG_KEY],
+        )
+
+    def set_asr_installed_models(self, value: list):
+        if isinstance(value, list):
+            self.config[ASR_INSTALLED_MODELS_CONFIG_KEY] = value
+        else:
+            self.config[ASR_INSTALLED_MODELS_CONFIG_KEY] = self.default_config[
+                ASR_INSTALLED_MODELS_CONFIG_KEY
+            ]
+
+    def get_asr_curated_catalog(self):
+        return self.config.get(
+            ASR_CURATED_CATALOG_CONFIG_KEY,
+            self.default_config[ASR_CURATED_CATALOG_CONFIG_KEY],
+        )
+
+    def set_asr_curated_catalog(self, value: list):
+        if isinstance(value, list):
+            self.config[ASR_CURATED_CATALOG_CONFIG_KEY] = value
+        else:
+            self.config[ASR_CURATED_CATALOG_CONFIG_KEY] = self.default_config[
+                ASR_CURATED_CATALOG_CONFIG_KEY
+            ]
 
     def get_use_vad(self):
         return self.config.get(USE_VAD_CONFIG_KEY, self.default_config[USE_VAD_CONFIG_KEY])


### PR DESCRIPTION
## Summary
- add automatic speech recognition configuration defaults
- expose ASR settings via constants and accessor methods

## Testing
- `python -m py_compile src/config_manager.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03c278f908330b61b765d9c923477