### PR TITLE
Expose ASR settings and auto-select backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+- Added curated ASR catalog with signed updates and embedded fallback.
+- Introduced CTranslate2 backend options including compute type (`int4_float16`), beam size and temperature controls.
+- Automatic cache scanning with GUI actions to remove or clear installed models.

--- a/README.md
+++ b/README.md
@@ -258,6 +258,26 @@ To access and change settings:
 *   **Model:** For text correction, choose one of the available models for the selected service (e.g., "deepseek/deepseek-chat-v3-0324:free" on OpenRouter or "gemini-2.5-flash" on Gemini).
 *   **Gemini Correction Prompt:** Customize the prompt sent to Gemini for text correction.
 *   **Agent Mode Prompt:** Customize the prompt sent to Gemini when using "Agent Mode".
+
+### CTranslate2 Backend (Optional)
+
+For faster inference, the application can use the [CTranslate2](https://github.com/OpenNMT/CTranslate2) backend through the `faster-whisper` library.
+
+**Installation:**
+
+```bash
+pip install faster-whisper
+```
+
+**Configuration Parameters:**
+
+* `asr_backend` – set to `"ctranslate2"` or leave as `"auto"` for automatic detection.
+* `asr_ct2_compute_type` – quantization mode. Options include `float16`, `int8_float16`, and `int4_float16` (smaller models but lower accuracy).
+* `asr_ct2_cpu_threads` – limit CPU threads used by the decoder.
+* `asr_ct2_beam_size` – beam search width (larger values improve accuracy at the cost of speed).
+* `asr_ct2_temperature` – decoding temperature (use values >0.0 to allow sampling when the model fails to predict).
+
+If the backend or required hardware is unavailable, the application transparently falls back to the standard Transformers pipeline.
 *   **Gemini Models (one per line):** Manage the list of available Gemini models in the dropdown.
 *   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
 *   **Batch Size:** Configure the batch size for transcription.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 # Ferramentas de Teste e Qualidade
 pytest
+pytest-cov
 flake8==7.2.0
 
 # Dependências da Aplicação usadas nos Testes
@@ -14,3 +15,4 @@ keyboard
 soundfile>=0.13.1
 onnxruntime
 psutil
+faster-whisper

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ soundfile==0.13.1
 onnxruntime==1.22.0
 bitsandbytes
 playwright==1.44.0
+faster-whisper

--- a/src/core.py
+++ b/src/core.py
@@ -25,6 +25,15 @@ from .config_manager import (
     DISPLAY_TRANSCRIPTS_KEY,
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
     GEMINI_PROMPT_CONFIG_KEY,
+    ASR_BACKEND_CONFIG_KEY,
+    ASR_MODEL_ID_CONFIG_KEY,
+    ASR_COMPUTE_DEVICE_CONFIG_KEY,
+    ASR_DTYPE_CONFIG_KEY,
+    ASR_CT2_COMPUTE_TYPE_CONFIG_KEY,
+    ASR_CT2_CPU_THREADS_CONFIG_KEY,
+    ASR_CT2_BEAM_SIZE_CONFIG_KEY,
+    ASR_CT2_TEMPERATURE_CONFIG_KEY,
+    ASR_CACHE_DIR_CONFIG_KEY,
 )
 from .audio_handler import AudioHandler, AUDIO_SAMPLE_RATE # AUDIO_SAMPLE_RATE ainda é usado em _handle_transcription_result
 from .transcription_handler import TranscriptionHandler
@@ -609,6 +618,15 @@ class AppCore:
                 "new_chunk_length_mode": "chunk_length_mode",
                 "new_chunk_length_sec": "chunk_length_sec",
                 "new_enable_torch_compile": "enable_torch_compile",
+                "new_asr_backend": ASR_BACKEND_CONFIG_KEY,
+                "new_asr_model_id": ASR_MODEL_ID_CONFIG_KEY,
+                "new_asr_compute_device": ASR_COMPUTE_DEVICE_CONFIG_KEY,
+                "new_asr_dtype": ASR_DTYPE_CONFIG_KEY,
+                "new_asr_ct2_compute_type": ASR_CT2_COMPUTE_TYPE_CONFIG_KEY,
+                "new_asr_ct2_cpu_threads": ASR_CT2_CPU_THREADS_CONFIG_KEY,
+                "new_asr_ct2_beam_size": ASR_CT2_BEAM_SIZE_CONFIG_KEY,
+                "new_asr_ct2_temperature": ASR_CT2_TEMPERATURE_CONFIG_KEY,
+                "new_asr_cache_dir": ASR_CACHE_DIR_CONFIG_KEY,
             }
             mapped_key = config_key_map.get(key, key) # Usa o nome original se não mapeado
 

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -34,6 +34,15 @@ from .config_manager import (
     MIN_TRANSCRIPTION_DURATION_CONFIG_KEY, DISPLAY_TRANSCRIPTS_KEY,
     SAVE_TEMP_RECORDINGS_CONFIG_KEY,
     CHUNK_LENGTH_SEC_CONFIG_KEY,
+    ASR_BACKEND_CONFIG_KEY,
+    ASR_MODEL_ID_CONFIG_KEY,
+    ASR_COMPUTE_DEVICE_CONFIG_KEY,
+    ASR_DTYPE_CONFIG_KEY,
+    ASR_CT2_COMPUTE_TYPE_CONFIG_KEY,
+    ASR_CT2_CPU_THREADS_CONFIG_KEY,
+    ASR_CT2_BEAM_SIZE_CONFIG_KEY,
+    ASR_CT2_TEMPERATURE_CONFIG_KEY,
+    ASR_CACHE_DIR_CONFIG_KEY,
 )
 
 class TranscriptionHandler:
@@ -66,6 +75,7 @@ class TranscriptionHandler:
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
         self.pipe = None
+        self.backend_resolved = None
         # Futura tarefa de transcrição em andamento
         self.transcription_future = None
         # Executor dedicado para a tarefa de transcrição em background
@@ -94,6 +104,17 @@ class TranscriptionHandler:
         self.chunk_length_sec = self.config_manager.get(CHUNK_LENGTH_SEC_CONFIG_KEY)
         self.chunk_length_mode = self.config_manager.get("chunk_length_mode", "manual")
         self.enable_torch_compile = bool(self.config_manager.get("enable_torch_compile", False))
+
+        # Configurações de ASR
+        self.asr_backend = self.config_manager.get(ASR_BACKEND_CONFIG_KEY)
+        self.asr_model_id = self.config_manager.get(ASR_MODEL_ID_CONFIG_KEY)
+        self.asr_compute_device = self.config_manager.get(ASR_COMPUTE_DEVICE_CONFIG_KEY)
+        self.asr_dtype = self.config_manager.get(ASR_DTYPE_CONFIG_KEY)
+        self.asr_ct2_compute_type = self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY)
+        self.asr_ct2_cpu_threads = self.config_manager.get(ASR_CT2_CPU_THREADS_CONFIG_KEY)
+        self.asr_ct2_beam_size = self.config_manager.get(ASR_CT2_BEAM_SIZE_CONFIG_KEY)
+        self.asr_ct2_temperature = self.config_manager.get(ASR_CT2_TEMPERATURE_CONFIG_KEY)
+        self.asr_cache_dir = self.config_manager.get(ASR_CACHE_DIR_CONFIG_KEY)
 
         self.openrouter_client = None
         # self.gemini_client é injetado
@@ -136,7 +157,52 @@ class TranscriptionHandler:
         self.chunk_length_sec = self.config_manager.get(CHUNK_LENGTH_SEC_CONFIG_KEY)
         self.chunk_length_mode = self.config_manager.get("chunk_length_mode", "manual")
         self.enable_torch_compile = bool(self.config_manager.get("enable_torch_compile", False))
+        self.asr_backend = self.config_manager.get(ASR_BACKEND_CONFIG_KEY)
+        self.asr_model_id = self.config_manager.get(ASR_MODEL_ID_CONFIG_KEY)
+        self.asr_compute_device = self.config_manager.get(ASR_COMPUTE_DEVICE_CONFIG_KEY)
+        self.asr_dtype = self.config_manager.get(ASR_DTYPE_CONFIG_KEY)
+        self.asr_ct2_compute_type = self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY)
+        self.asr_ct2_cpu_threads = self.config_manager.get(ASR_CT2_CPU_THREADS_CONFIG_KEY)
+        self.asr_ct2_beam_size = self.config_manager.get(ASR_CT2_BEAM_SIZE_CONFIG_KEY)
+        self.asr_ct2_temperature = self.config_manager.get(ASR_CT2_TEMPERATURE_CONFIG_KEY)
+        self.asr_cache_dir = self.config_manager.get(ASR_CACHE_DIR_CONFIG_KEY)
         logging.info("TranscriptionHandler: Configurações atualizadas.")
+
+    def _resolve_asr_settings(self):
+        """Determina backend, modelo e parâmetros de ASR conforme hardware."""
+        backend = (self.asr_backend or "auto").lower()
+        compute_device = (self.asr_compute_device or "auto").lower()
+        model_id = self.asr_model_id or "auto"
+        dtype = (self.asr_dtype or "auto").lower()
+
+        if backend == "auto":
+            try:
+                import importlib.util as _spec
+                has_ct2 = _spec.find_spec("faster_whisper") is not None
+            except Exception:
+                has_ct2 = False
+            backend = "ctranslate2" if has_ct2 else "transformers"
+        elif backend == "ctranslate2":
+            try:
+                import importlib.util as _spec
+                if _spec.find_spec("faster_whisper") is None:
+                    logging.warning("Backend 'ctranslate2' solicitado mas 'faster_whisper' não está instalado. Usando 'transformers'.")
+                    backend = "transformers"
+            except Exception:
+                backend = "transformers"
+
+        if compute_device == "auto":
+            compute_device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        if dtype == "auto":
+            dtype = "float16" if compute_device.startswith("cuda") else "float32"
+
+        default_gpu_model = "openai/whisper-large-v3-turbo"
+        default_cpu_model = "openai/whisper-large-v3"
+        if model_id in ("auto", default_gpu_model, default_cpu_model):
+            model_id = default_gpu_model if compute_device.startswith("cuda") else default_cpu_model
+
+        return backend, model_id, compute_device, dtype
 
     def _initialize_model_and_processor(self):
         # Este método será chamado para orquestrar o carregamento do modelo e a criação da pipeline
@@ -145,6 +211,12 @@ class TranscriptionHandler:
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
             model, processor = self._load_model_task()
+            if self.backend_resolved == "ctranslate2" and model:
+                self.pipe = model
+                logging.info("Modelo CTranslate2 carregado.")
+                if self.on_model_ready_callback:
+                    self.on_model_ready_callback()
+                return
             if model and processor:
                 device = f"cuda:{self.gpu_index}" if self.gpu_index >= 0 and torch.cuda.is_available() else "cpu"
 
@@ -352,44 +424,66 @@ class TranscriptionHandler:
         # Removido: model_loaded_successfully = False
         # Removido: error_message = "Unknown error during model load."
         try:
-            # Removido: device_param = "cpu"
-            torch_dtype_local = torch.float32
+            backend, model_id, compute_device, dtype = self._resolve_asr_settings()
+            self.backend_resolved = backend
+            os.environ.setdefault("TRANSFORMERS_CACHE", os.path.expanduser(self.asr_cache_dir))
 
-            if torch.cuda.is_available():
-                if self.gpu_index == -1: # Auto-seleção de GPU
-                    num_gpus = torch.cuda.device_count()
-                    if num_gpus > 0:
-                        best_gpu_index = 0
-                        max_vram = 0
-                        for i in range(num_gpus):
-                            props = torch.cuda.get_device_properties(i)
-                            if props.total_memory > max_vram:
-                                max_vram = props.total_memory
-                                best_gpu_index = i
-                        self.gpu_index = best_gpu_index
-                        logging.info(f"Auto-seleção de GPU (maior VRAM total): {self.gpu_index} ({torch.cuda.get_device_name(self.gpu_index)})")
-                    else:
-                        logging.info("Nenhuma GPU disponível, usando CPU.")
-                        self.gpu_index = -1 # Garante que o índice seja -1 se não houver GPU
-                
-            model_id = "openai/whisper-large-v3"
-            
+            if backend == "ctranslate2":
+                from faster_whisper import WhisperModel
+
+                compute_type = self.asr_ct2_compute_type
+                if compute_type == "auto":
+                    compute_type = "float16" if compute_device == "cuda" else "int8_float16"
+                threads = self.asr_ct2_cpu_threads
+                if isinstance(threads, str) and threads == "auto":
+                    threads = 0
+                model = WhisperModel(
+                    model_id,
+                    device=compute_device,
+                    compute_type=compute_type,
+                    cache_directory=os.path.expanduser(self.asr_cache_dir),
+                    cpu_threads=threads,
+                )
+                return model, None
+
+            torch_dtype_local = torch.float16 if dtype == "float16" else torch.float32
+
+            if compute_device == "cpu":
+                self.gpu_index = -1
+            elif compute_device == "cuda" and self.gpu_index == -1 and torch.cuda.is_available():
+                num_gpus = torch.cuda.device_count()
+                if num_gpus > 0:
+                    best_gpu_index = 0
+                    max_vram = 0
+                    for i in range(num_gpus):
+                        props = torch.cuda.get_device_properties(i)
+                        if props.total_memory > max_vram:
+                            max_vram = props.total_memory
+                            best_gpu_index = i
+                    self.gpu_index = best_gpu_index
+                    logging.info(
+                        f"Auto-seleção de GPU (maior VRAM total): {self.gpu_index} ({torch.cuda.get_device_name(self.gpu_index)})"
+                    )
+                else:
+                    compute_device = "cpu"
+                    self.gpu_index = -1
+
             logging.info(f"Carregando processador de {model_id}...")
             processor = AutoProcessor.from_pretrained(model_id)
 
-            # Determinar o dispositivo explicitamente antes de carregar o modelo
-            device = f"cuda:{self.gpu_index}" if self.gpu_index >= 0 and torch.cuda.is_available() else "cpu"
+            device = (
+                f"cuda:{self.gpu_index}" if compute_device == "cuda" and torch.cuda.is_available() and self.gpu_index >= 0 else "cpu"
+            )
             logging.info(f"Dispositivo de carregamento do modelo definido explicitamente como: {device}")
 
-            if torch.cuda.is_available() and self.gpu_index >= 0:
-                torch_dtype_local = torch.float16
-                logging.info("GPU detectada e selecionada, usando torch.float16.")
+            if compute_device == "cuda" and torch.cuda.is_available() and self.gpu_index >= 0:
+                torch_dtype_local = torch.float16 if dtype == "float16" else torch.float32
             else:
                 torch_dtype_local = torch.float32
                 logging.info("Nenhuma GPU detectada ou selecionada, usando torch.float32 (CPU).")
-            # Seleção automática de GPU por memória livre quando gpu_index == -1
+
             try:
-                if torch.cuda.is_available() and self.gpu_index == -1:
+                if compute_device == "cuda" and torch.cuda.is_available() and self.gpu_index == -1:
                     best_idx = None
                     best_free = -1
                     for i in range(torch.cuda.device_count()):
@@ -404,18 +498,19 @@ class TranscriptionHandler:
                         self.gpu_index = best_idx
                         free_gb = best_free / (1024 ** 3) if best_free > 0 else 0.0
                         total_gb = torch.cuda.get_device_properties(self.gpu_index).total_memory / (1024 ** 3)
-                        logging.info(f"[METRIC] stage=gpu_autoselect gpu={self.gpu_index} free_gb={free_gb:.2f} total_gb={total_gb:.2f}")
+                        logging.info(
+                            f"[METRIC] stage=gpu_autoselect gpu={self.gpu_index} free_gb={free_gb:.2f} total_gb={total_gb:.2f}"
+                        )
+                        device = f"cuda:{self.gpu_index}"
             except Exception as _gpu_sel_e:
                 logging.warning(f"Falha ao escolher GPU por memória livre: {_gpu_sel_e}")
 
             logging.info(f"Carregando modelo {model_id}...")
 
-            # Define configuração de quantização apenas se uma GPU válida estiver disponível
             quant_config = None
-            if torch.cuda.is_available() and self.gpu_index >= 0:
+            if compute_device == "cuda" and torch.cuda.is_available() and self.gpu_index >= 0:
                 quant_config = BitsAndBytesConfig(load_in_8bit=True)
 
-            # Determina dinamicamente se o FlashAttention 2 está disponível
             try:
                 import importlib.util
 
@@ -432,7 +527,6 @@ class TranscriptionHandler:
                 "device_map": {'': device},
                 "attn_implementation": attn_impl,
             }
-            # Adiciona a configuração de quantização somente quando aplicável
             if quant_config is not None:
                 model_kwargs["quantization_config"] = quant_config
 
@@ -448,7 +542,7 @@ class TranscriptionHandler:
                     logging.info(f"[METRIC] stage=attn_impl_effective value={getattr(eff_attn, 'attn_implementation', 'unknown')}")
             except Exception:
                 pass
-            
+
             # Retorna o modelo e o processador para que a pipeline seja criada fora desta função
             return model, processor
 
@@ -473,97 +567,98 @@ class TranscriptionHandler:
 
         text_result = None
         try:
+            if self.backend_resolved == "ctranslate2":
+                segments, _ = self.pipe.transcribe(
+                    audio_source,
+                    language=None,
+                    beam_size=int(self.asr_ct2_beam_size),
+                    temperature=float(self.asr_ct2_temperature),
+                )
+                text_result = "".join(seg.text for seg in segments).strip()
+                if not text_result:
+                    text_result = "[No speech detected]"
+                logging.info("Transcrição via CTranslate2 concluída.")
+            else:
+                if self.pipe is None:
+                    error_message = "Pipeline de transcrição indisponível. Modelo não carregado ou falhou."
+                    logging.error(error_message)
+                    self.on_model_error_callback(error_message)
+                    return
 
-            if self.pipe is None:
-                error_message = "Pipeline de transcrição indisponível. Modelo não carregado ou falhou."
-                logging.error(error_message)
-                self.on_model_error_callback(error_message)
-                return
+                dynamic_batch_size = self._get_dynamic_batch_size()
+                logging.info(f"Iniciando transcrição de segmento com batch_size={dynamic_batch_size}...")
 
-            dynamic_batch_size = self._get_dynamic_batch_size()
-            logging.info(f"Iniciando transcrição de segmento com batch_size={dynamic_batch_size}...")
+                generate_kwargs = {
+                    "task": "transcribe",
+                    "language": None
+                }
+                if isinstance(audio_source, np.ndarray) and audio_source.ndim > 1:
+                    audio_source = audio_source.flatten()
 
-            generate_kwargs = {
-                "task": "transcribe",
-                "language": None
-            }
-            if isinstance(audio_source, np.ndarray) and audio_source.ndim > 1:
-                audio_source = audio_source.flatten()
+                if self.chunk_length_mode == "auto":
+                    try:
+                        self.chunk_length_sec = float(self._effective_chunk_length())
+                    except Exception:
+                        pass
 
-            # Revalidar chunk em runtime se modo auto (segurança extra)
-            if self.chunk_length_mode == "auto":
                 try:
-                    self.chunk_length_sec = float(self._effective_chunk_length())
+                    device = f"cuda:{self.gpu_index}" if torch.cuda.is_available() and self.gpu_index >= 0 else "cpu"
+                except Exception:
+                    device = "cpu"
+                dtype = "fp16" if (torch.cuda.is_available() and self.gpu_index >= 0) else "fp32"
+                try:
+                    import importlib.util as _spec_util
+                    attn_impl = "flash_attn2" if _spec_util.find_spec("flash_attn") is not None else "sdpa"
+                except Exception:
+                    attn_impl = "sdpa"
+
+                t_total_start = time.perf_counter()
+                t_pre_start = time.perf_counter()
+                t_pre_end = time.perf_counter()
+                t_pre_ms = (t_pre_end - t_pre_start) * 1000.0
+
+                with torch.no_grad():
+                    t_infer_start = time.perf_counter()
+                    result = self.pipe(
+                        audio_source,
+                        chunk_length_s=self.chunk_length_sec,
+                        batch_size=dynamic_batch_size,
+                        return_timestamps=False,
+                        generate_kwargs=generate_kwargs
+                    )
+                    t_infer_end = time.perf_counter()
+                t_infer_ms = (t_infer_end - t_infer_start) * 1000.0
+
+                try:
+                    self.last_dynamic_batch_size = int(dynamic_batch_size)
+                except Exception:
+                    self.last_dynamic_batch_size = None
+
+                t_post_start = time.perf_counter()
+
+                if result and "text" in result:
+                    text_result = result["text"].strip()
+                    if not text_result:
+                        text_result = "[No speech detected]"
+                    else:
+                        logging.info("Transcrição de segmento bem-sucedida.")
+                else:
+                    text_result = "[Transcription failed: Bad format]"
+                    logging.error(f"Formato de resultado inesperado: {result}")
+
+                t_post_end = time.perf_counter()
+                t_post_ms = (t_post_end - t_post_start) * 1000.0
+                t_total_ms = (t_post_end - t_total_start) * 1000.0
+
+                try:
+                    logging.info(f"[METRIC] stage=t_pre value_ms={t_pre_ms:.2f} device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} dtype={dtype} attn={attn_impl}")
+                    logging.info(f"[METRIC] stage=t_infer value_ms={t_infer_ms:.2f} device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} dtype={dtype} attn={attn_impl}")
+                    logging.info(f"[METRIC] stage=t_post value_ms={t_post_ms:.2f} device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} dtype={dtype} attn={attn_impl}")
+                    logging.info(f"[METRIC] stage=segment_total value_ms={t_total_ms:.2f} device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} dtype={dtype} attn={attn_impl}")
                 except Exception:
                     pass
 
-            # Métricas detalhadas de tempos: t_pre, t_infer, t_post e t_total_segment
-            # Campos técnicos
-            try:
-                device = f"cuda:{self.gpu_index}" if torch.cuda.is_available() and self.gpu_index >= 0 else "cpu"
-            except Exception:
-                device = "cpu"
-            dtype = "fp16" if (torch.cuda.is_available() and self.gpu_index >= 0) else "fp32"
-            try:
-                import importlib.util as _spec_util
-                attn_impl = "flash_attn2" if _spec_util.find_spec("flash_attn") is not None else "sdpa"
-            except Exception:
-                attn_impl = "sdpa"
-
-            t_total_start = time.perf_counter()
-            # t_pre: placeholder para etapas leves de pré-processamento (flatten já foi aplicado)
-            t_pre_start = time.perf_counter()
-            t_pre_end = time.perf_counter()
-            t_pre_ms = (t_pre_end - t_pre_start) * 1000.0
-
-            # Inferência (t_infer) sob no_grad
-            with torch.no_grad():
-                t_infer_start = time.perf_counter()
-                result = self.pipe(
-                    audio_source,
-                    chunk_length_s=self.chunk_length_sec,
-                    batch_size=dynamic_batch_size,
-                    return_timestamps=False,
-                    generate_kwargs=generate_kwargs
-                )
-                t_infer_end = time.perf_counter()
-            t_infer_ms = (t_infer_end - t_infer_start) * 1000.0
-
-            # Expor último batch dinâmico para UI/tooltip
-            try:
-                self.last_dynamic_batch_size = int(dynamic_batch_size)
-            except Exception:
-                self.last_dynamic_batch_size = None
-
-            # t_post: montagem/validação do texto
-            t_post_start = time.perf_counter()
-            # o processamento de result segue abaixo (text_result, etc.)
-
-            if result and "text" in result:
-                text_result = result["text"].strip()
-                if not text_result:
-                    text_result = "[No speech detected]"
-                else:
-                    logging.info("Transcrição de segmento bem-sucedida.")
-            else:
-                text_result = "[Transcription failed: Bad format]"
-                logging.error(f"Formato de resultado inesperado: {result}")
-
-            # concluir t_post e t_total
-            t_post_end = time.perf_counter()
-            t_post_ms = (t_post_end - t_post_start) * 1000.0
-            t_total_ms = (t_post_end - t_total_start) * 1000.0
-
-            # Logs [METRIC]
-            try:
-                logging.info(f"[METRIC] stage=t_pre value_ms={t_pre_ms:.2f} device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} dtype={dtype} attn={attn_impl}")
-                logging.info(f"[METRIC] stage=t_infer value_ms={t_infer_ms:.2f} device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} dtype={dtype} attn={attn_impl}")
-                logging.info(f"[METRIC] stage=t_post value_ms={t_post_ms:.2f} device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} dtype={dtype} attn={attn_impl}")
-                logging.info(f"[METRIC] stage=segment_total value_ms={t_total_ms:.2f} device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} dtype={dtype} attn={attn_impl}")
-            except Exception:
-                pass
-
-            # Fim do bloco de processamento principal do segmento
+                # Fim do bloco de processamento principal do segmento
 
         except Exception as e:
             # Tratamento de OOM e fallback automático (reduz batch, depois chunk) – não recria a pipeline

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -370,6 +370,50 @@ class UIManager:
                 chunk_length_sec_var = ctk.DoubleVar(value=self.config_manager.get_chunk_length_sec())
                 # New: Torch compile switch variable
                 enable_torch_compile_var = ctk.BooleanVar(value=self.config_manager.get_enable_torch_compile())
+                asr_backend_var = ctk.StringVar(value=self.config_manager.get_asr_backend())
+                asr_model_id_var = ctk.StringVar(value=self.config_manager.get_asr_model_id())
+                asr_compute_device_var = ctk.StringVar(value=self.config_manager.get_asr_compute_device())
+                asr_dtype_var = ctk.StringVar(value=self.config_manager.get_asr_dtype())
+                asr_ct2_compute_type_var = ctk.StringVar(value=self.config_manager.get_asr_ct2_compute_type())
+                asr_ct2_cpu_threads_var = ctk.StringVar(value=str(self.config_manager.get_asr_ct2_cpu_threads()))
+                asr_ct2_beam_size_var = ctk.IntVar(value=self.config_manager.get_asr_ct2_beam_size())
+                asr_ct2_temperature_var = ctk.DoubleVar(value=self.config_manager.get_asr_ct2_temperature())
+                asr_cache_dir_var = ctk.StringVar(value=self.config_manager.get_asr_cache_dir())
+
+                def _current_model_options():
+                    curated = [m.get("model_id", "") for m in self.config_manager.get_asr_curated_catalog()]
+                    installed = self.config_manager.get_asr_installed_models()
+                    return sorted({m for m in curated + installed if m})
+
+                model_options = _current_model_options()
+                asr_model_select_var = ctk.StringVar(value=model_options[0] if model_options else "")
+
+                def refresh_catalog(menu):
+                    url = self.config_manager.get_asr_curated_catalog_url()
+                    if self.config_manager.update_asr_curated_catalog_from_url(url):
+                        new_vals = _current_model_options()
+                        menu.configure(values=new_vals)
+                        if new_vals:
+                            asr_model_select_var.set(new_vals[0])
+                        messagebox.showinfo("Catálogo", "Catálogo atualizado com sucesso.", parent=settings_win)
+                    else:
+                        messagebox.showerror("Catálogo", "Falha ao atualizar catálogo.", parent=settings_win)
+
+                def remove_model(model_id):
+                    self.config_manager.remove_installed_model(model_id)
+                    new_vals = _current_model_options()
+                    asr_model_menu.configure(values=new_vals)
+                    if new_vals:
+                        asr_model_select_var.set(new_vals[0])
+                    messagebox.showinfo("Cache", "Modelo removido.", parent=settings_win)
+
+                def clear_cache():
+                    if messagebox.askyesno("Cache", "Remover todos os modelos do cache?", parent=settings_win):
+                        self.config_manager.clear_installed_models()
+                        new_vals = _current_model_options()
+                        asr_model_menu.configure(values=new_vals)
+                        if new_vals:
+                            asr_model_select_var.set(new_vals[0])
 
                 def update_text_correction_fields():
                     enabled = text_correction_enabled_var.get()
@@ -454,6 +498,27 @@ class UIManager:
                     if max_memory_seconds_to_apply is None:
                         return
 
+                    asr_backend_to_apply = asr_backend_var.get()
+                    asr_model_id_to_apply = asr_model_id_var.get()
+                    asr_compute_device_to_apply = asr_compute_device_var.get()
+                    asr_dtype_to_apply = asr_dtype_var.get()
+                    asr_ct2_compute_type_to_apply = asr_ct2_compute_type_var.get()
+                    ct2_threads_input = asr_ct2_cpu_threads_var.get().strip()
+                    if ct2_threads_input.lower() == "auto":
+                        asr_ct2_cpu_threads_to_apply = "auto"
+                    else:
+                        ct2_threads_val = self._safe_get_int(asr_ct2_cpu_threads_var, "CT2 Threads", settings_win)
+                        if ct2_threads_val is None:
+                            return
+                        asr_ct2_cpu_threads_to_apply = ct2_threads_val
+                    asr_ct2_beam_size_to_apply = self._safe_get_int(asr_ct2_beam_size_var, "CT2 Beam Size", settings_win)
+                    if asr_ct2_beam_size_to_apply is None:
+                        return
+                    asr_ct2_temperature_to_apply = self._safe_get_float(asr_ct2_temperature_var, "CT2 Temperature", settings_win)
+                    if asr_ct2_temperature_to_apply is None:
+                        return
+                    asr_cache_dir_to_apply = asr_cache_dir_var.get()
+
                     # Logic for converting UI to GPU index
                     selected_device_str = gpu_selection_var.get()
                     gpu_index_to_apply = -1 # Default to "Auto-select"
@@ -511,7 +576,16 @@ class UIManager:
                         new_chunk_length_mode=chunk_length_mode_var.get(),
                         new_chunk_length_sec=float(chunk_length_sec_var.get()),
                         # New: torch compile setting
-                        new_enable_torch_compile=bool(enable_torch_compile_var.get())
+                        new_enable_torch_compile=bool(enable_torch_compile_var.get()),
+                        new_asr_backend=asr_backend_to_apply,
+                        new_asr_model_id=asr_model_id_to_apply,
+                        new_asr_compute_device=asr_compute_device_to_apply,
+                        new_asr_dtype=asr_dtype_to_apply,
+                        new_asr_ct2_compute_type=asr_ct2_compute_type_to_apply,
+                        new_asr_ct2_cpu_threads=asr_ct2_cpu_threads_to_apply,
+                        new_asr_ct2_beam_size=asr_ct2_beam_size_to_apply,
+                        new_asr_ct2_temperature=asr_ct2_temperature_to_apply,
+                        new_asr_cache_dir=asr_cache_dir_to_apply
                     )
                     self._close_settings_window() # Call class method
 
@@ -588,6 +662,15 @@ class UIManager:
                     max_memory_seconds_var.set(DEFAULT_CONFIG["max_memory_seconds"])
                     max_memory_seconds_mode_var.set(DEFAULT_CONFIG["max_memory_seconds_mode"])
                     launch_at_startup_var.set(DEFAULT_CONFIG["launch_at_startup"])
+                    asr_backend_var.set(DEFAULT_CONFIG["asr_backend"])
+                    asr_model_id_var.set(DEFAULT_CONFIG["asr_model_id"])
+                    asr_compute_device_var.set(DEFAULT_CONFIG["asr_compute_device"])
+                    asr_dtype_var.set(DEFAULT_CONFIG["asr_dtype"])
+                    asr_ct2_compute_type_var.set(DEFAULT_CONFIG["asr_ct2_compute_type"])
+                    asr_ct2_cpu_threads_var.set(str(DEFAULT_CONFIG["asr_ct2_cpu_threads"]))
+                    asr_ct2_beam_size_var.set(DEFAULT_CONFIG["asr_ct2_beam_size"])
+                    asr_ct2_temperature_var.set(DEFAULT_CONFIG["asr_ct2_temperature"])
+                    asr_cache_dir_var.set(DEFAULT_CONFIG["asr_cache_dir"])
 
                     self.config_manager.save_config()
 
@@ -888,6 +971,79 @@ class UIManager:
                 display_switch = ctk.CTkSwitch(display_transcripts_frame, text="Display Transcript in Terminal", variable=display_transcripts_var)
                 display_switch.pack(side="left", padx=5)
                 Tooltip(display_switch, "Print transcripts to the terminal window.")
+
+                # --- ASR Settings ---
+                asr_backend_frame = ctk.CTkFrame(transcription_frame)
+                asr_backend_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(asr_backend_frame, text="ASR Backend:").pack(side="left", padx=(5, 10))
+                asr_backend_menu = ctk.CTkOptionMenu(asr_backend_frame, variable=asr_backend_var, values=["auto", "transformers"])
+                asr_backend_menu.pack(side="left", padx=5)
+                Tooltip(asr_backend_menu, "Inference backend for speech recognition.")
+
+                asr_model_frame = ctk.CTkFrame(transcription_frame)
+                asr_model_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(asr_model_frame, text="ASR Model ID:").pack(side="left", padx=(5, 10))
+                asr_model_menu = ctk.CTkOptionMenu(asr_model_frame, variable=asr_model_select_var, values=model_options, command=lambda choice: asr_model_id_var.set(choice))
+                asr_model_menu.pack(side="left", padx=5)
+                asr_model_entry = ctk.CTkEntry(asr_model_frame, textvariable=asr_model_id_var, width=180)
+                asr_model_entry.pack(side="left", padx=5)
+                update_catalog_btn = ctk.CTkButton(asr_model_frame, text="Atualizar Catálogo", command=lambda: refresh_catalog(asr_model_menu))
+                update_catalog_btn.pack(side="left", padx=5)
+                Tooltip(asr_model_entry, "Hugging Face model identifier.")
+
+                asr_device_frame = ctk.CTkFrame(transcription_frame)
+                asr_device_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(asr_device_frame, text="ASR Compute Device:").pack(side="left", padx=(5, 10))
+                asr_device_menu = ctk.CTkOptionMenu(asr_device_frame, variable=asr_compute_device_var, values=["auto", "cuda", "cpu"])
+                asr_device_menu.pack(side="left", padx=5)
+                Tooltip(asr_device_menu, "Execution device for ASR model.")
+
+                asr_dtype_frame = ctk.CTkFrame(transcription_frame)
+                asr_dtype_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(asr_dtype_frame, text="ASR DType:").pack(side="left", padx=(5, 10))
+                asr_dtype_menu = ctk.CTkOptionMenu(asr_dtype_frame, variable=asr_dtype_var, values=["auto", "float16", "float32"])
+                asr_dtype_menu.pack(side="left", padx=5)
+                Tooltip(asr_dtype_menu, "Torch dtype for ASR model.")
+
+                asr_ct2_frame = ctk.CTkFrame(transcription_frame)
+                asr_ct2_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(asr_ct2_frame, text="CT2 Compute Type:").pack(side="left", padx=(5, 10))
+                asr_ct2_menu = ctk.CTkOptionMenu(asr_ct2_frame, variable=asr_ct2_compute_type_var, values=["auto", "float16", "float32", "int8_float16", "int8_float32", "int4_float16"])
+                asr_ct2_menu.pack(side="left", padx=5)
+                Tooltip(asr_ct2_menu, "Compute type for CTranslate2 backend.")
+
+                asr_ct2_threads_frame = ctk.CTkFrame(transcription_frame)
+                asr_ct2_threads_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(asr_ct2_threads_frame, text="CT2 Threads:").pack(side="left", padx=(5, 10))
+                asr_ct2_threads_entry = ctk.CTkEntry(asr_ct2_threads_frame, textvariable=asr_ct2_cpu_threads_var, width=80)
+                asr_ct2_threads_entry.pack(side="left", padx=5)
+                Tooltip(asr_ct2_threads_entry, "CPU threads for CTranslate2 backend.")
+
+                asr_ct2_beam_frame = ctk.CTkFrame(transcription_frame)
+                asr_ct2_beam_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(asr_ct2_beam_frame, text="CT2 Beam Size:").pack(side="left", padx=(5, 10))
+                asr_ct2_beam_entry = ctk.CTkEntry(asr_ct2_beam_frame, textvariable=asr_ct2_beam_size_var, width=80)
+                asr_ct2_beam_entry.pack(side="left", padx=5)
+                Tooltip(asr_ct2_beam_entry, "Beam search size for CTranslate2 backend.")
+
+                asr_ct2_temp_frame = ctk.CTkFrame(transcription_frame)
+                asr_ct2_temp_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(asr_ct2_temp_frame, text="CT2 Temperature:").pack(side="left", padx=(5, 10))
+                asr_ct2_temp_entry = ctk.CTkEntry(asr_ct2_temp_frame, textvariable=asr_ct2_temperature_var, width=80)
+                asr_ct2_temp_entry.pack(side="left", padx=5)
+                Tooltip(asr_ct2_temp_entry, "Temperature parameter for decoding.")
+
+                asr_cache_frame = ctk.CTkFrame(transcription_frame)
+                asr_cache_frame.pack(fill="x", pady=5)
+                ctk.CTkLabel(asr_cache_frame, text="ASR Cache Dir:").pack(side="left", padx=(5, 10))
+                asr_cache_entry = ctk.CTkEntry(asr_cache_frame, textvariable=asr_cache_dir_var, width=240)
+                asr_cache_entry.pack(side="left", padx=5)
+                Tooltip(asr_cache_entry, "Directory for cached ASR models.")
+
+                cache_actions_frame = ctk.CTkFrame(transcription_frame)
+                cache_actions_frame.pack(fill="x", pady=5)
+                ctk.CTkButton(cache_actions_frame, text="Remover Modelo", command=lambda: remove_model(asr_model_select_var.get())).pack(side="left", padx=5)
+                ctk.CTkButton(cache_actions_frame, text="Limpar Cache", command=clear_cache).pack(side="left", padx=5)
 
                 # --- Action Buttons ---
                 button_frame = ctk.CTkFrame(settings_win) # Move outside scrollable_frame to keep fixed

--- a/tests/test_asr_features.py
+++ b/tests/test_asr_features.py
@@ -1,0 +1,230 @@
+import types
+import importlib.util
+import pathlib
+import sys
+import json
+import hmac
+import hashlib
+import requests
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+sys.modules.setdefault("pyautogui", types.ModuleType("pyautogui"))
+sys.modules.setdefault("pyperclip", types.ModuleType("pyperclip"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+sys.modules.setdefault("sounddevice", types.ModuleType("sounddevice"))
+sys.modules.setdefault("psutil", types.ModuleType("psutil"))
+sys.modules.setdefault("onnxruntime", types.ModuleType("onnxruntime"))
+torch_stub = types.ModuleType("torch")
+torch_stub.cuda = types.SimpleNamespace(is_available=lambda: False)
+sys.modules.setdefault("torch", torch_stub)
+transformers_stub = types.ModuleType("transformers")
+transformers_stub.pipeline = lambda *a, **k: None
+class _DummyAuto:
+    @staticmethod
+    def from_pretrained(*a, **k):
+        return object()
+transformers_stub.AutoProcessor = _DummyAuto
+transformers_stub.AutoModelForSpeechSeq2Seq = _DummyAuto
+sys.modules.setdefault("transformers", transformers_stub)
+sys.modules.setdefault("keyboard", types.ModuleType("keyboard"))
+google_stub = types.ModuleType("google")
+generativeai_stub = types.ModuleType("google.generativeai")
+generativeai_stub.types = types.ModuleType("google.generativeai.types")
+generativeai_stub.types.helper_types = types.SimpleNamespace()
+generativeai_stub.types.BrokenResponseError = Exception
+generativeai_stub.types.IncompleteIterationError = Exception
+google_stub.generativeai = generativeai_stub
+sys.modules.setdefault("google", google_stub)
+sys.modules.setdefault("google.generativeai", generativeai_stub)
+sys.modules.setdefault("google.generativeai.types", generativeai_stub.types)
+
+from src.config_manager import (
+    ConfigManager,
+    EMBEDDED_ASR_CATALOG,
+    CATALOG_SIGNATURE_KEY,
+)
+from src.core import AppCore
+from src.transcription_handler import TranscriptionHandler
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_curated_catalog_update(monkeypatch):
+    models = [{"model_id": "m1"}, {"model_id": "m2"}]
+    sig = hmac.new(
+        CATALOG_SIGNATURE_KEY,
+        json.dumps(models, sort_keys=True).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    data = {"models": models, "signature": sig}
+    monkeypatch.setattr(
+        "requests.get", lambda url, timeout=10: DummyResponse(data)
+    )
+    cm = ConfigManager()
+    assert cm.get_asr_curated_catalog() == models
+
+
+def test_resolve_backend_ct2(monkeypatch):
+    monkeypatch.setattr("requests.get", lambda url, timeout=10: DummyResponse([]))
+    cm = ConfigManager()
+    th = TranscriptionHandler(
+        config_manager=cm,
+        gemini_api_client=None,
+        on_model_ready_callback=lambda: None,
+        on_model_error_callback=lambda e: None,
+        on_transcription_result_callback=lambda r: None,
+        on_agent_result_callback=lambda r: None,
+        on_segment_transcribed_callback=lambda s: None,
+        is_state_transcribing_fn=lambda: False,
+    )
+
+    th.asr_backend = "auto"
+
+    def fake_find_spec(name):
+        if name == "faster_whisper":
+            return object()
+        return importlib.util.find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    backend, *_ = th._resolve_asr_settings()
+    assert backend == "ctranslate2"
+
+
+def test_apply_settings_updates_trans_handler(monkeypatch):
+    data = [{"model_id": "m1"}]
+    monkeypatch.setattr(
+        "requests.get", lambda url, timeout=10: DummyResponse(data)
+    )
+
+    class DummyAudioHandler:
+        def __init__(self, *_, **__):
+            self.is_recording = False
+
+        def update_config(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    class DummyTransHandler:
+        def __init__(self, config_manager, **kwargs):
+            self.config_manager = config_manager
+            self.gemini_client = None
+            self.openrouter_client = None
+
+        def start_model_loading(self):
+            pass
+
+        def update_config(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    class DummyKeyboardHotkeyManager:
+        def __init__(self, *_, **__):
+            pass
+
+        def update_config(self, **kwargs):
+            pass
+
+    class DummyGeminiAPI:
+        def __init__(self, *_):
+            pass
+
+        def reinitialize_client(self):
+            pass
+
+    monkeypatch.setattr("src.core.AudioHandler", DummyAudioHandler)
+    monkeypatch.setattr("src.core.TranscriptionHandler", DummyTransHandler)
+    monkeypatch.setattr("src.core.KeyboardHotkeyManager", DummyKeyboardHotkeyManager)
+    monkeypatch.setattr("src.core.GeminiAPI", DummyGeminiAPI)
+
+    updated = {}
+    def mark_update(self):
+        updated["called"] = True
+    monkeypatch.setattr(DummyTransHandler, "update_config", mark_update)
+
+    app = AppCore(None)
+    updated.clear()
+    app.apply_settings_from_external(new_asr_model_id="model-x")
+    app.transcription_handler.update_config()
+    assert updated.get("called")
+
+
+def test_scan_cache_and_remove(tmp_path, monkeypatch):
+    monkeypatch.setattr("requests.get", lambda url, timeout=10: DummyResponse([]))
+    cache_dir = tmp_path / "cache"
+    (cache_dir / "m1").mkdir(parents=True)
+    (cache_dir / "m2").mkdir()
+    cm = ConfigManager()
+    cm.set_asr_cache_dir(str(cache_dir))
+    cm.scan_asr_cache_dir()
+    assert set(cm.get_asr_installed_models()) == {"m1", "m2"}
+    cm.remove_installed_model("m1")
+    assert cm.get_asr_installed_models() == ["m2"]
+
+
+def test_ct2_advanced_params(monkeypatch):
+    class DummyModel:
+        def __init__(self, *a, **k):
+            pass
+
+        def transcribe(self, audio, language=None, beam_size=0, temperature=0.0):
+            self.beam_size = beam_size
+            self.temperature = temperature
+            return [], None
+
+    monkeypatch.setattr("requests.get", lambda url, timeout=10: DummyResponse([]))
+    cm = ConfigManager()
+    th = TranscriptionHandler(
+        config_manager=cm,
+        gemini_api_client=None,
+        on_model_ready_callback=lambda: None,
+        on_model_error_callback=lambda e: None,
+        on_transcription_result_callback=lambda r: None,
+        on_agent_result_callback=lambda r: None,
+        on_segment_transcribed_callback=lambda s: None,
+        is_state_transcribing_fn=lambda: False,
+    )
+    th.backend_resolved = "ctranslate2"
+    th.pipe = DummyModel()
+    th.asr_ct2_beam_size = 7
+    th.asr_ct2_temperature = 0.5
+    th._transcription_task("dummy", False)
+    assert th.pipe.beam_size == 7
+    assert th.pipe.temperature == 0.5
+
+
+def test_catalog_fallback(monkeypatch):
+    models = [{"model_id": "m1"}]
+    sig = hmac.new(
+        CATALOG_SIGNATURE_KEY,
+        json.dumps(models, sort_keys=True).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    monkeypatch.setattr(
+        "requests.get", lambda url, timeout=10: DummyResponse({"models": models, "signature": sig})
+    )
+    cm = ConfigManager()
+    assert cm.get_asr_curated_catalog() == models
+
+    def _fail(*a, **k):
+        raise requests.RequestException("fail")
+
+    monkeypatch.setattr("requests.get", _fail)
+    cm2 = ConfigManager()
+    assert cm2.get_asr_curated_catalog() == EMBEDDED_ASR_CATALOG
+


### PR DESCRIPTION
## Summary
- support beam size, temperature and int4 quantization for the CTranslate2 backend
- auto-scan the ASR cache with GUI options to remove or clear models
- validate signed curated catalogs with retry/backoff and fallback

## Testing
- `python -m py_compile src/config_manager.py src/transcription_handler.py src/ui_manager.py src/core.py tests/test_asr_features.py`
- `pytest --cov=src -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03c278f908330b61b765d9c923477