### PR TITLE
Fix UnboundLocalError when CTranslate2 fails

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -594,6 +594,9 @@ class TranscriptionHandler:
             return
 
         text_result = None
+        # Garantir que dynamic_batch_size esteja definido mesmo quando o backend
+        # for CTranslate2, evitando UnboundLocalError no bloco de exceção.
+        dynamic_batch_size = None
         try:
             if self.backend_resolved == "ctranslate2":
                 segments, _ = self.pipe.transcribe(audio_source, language=None)

--- a/tests/test_ctranslate2_error_handling.py
+++ b/tests/test_ctranslate2_error_handling.py
@@ -1,0 +1,47 @@
+import contextlib
+import threading
+import types
+import sys
+import numpy as np
+import pytest
+
+# Stub torch to avoid heavy dependency
+fake_torch = types.SimpleNamespace(
+    no_grad=lambda: contextlib.nullcontext(),
+    cuda=types.SimpleNamespace(is_available=lambda: False),
+)
+sys.modules.setdefault("torch", fake_torch)
+sys.modules.setdefault("sounddevice", types.ModuleType("sounddevice"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+sys.modules.setdefault("psutil", types.ModuleType("psutil"))
+sys.modules.setdefault("onnxruntime", types.ModuleType("onnxruntime"))
+
+import src.config_manager as _cfg
+_cfg.ASR_CACHE_DIR = ""
+_cfg.ASR_MODEL_CONFIG_KEY = "asr_model"
+_cfg.list_catalog = lambda: []
+_cfg.list_installed = lambda path: []
+
+from src.transcription_handler import TranscriptionHandler
+
+
+class FailingPipe:
+    def transcribe(self, *args, **kwargs):
+        raise RuntimeError("boom")
+
+
+def test_ctranslate2_exception_no_unboundlocalerror():
+    handler = TranscriptionHandler.__new__(TranscriptionHandler)
+    handler.backend_resolved = "ctranslate2"
+    handler.pipe = FailingPipe()
+    handler.transcription_cancel_event = threading.Event()
+    handler.on_model_error_callback = lambda *args, **kwargs: None
+    handler.config_manager = types.SimpleNamespace(get=lambda key: False)
+    handler.on_segment_transcribed_callback = lambda *args, **kwargs: None
+    handler.on_transcription_result_callback = lambda *args, **kwargs: None
+    handler.is_state_transcribing_fn = lambda: False
+    handler.text_correction_enabled = False
+    handler.gemini_prompt = ""
+
+    # Should handle exception without raising UnboundLocalError
+    handler._transcription_task(np.zeros(16000), agent_mode=False)


### PR DESCRIPTION
## Summary
- prevent `UnboundLocalError` during CTranslate2 failures by initializing `dynamic_batch_size`
- add regression test ensuring CTranslate2 exceptions are handled gracefully

## Testing
- `PYTHONPATH=. pytest tests/test_ctranslate2_error_handling.py::test_ctranslate2_exception_no_unboundlocalerror -k ''`


------
https://chatgpt.com/codex/tasks/task_e_68c0643535e483308c92eb3ed783a508