### PR TITLE
Accept arbitrary parameters in TransformersBackend.load

### DIFF
--- a/src/asr/backend_transformers.py
+++ b/src/asr/backend_transformers.py
@@ -14,8 +14,12 @@ class TransformersBackend:
         self.pipe = None
         self.sample_rate = 16000
 
-    def load(self) -> None:
-        """Load model and processor, constructing the inference pipeline."""
+    def load(self, *args, **kwargs) -> None:
+        """Load model and processor, constructing the inference pipeline.
+
+        Extra positional or keyword arguments are accepted for compatibility
+        with the :class:`ASRBackend` protocol but are ignored.
+        """
         from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq, pipeline
 
         self.processor = AutoProcessor.from_pretrained(self.model_id)


### PR DESCRIPTION
## Summary
- allow TransformersBackend.load to accept arbitrary *args and **kwargs for protocol compatibility

## Testing
- `flake8 src/asr/backend_transformers.py`


------
https://chatgpt.com/codex/tasks/task_e_68c043ae6c8c83309a57481d77c449fb