### PR TITLE
feat: add ASR settings frame

### DIFF
--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -1,0 +1,69 @@
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Any
+
+try:
+    from huggingface_hub import snapshot_download
+except Exception:  # pragma: no cover - huggingface_hub is a transformers dependency
+    snapshot_download = None  # type: ignore
+
+# Base directory for storing ASR models
+MODEL_DIR = Path.home() / ".cache" / "whisper_flash_transcriber" / "asr"
+MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
+# Curated models with metadata; repo indicates HF repo id
+CURATED: Dict[str, Dict[str, Any]] = {
+    "distil-whisper/large-v2": {
+        "backend": "Transformers",
+        "dtype": "fp16",
+        "chunk": 30,
+        "batch": 16,
+        "device": "auto",
+        "repo": "distil-whisper/distil-large-v2",
+    },
+    "Systran/faster-whisper-large-v3": {
+        "backend": "Faster-Whisper",
+        "dtype": "fp16",
+        "chunk": 30,
+        "batch": 16,
+        "device": "auto",
+        "repo": "Systran/faster-whisper-large-v3",
+    },
+}
+
+
+def asr_installed_models() -> Dict[str, Dict[str, Any]]:
+    """Return installed ASR models with metadata."""
+    models: Dict[str, Dict[str, Any]] = {}
+    for path in MODEL_DIR.glob("*"):
+        if not path.is_dir():
+            continue
+        meta_file = path / "metadata.json"
+        try:
+            info = json.loads(meta_file.read_text()) if meta_file.exists() else {}
+        except Exception:
+            info = {}
+        models[path.name.replace("__", "/")] = info
+    return models
+
+
+def ensure_download(backend: str, model: str) -> Path:
+    """Ensure model is downloaded; returns local path."""
+    info = CURATED.get(model, {})
+    repo = info.get("repo", model)
+    local_dir = MODEL_DIR / model.replace("/", "__")
+    if local_dir.exists():
+        logging.info("Model already available: %s", local_dir)
+        return local_dir
+    if snapshot_download is None:
+        raise RuntimeError("huggingface_hub not available for downloading models")
+    try:
+        snapshot_download(repo_id=repo, local_dir=local_dir)
+        meta = {"backend": backend, **{k: v for k, v in info.items() if k != "repo"}}
+        (local_dir / "metadata.json").write_text(json.dumps(meta))
+        logging.info("Model '%s' downloaded to %s", repo, local_dir)
+        return local_dir
+    except Exception as e:  # pragma: no cover - network/IO errors
+        logging.error("Failed to download model '%s': %s", repo, e)
+        raise

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -25,6 +25,21 @@ from .utils.tooltip import Tooltip
 # Para este plano, vamos movê-lo para cá.
 import torch # Necessário para get_available_devices_for_ui
 
+# Importar gerenciador de modelos de ASR
+try:
+    from . import model_manager
+except Exception:  # pragma: no cover - fallback caso o módulo não exista
+    class _DummyModelManager:
+        CURATED = {}
+
+        def asr_installed_models(self):
+            return {}
+
+        def ensure_download(self, *_args, **_kwargs):
+            logging.warning("model_manager module not available.")
+
+    model_manager = _DummyModelManager()
+
 def get_available_devices_for_ui():
     """Returns a list of devices for the settings interface."""
     devices = ["Auto-select (Recommended)"]
@@ -756,6 +771,116 @@ class UIManager:
                 gemini_models_textbox.pack(fill="x", expand=True, pady=5)
                 gemini_models_textbox.insert("1.0", "\n".join(self.config_manager.get("gemini_model_options", [])))
                 Tooltip(gemini_models_textbox, "List of models to try, one per line.")
+
+                # --- ASR Settings ---
+                asr_frame = ctk.CTkFrame(scrollable_frame, fg_color="transparent")
+                asr_frame.pack(fill="x", padx=10, pady=5)
+                ctk.CTkLabel(asr_frame, text="ASR", font=ctk.CTkFont(weight="bold")).pack(pady=(5, 10), anchor="w")
+
+                # Backend selection
+                asr_backend_frame = ctk.CTkFrame(asr_frame)
+                asr_backend_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(asr_backend_frame, text="Backend:").pack(side="left", padx=(5, 10))
+                asr_backend_var = ctk.StringVar(value=self.config_manager.get("asr_backend", "Transformers"))
+                backend_menu = ctk.CTkOptionMenu(
+                    asr_backend_frame,
+                    variable=asr_backend_var,
+                    values=["Transformers", "Faster-Whisper"],
+                )
+                backend_menu.pack(side="left", padx=5)
+                Tooltip(backend_menu, "Mecanismo de reconhecimento de fala.")
+
+                # Model selection
+                asr_model_frame = ctk.CTkFrame(asr_frame)
+                asr_model_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(asr_model_frame, text="Modelo:").pack(side="left", padx=(5, 10))
+
+                installed = (
+                    model_manager.asr_installed_models()
+                    if hasattr(model_manager, "asr_installed_models")
+                    else {}
+                )
+                curated = getattr(model_manager, "CURATED", {})
+                combined_models = {**installed, **curated}
+                asr_model_var = ctk.StringVar(
+                    value=self.config_manager.get("asr_model", "")
+                )
+                model_menu = ctk.CTkOptionMenu(
+                    asr_model_frame, variable=asr_model_var, values=[]
+                )
+                model_menu.pack(side="left", padx=5)
+                model_tooltip = Tooltip(model_menu, "")
+
+                def _update_model_tooltip(name: str) -> None:
+                    info = combined_models.get(name, {})
+                    tip = " | ".join(
+                        str(info.get(k, "?"))
+                        for k in ("backend", "dtype", "chunk", "batch", "device")
+                    )
+                    model_tooltip.text = tip
+
+                def _refresh_model_options() -> None:
+                    backend = asr_backend_var.get()
+                    options = [
+                        m for m, meta in combined_models.items() if meta.get("backend") == backend
+                    ]
+                    model_menu.configure(values=options)
+                    if asr_model_var.get() not in options and options:
+                        asr_model_var.set(options[0])
+                        self.config_manager.set("asr_model", options[0])
+                    _update_model_tooltip(asr_model_var.get())
+
+                def _reload_if_idle() -> None:
+                    handler = getattr(self.core_instance_ref, "transcription_handler", None)
+                    state = getattr(self.core_instance_ref, "current_state", "IDLE")
+                    if handler and state not in ["LOADING_MODEL", "RECORDING", "TRANSCRIBING"]:
+                        try:
+                            handler.start_model_loading()
+                        except Exception as e:  # pragma: no cover
+                            logging.error("Model reload failed: %s", e)
+                            messagebox.showerror("Model", f"Falha ao carregar modelo: {e}")
+
+                def _on_backend_change(choice: str) -> None:
+                    prev = self.config_manager.get("asr_backend")
+                    self.config_manager.set("asr_backend", choice)
+                    self.config_manager.save_config()
+                    _refresh_model_options()
+                    if prev != choice:
+                        _reload_if_idle()
+
+                def _on_model_change(choice: str) -> None:
+                    prev = self.config_manager.get("asr_model")
+                    self.config_manager.set("asr_model", choice)
+                    self.config_manager.save_config()
+                    _update_model_tooltip(choice)
+                    if prev != choice:
+                        _reload_if_idle()
+
+                backend_menu.configure(command=_on_backend_change)
+                model_menu.configure(command=_on_model_change)
+                _refresh_model_options()
+
+                def _install_model() -> None:
+                    try:
+                        model_manager.ensure_download(
+                            asr_backend_var.get(), asr_model_var.get()
+                        )
+                    except Exception as e:  # pragma: no cover
+                        logging.error("Model download failed: %s", e)
+                        messagebox.showerror(
+                            "Model Manager", f"Falha ao baixar modelo: {e}"
+                        )
+                    else:
+                        messagebox.showinfo(
+                            "Model Manager", "Modelo instalado/atualizado com sucesso."
+                        )
+
+                install_button = ctk.CTkButton(
+                    asr_frame, text="Instalar/Atualizar", command=_install_model
+                )
+                install_button.pack(pady=5)
+                Tooltip(install_button, "Baixa ou atualiza o modelo selecionado.")
+
 
                 # --- Transcription Settings (Advanced) Section ---
                 transcription_frame = ctk.CTkFrame(scrollable_frame, fg_color="transparent")


### PR DESCRIPTION
## Summary
- add ASR section with backend and model selectors
- support model installation via model_manager.ensure_download
- persist selections and reload model when changed
- integrate real model_manager with metadata and backend filtering
- handle safe model reload and install errors

## Testing
- `python -m py_compile src/ui_manager.py src/model_manager.py`
- `flake8 src/ui_manager.py src/model_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c03c41e9388330a78395593143b976