### PR TITLE
Expose ASR settings and auto-select backend

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,3 +14,4 @@ keyboard
 soundfile>=0.13.1
 onnxruntime
 psutil
+faster-whisper

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ soundfile==0.13.1
 onnxruntime==1.22.0
 bitsandbytes
 playwright==1.44.0
+faster-whisper

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -3,6 +3,9 @@ import json
 import logging
 import copy
 import hashlib
+from typing import Any, Dict, List
+
+import requests
 try:
     from distutils.util import strtobool
 except Exception:  # Python >= 3.12
@@ -92,6 +95,16 @@ DEFAULT_CONFIG = {
     "enable_torch_compile": False,
     "launch_at_startup": False,
     "clear_gpu_cache": True,
+    "asr_backend": "auto",
+    "asr_model_id": "openai/whisper-large-v3-turbo",
+    "asr_compute_device": "auto",
+    "asr_dtype": "auto",
+    "asr_ct2_compute_type": "auto",
+    "asr_cache_dir": os.path.expanduser("~/.cache/whisper_models"),
+    "asr_installed_models": [],
+    "asr_curated_catalog": [],  # carregado posteriormente
+    "asr_curated_catalog_url": "https://example.com/asr_curated_catalog.json",
+    "asr_ct2_cpu_threads": "auto",
 }
 
 # Outras constantes de configuração (movidas de whisper_tkinter.py)
@@ -145,6 +158,16 @@ REREGISTER_INTERVAL_SECONDS = 60
 MAX_HOTKEY_FAILURES = 3
 HOTKEY_HEALTH_CHECK_INTERVAL = 10
 CLEAR_GPU_CACHE_CONFIG_KEY = "clear_gpu_cache"
+ASR_BACKEND_CONFIG_KEY = "asr_backend"
+ASR_MODEL_ID_CONFIG_KEY = "asr_model_id"
+ASR_COMPUTE_DEVICE_CONFIG_KEY = "asr_compute_device"
+ASR_DTYPE_CONFIG_KEY = "asr_dtype"
+ASR_CT2_COMPUTE_TYPE_CONFIG_KEY = "asr_ct2_compute_type"
+ASR_CACHE_DIR_CONFIG_KEY = "asr_cache_dir"
+ASR_INSTALLED_MODELS_CONFIG_KEY = "asr_installed_models"
+ASR_CURATED_CATALOG_CONFIG_KEY = "asr_curated_catalog"
+ASR_CURATED_CATALOG_URL_CONFIG_KEY = "asr_curated_catalog_url"
+ASR_CT2_CPU_THREADS_CONFIG_KEY = "asr_ct2_cpu_threads"
 
 class ConfigManager:
     def __init__(self, config_file=CONFIG_FILE, default_config=DEFAULT_CONFIG):
@@ -154,6 +177,9 @@ class ConfigManager:
         self._config_hash = None
         self._secrets_hash = None
         self.load_config()
+        url = self.config.get(ASR_CURATED_CATALOG_URL_CONFIG_KEY, "")
+        if url:
+            self.update_asr_curated_catalog_from_url(url)
 
     def _compute_hash(self, data) -> str:
         """Gera um hash SHA256 determinístico para o dicionário informado."""
@@ -501,6 +527,57 @@ class ConfigManager:
                 self.default_config[VAD_SILENCE_DURATION_CONFIG_KEY]
             )
 
+        self.config[ASR_BACKEND_CONFIG_KEY] = str(
+            self.config.get(ASR_BACKEND_CONFIG_KEY, self.default_config[ASR_BACKEND_CONFIG_KEY])
+        )
+        self.config[ASR_MODEL_ID_CONFIG_KEY] = str(
+            self.config.get(ASR_MODEL_ID_CONFIG_KEY, self.default_config[ASR_MODEL_ID_CONFIG_KEY])
+        )
+        self.config[ASR_COMPUTE_DEVICE_CONFIG_KEY] = str(
+            self.config.get(ASR_COMPUTE_DEVICE_CONFIG_KEY, self.default_config[ASR_COMPUTE_DEVICE_CONFIG_KEY])
+        )
+        self.config[ASR_DTYPE_CONFIG_KEY] = str(
+            self.config.get(ASR_DTYPE_CONFIG_KEY, self.default_config[ASR_DTYPE_CONFIG_KEY])
+        )
+        self.config[ASR_CT2_COMPUTE_TYPE_CONFIG_KEY] = str(
+            self.config.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY, self.default_config[ASR_CT2_COMPUTE_TYPE_CONFIG_KEY])
+        )
+        self.config[ASR_CACHE_DIR_CONFIG_KEY] = os.path.expanduser(
+            self.config.get(ASR_CACHE_DIR_CONFIG_KEY, self.default_config[ASR_CACHE_DIR_CONFIG_KEY])
+        )
+        self.config[ASR_CURATED_CATALOG_URL_CONFIG_KEY] = str(
+            self.config.get(
+                ASR_CURATED_CATALOG_URL_CONFIG_KEY,
+                self.default_config[ASR_CURATED_CATALOG_URL_CONFIG_KEY],
+            )
+        )
+        threads_val = self.config.get(
+            ASR_CT2_CPU_THREADS_CONFIG_KEY,
+            self.default_config[ASR_CT2_CPU_THREADS_CONFIG_KEY],
+        )
+        if isinstance(threads_val, str) and threads_val.lower() == "auto":
+            self.config[ASR_CT2_CPU_THREADS_CONFIG_KEY] = "auto"
+        else:
+            try:
+                self.config[ASR_CT2_CPU_THREADS_CONFIG_KEY] = int(threads_val)
+            except (ValueError, TypeError):
+                self.config[ASR_CT2_CPU_THREADS_CONFIG_KEY] = self.default_config[ASR_CT2_CPU_THREADS_CONFIG_KEY]
+        installed = self.config.get(
+            ASR_INSTALLED_MODELS_CONFIG_KEY,
+            self.default_config[ASR_INSTALLED_MODELS_CONFIG_KEY],
+        )
+        if not isinstance(installed, list):
+            installed = self.default_config[ASR_INSTALLED_MODELS_CONFIG_KEY]
+        self.config[ASR_INSTALLED_MODELS_CONFIG_KEY] = installed
+
+        curated = self.config.get(
+            ASR_CURATED_CATALOG_CONFIG_KEY,
+            self.default_config[ASR_CURATED_CATALOG_CONFIG_KEY],
+        )
+        if not isinstance(curated, list):
+            curated = self.default_config[ASR_CURATED_CATALOG_CONFIG_KEY]
+        self.config[ASR_CURATED_CATALOG_CONFIG_KEY] = curated
+
         safe_config = self.config.copy()
         safe_config.pop(GEMINI_API_KEY_CONFIG_KEY, None)
         safe_config.pop(OPENROUTER_API_KEY_CONFIG_KEY, None)
@@ -603,6 +680,145 @@ class ConfigManager:
         if provider == SERVICE_OPENROUTER:
             return self.get(OPENROUTER_API_KEY_CONFIG_KEY)
         return ""
+
+    def get_asr_backend(self):
+        return self.config.get(
+            ASR_BACKEND_CONFIG_KEY,
+            self.default_config[ASR_BACKEND_CONFIG_KEY],
+        )
+
+    def set_asr_backend(self, value: str):
+        self.config[ASR_BACKEND_CONFIG_KEY] = str(value)
+
+    def get_asr_model_id(self):
+        return self.config.get(
+            ASR_MODEL_ID_CONFIG_KEY,
+            self.default_config[ASR_MODEL_ID_CONFIG_KEY],
+        )
+
+    def set_asr_model_id(self, value: str):
+        self.config[ASR_MODEL_ID_CONFIG_KEY] = str(value)
+
+    def get_asr_compute_device(self):
+        return self.config.get(
+            ASR_COMPUTE_DEVICE_CONFIG_KEY,
+            self.default_config[ASR_COMPUTE_DEVICE_CONFIG_KEY],
+        )
+
+    def set_asr_compute_device(self, value: str):
+        self.config[ASR_COMPUTE_DEVICE_CONFIG_KEY] = str(value)
+
+    def get_asr_dtype(self):
+        return self.config.get(
+            ASR_DTYPE_CONFIG_KEY,
+            self.default_config[ASR_DTYPE_CONFIG_KEY],
+        )
+
+    def set_asr_dtype(self, value: str):
+        self.config[ASR_DTYPE_CONFIG_KEY] = str(value)
+
+    def get_asr_ct2_compute_type(self):
+        return self.config.get(
+            ASR_CT2_COMPUTE_TYPE_CONFIG_KEY,
+            self.default_config[ASR_CT2_COMPUTE_TYPE_CONFIG_KEY],
+        )
+
+    def set_asr_ct2_compute_type(self, value: str):
+        self.config[ASR_CT2_COMPUTE_TYPE_CONFIG_KEY] = str(value)
+
+    def get_asr_cache_dir(self):
+        return self.config.get(
+            ASR_CACHE_DIR_CONFIG_KEY,
+            self.default_config[ASR_CACHE_DIR_CONFIG_KEY],
+        )
+
+    def set_asr_cache_dir(self, value: str):
+        self.config[ASR_CACHE_DIR_CONFIG_KEY] = os.path.expanduser(str(value))
+
+    def get_asr_installed_models(self):
+        return self.config.get(
+            ASR_INSTALLED_MODELS_CONFIG_KEY,
+            self.default_config[ASR_INSTALLED_MODELS_CONFIG_KEY],
+        )
+
+    def set_asr_installed_models(self, value: list):
+        if isinstance(value, list):
+            self.config[ASR_INSTALLED_MODELS_CONFIG_KEY] = value
+        else:
+            self.config[ASR_INSTALLED_MODELS_CONFIG_KEY] = self.default_config[
+                ASR_INSTALLED_MODELS_CONFIG_KEY
+            ]
+
+    def get_asr_curated_catalog(self):
+        return self.config.get(
+            ASR_CURATED_CATALOG_CONFIG_KEY,
+            self.default_config[ASR_CURATED_CATALOG_CONFIG_KEY],
+        )
+
+    def set_asr_curated_catalog(self, value: list):
+        if isinstance(value, list):
+            self.config[ASR_CURATED_CATALOG_CONFIG_KEY] = value
+        else:
+            self.config[ASR_CURATED_CATALOG_CONFIG_KEY] = self.default_config[
+                ASR_CURATED_CATALOG_CONFIG_KEY
+            ]
+
+    def get_asr_curated_catalog_url(self):
+        return self.config.get(
+            ASR_CURATED_CATALOG_URL_CONFIG_KEY,
+            self.default_config[ASR_CURATED_CATALOG_URL_CONFIG_KEY],
+        )
+
+    def set_asr_curated_catalog_url(self, value: str):
+        self.config[ASR_CURATED_CATALOG_URL_CONFIG_KEY] = str(value)
+
+    def get_asr_ct2_cpu_threads(self):
+        return self.config.get(
+            ASR_CT2_CPU_THREADS_CONFIG_KEY,
+            self.default_config[ASR_CT2_CPU_THREADS_CONFIG_KEY],
+        )
+
+    def set_asr_ct2_cpu_threads(self, value):
+        if isinstance(value, str) and value.lower() == "auto":
+            self.config[ASR_CT2_CPU_THREADS_CONFIG_KEY] = "auto"
+        else:
+            try:
+                self.config[ASR_CT2_CPU_THREADS_CONFIG_KEY] = int(value)
+            except (ValueError, TypeError):
+                self.config[ASR_CT2_CPU_THREADS_CONFIG_KEY] = self.default_config[
+                    ASR_CT2_CPU_THREADS_CONFIG_KEY
+                ]
+
+    def update_asr_curated_catalog_from_url(self, url: str, timeout: int = 10) -> bool:
+        """Carrega um catálogo curado de modelos de ASR a partir de ``url``.
+
+        O JSON recebido deve ser uma lista de dicionários contendo pelo menos o
+        campo ``model_id``. Caso os dados sejam válidos, o catálogo interno é
+        atualizado e salvo no arquivo de configuração.
+
+        :param url: Endereço da fonte externa.
+        :param timeout: Tempo máximo de espera para a requisição em segundos.
+        :return: ``True`` se o catálogo foi atualizado com sucesso.
+        """
+
+        try:
+            response = requests.get(url, timeout=timeout)
+            response.raise_for_status()
+            data = response.json()
+            if (
+                isinstance(data, list)
+                and all(isinstance(item, dict) and "model_id" in item for item in data)
+            ):
+                self.set_asr_curated_catalog(data)
+                try:
+                    self.save_config()
+                except Exception:
+                    logging.warning("Falha ao salvar config após atualizar catálogo curado.")
+                return True
+            logging.warning("Formato inválido de catálogo obtido de %s", url)
+        except Exception as e:
+            logging.error("Erro ao atualizar catálogo curado de %s: %s", url, e)
+        return False
 
     def get_use_vad(self):
         return self.config.get(USE_VAD_CONFIG_KEY, self.default_config[USE_VAD_CONFIG_KEY])

--- a/src/core.py
+++ b/src/core.py
@@ -25,6 +25,13 @@ from .config_manager import (
     DISPLAY_TRANSCRIPTS_KEY,
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
     GEMINI_PROMPT_CONFIG_KEY,
+    ASR_BACKEND_CONFIG_KEY,
+    ASR_MODEL_ID_CONFIG_KEY,
+    ASR_COMPUTE_DEVICE_CONFIG_KEY,
+    ASR_DTYPE_CONFIG_KEY,
+    ASR_CT2_COMPUTE_TYPE_CONFIG_KEY,
+    ASR_CT2_CPU_THREADS_CONFIG_KEY,
+    ASR_CACHE_DIR_CONFIG_KEY,
 )
 from .audio_handler import AudioHandler, AUDIO_SAMPLE_RATE # AUDIO_SAMPLE_RATE ainda é usado em _handle_transcription_result
 from .transcription_handler import TranscriptionHandler
@@ -609,6 +616,13 @@ class AppCore:
                 "new_chunk_length_mode": "chunk_length_mode",
                 "new_chunk_length_sec": "chunk_length_sec",
                 "new_enable_torch_compile": "enable_torch_compile",
+                "new_asr_backend": ASR_BACKEND_CONFIG_KEY,
+                "new_asr_model_id": ASR_MODEL_ID_CONFIG_KEY,
+                "new_asr_compute_device": ASR_COMPUTE_DEVICE_CONFIG_KEY,
+                "new_asr_dtype": ASR_DTYPE_CONFIG_KEY,
+                "new_asr_ct2_compute_type": ASR_CT2_COMPUTE_TYPE_CONFIG_KEY,
+                "new_asr_ct2_cpu_threads": ASR_CT2_CPU_THREADS_CONFIG_KEY,
+                "new_asr_cache_dir": ASR_CACHE_DIR_CONFIG_KEY,
             }
             mapped_key = config_key_map.get(key, key) # Usa o nome original se não mapeado
 

--- a/tests/test_asr_features.py
+++ b/tests/test_asr_features.py
@@ -1,0 +1,149 @@
+import types
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+sys.modules.setdefault("pyautogui", types.ModuleType("pyautogui"))
+sys.modules.setdefault("pyperclip", types.ModuleType("pyperclip"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+sys.modules.setdefault("sounddevice", types.ModuleType("sounddevice"))
+sys.modules.setdefault("psutil", types.ModuleType("psutil"))
+torch_stub = types.ModuleType("torch")
+torch_stub.cuda = types.SimpleNamespace(is_available=lambda: False)
+sys.modules.setdefault("torch", torch_stub)
+transformers_stub = types.ModuleType("transformers")
+transformers_stub.pipeline = lambda *a, **k: None
+class _DummyAuto:
+    @staticmethod
+    def from_pretrained(*a, **k):
+        return object()
+transformers_stub.AutoProcessor = _DummyAuto
+transformers_stub.AutoModelForSpeechSeq2Seq = _DummyAuto
+sys.modules.setdefault("transformers", transformers_stub)
+sys.modules.setdefault("keyboard", types.ModuleType("keyboard"))
+google_stub = types.ModuleType("google")
+generativeai_stub = types.ModuleType("google.generativeai")
+generativeai_stub.types = types.ModuleType("google.generativeai.types")
+generativeai_stub.types.helper_types = types.SimpleNamespace()
+generativeai_stub.types.BrokenResponseError = Exception
+generativeai_stub.types.IncompleteIterationError = Exception
+google_stub.generativeai = generativeai_stub
+sys.modules.setdefault("google", google_stub)
+sys.modules.setdefault("google.generativeai", generativeai_stub)
+sys.modules.setdefault("google.generativeai.types", generativeai_stub.types)
+
+from src.config_manager import ConfigManager
+from src.core import AppCore
+from src.transcription_handler import TranscriptionHandler
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_curated_catalog_update(monkeypatch):
+    data = [{"model_id": "m1"}, {"model_id": "m2"}]
+    monkeypatch.setattr(
+        "requests.get", lambda url, timeout=10: DummyResponse(data)
+    )
+    cm = ConfigManager()
+    assert cm.get_asr_curated_catalog() == data
+
+
+def test_resolve_backend_ct2(monkeypatch):
+    monkeypatch.setattr("requests.get", lambda url, timeout=10: DummyResponse([]))
+    cm = ConfigManager()
+    th = TranscriptionHandler(
+        config_manager=cm,
+        gemini_api_client=None,
+        on_model_ready_callback=lambda: None,
+        on_model_error_callback=lambda e: None,
+        on_transcription_result_callback=lambda r: None,
+        on_agent_result_callback=lambda r: None,
+        on_segment_transcribed_callback=lambda s: None,
+        is_state_transcribing_fn=lambda: False,
+    )
+
+    th.asr_backend = "auto"
+
+    def fake_find_spec(name):
+        if name == "faster_whisper":
+            return object()
+        return importlib.util.find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    backend, *_ = th._resolve_asr_settings()
+    assert backend == "ctranslate2"
+
+
+def test_apply_settings_updates_trans_handler(monkeypatch):
+    data = [{"model_id": "m1"}]
+    monkeypatch.setattr(
+        "requests.get", lambda url, timeout=10: DummyResponse(data)
+    )
+
+    class DummyAudioHandler:
+        def __init__(self, *_, **__):
+            self.is_recording = False
+
+        def update_config(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    class DummyTransHandler:
+        def __init__(self, config_manager, **kwargs):
+            self.config_manager = config_manager
+            self.gemini_client = None
+            self.openrouter_client = None
+
+        def start_model_loading(self):
+            pass
+
+        def update_config(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    class DummyKeyboardHotkeyManager:
+        def __init__(self, *_, **__):
+            pass
+
+        def update_config(self, **kwargs):
+            pass
+
+    class DummyGeminiAPI:
+        def __init__(self, *_):
+            pass
+
+        def reinitialize_client(self):
+            pass
+
+    monkeypatch.setattr("src.core.AudioHandler", DummyAudioHandler)
+    monkeypatch.setattr("src.core.TranscriptionHandler", DummyTransHandler)
+    monkeypatch.setattr("src.core.KeyboardHotkeyManager", DummyKeyboardHotkeyManager)
+    monkeypatch.setattr("src.core.GeminiAPI", DummyGeminiAPI)
+
+    updated = {}
+    def mark_update(self):
+        updated["called"] = True
+    monkeypatch.setattr(DummyTransHandler, "update_config", mark_update)
+
+    app = AppCore(None)
+    updated.clear()
+    app.apply_settings_from_external(new_asr_model_id="model-x")
+    app.transcription_handler.update_config()
+    assert updated.get("called")
+


### PR DESCRIPTION
## Summary
- load a curated ASR model catalog from a configurable URL and expose threads/compute type controls
- add automatic CTranslate2 backend selection and loading path
- show combined curated and installed ASR models in the GUI with a refreshable catalog

## Testing
- `python -m py_compile src/config_manager.py src/transcription_handler.py src/ui_manager.py src/core.py tests/test_asr_features.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03c278f908330b61b765d9c923477