### PR TITLE
feat: show model download size and fix settings UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A lightweight, high-performance desktop tool for Windows that turns your speech 
     *   Quickly switch between Gemini models directly from the tray menu.
 *   **Auditory Feedback:** Optional sound cues for starting and stopping recording.
 *   **Automatically remove silent sections** using the Silero VAD. Initialization uses `onnxruntime` with automatic selection of `CUDAExecutionProvider` when available, falling back to `CPUExecutionProvider`.
+*   **Model awareness:** the settings UI shows the download size of each Whisper model and whether it is already installed.
 *   **Robust and Stable:** Includes a background service to ensure hotkeys remain responsive, a common issue on Windows 11.
 *   **Launch at Startup Option:** Start the application automatically when Windows boots.
 *   **Unified `TRANSCRIBING` State:** recording, Whisper processing, and optional AI correction all occur while the application remains in this state. Once the final text is ready, the state returns to `IDLE`.


### PR DESCRIPTION
## Summary
- show Whisper model download size and installed status in settings UI
- fix duplicated ASR model sections and restore Apply/Cancel buttons
- add helper to fetch model size from Hugging Face Hub

## Testing
- `flake8 src/model_manager.py src/ui_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2c5a2f2048330887fbd2d983bc0aa