### PR TITLE
Fix ensure_download usage with new signature

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -490,7 +490,12 @@ class TranscriptionHandler:
 
             # --- Fallback sem whisper_flash ---
             model_id = self.asr_model_id
-            ensure_download(model_id, config_manager=self.config_manager)
+            ensure_download(
+                model_id,
+                backend=self.asr_backend,
+                cache_dir=self.asr_cache_dir,
+                quant=self.asr_ct2_compute_type,
+            )
             logging.info(f"Carregando processador de {model_id}...")
             processor = AutoProcessor.from_pretrained(model_id)
 

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -962,7 +962,9 @@ class UIManager:
                 def _install_model() -> None:
                     try:
                         model_manager.ensure_download(
-                            asr_backend_var.get(), asr_model_var.get()
+                            asr_model_var.get(),
+                            asr_backend_var.get(),
+                            self.config_manager.get_asr_cache_dir(),
                         )
                     except Exception as e:  # pragma: no cover
                         logging.error("Model download failed: %s", e)


### PR DESCRIPTION
## Summary
- adjust TranscriptionHandler to call `ensure_download` with backend, cache directory, and quantization arguments
- update UIManager's model installation to use new `ensure_download` signature and respect configured cache directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c096ab489483308dcaf8272c0ab844