### PR TITLE
Add pluggable ASR backends

### DIFF
--- a/src/asr/__init__.py
+++ b/src/asr/__init__.py
@@ -1,0 +1,3 @@
+from .backends import ASRBackend, make_backend
+
+__all__ = ['ASRBackend', 'make_backend']

--- a/src/asr/backend_faster_whisper.py
+++ b/src/asr/backend_faster_whisper.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class FasterWhisperBackend:
+    """ASR backend powered by faster-whisper."""
+
+    def __init__(self, model_id: str = "whisper-large-v3", device: str = "auto") -> None:
+        self.model_id = model_id
+        self.device = device
+        self.model = None
+
+    def load(self, ct2_compute_type: str = "default", **kwargs) -> None:
+        """Load the WhisperModel with the given compute type."""
+        from faster_whisper import WhisperModel
+
+        self.model = WhisperModel(
+            self.model_id,
+            device=self.device,
+            compute_type=ct2_compute_type,
+            **kwargs,
+        )
+
+    def warmup(self) -> None:
+        """Run a dummy inference to initialize the model."""
+        if not self.model:
+            return
+        import numpy as np
+
+        audio = np.zeros(int(16000 * 0.015), dtype="float32")
+        segments, _ = self.model.transcribe(audio)
+        next(segments, None)
+
+    def transcribe(self, audio: Any, **kwargs) -> dict:
+        """Transcribe the provided audio and return just the text."""
+        if not self.model:
+            raise RuntimeError("Backend not loaded")
+        segments, _ = self.model.transcribe(audio, **kwargs)
+        text = "".join(segment.text for segment in segments)
+        return {"text": text}
+
+    def unload(self) -> None:
+        """Release model resources."""
+        self.model = None

--- a/src/asr/backend_transformers.py
+++ b/src/asr/backend_transformers.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class TransformersBackend:
+    """ASR backend based on Hugging Face Transformers."""
+
+    def __init__(self, model_id: str = "openai/whisper-large-v3", device: int | str | None = None) -> None:
+        self.model_id = model_id
+        self.device = device
+        self.processor = None
+        self.model = None
+        self.pipe = None
+        self.sample_rate = 16000
+
+    def load(self) -> None:
+        """Load model and processor, constructing the inference pipeline."""
+        from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq, pipeline
+
+        self.processor = AutoProcessor.from_pretrained(self.model_id)
+        self.model = AutoModelForSpeechSeq2Seq.from_pretrained(self.model_id)
+        self.pipe = pipeline(
+            "automatic-speech-recognition",
+            model=self.model,
+            processor=self.processor,
+            device=self.device,
+        )
+        try:
+            self.sample_rate = int(self.processor.feature_extractor.sampling_rate)  # type: ignore[attr-defined]
+        except Exception:
+            self.sample_rate = 16000
+
+    def warmup(self) -> None:
+        """Run a small inference pass with 15 ms of silence to initialize kernels."""
+        if not self.pipe:
+            return
+        import numpy as np
+
+        samples = int(self.sample_rate * 0.015)
+        audio = np.zeros(samples, dtype="float32")
+        self.pipe(audio)
+
+    def transcribe(self, audio: Any, **kwargs) -> dict:
+        """Transcribe the provided audio and return a dictionary with text."""
+        if not self.pipe:
+            raise RuntimeError("Backend not loaded")
+        result = self.pipe(audio, **kwargs)
+        return {"text": result.get("text", "")}
+
+    def unload(self) -> None:
+        """Free model resources."""
+        self.pipe = None
+        self.model = None
+        self.processor = None

--- a/src/asr/backends.py
+++ b/src/asr/backends.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ASRBackend(Protocol):
+    """Minimal interface for ASR backends."""
+
+    def load(self, *args, **kwargs) -> None: ...
+
+    def warmup(self) -> None: ...
+
+    def transcribe(self, audio: str | bytes | list[float] | None, **kwargs) -> dict: ...
+
+    def unload(self) -> None: ...
+
+
+def make_backend(name: str) -> ASRBackend:
+    """Factory that returns an ASR backend by name."""
+    normalized = name.strip().lower()
+    if normalized == "transformers":
+        from .backend_transformers import TransformersBackend
+        return TransformersBackend()
+    if normalized in {"faster-whisper", "faster_whisper"}:
+        from .backend_faster_whisper import FasterWhisperBackend
+        return FasterWhisperBackend()
+    raise ValueError(f"Unknown ASR backend: {name}")


### PR DESCRIPTION
## Summary
- introduce ASRBackend protocol and factory
- implement Transformers and faster-whisper backends

## Testing
- `python -m py_compile src/asr/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c03c2c70fc8330b66e2b7ee6ee3d8c