### PR TITLE
Fix undefined ct2 quantization variable

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -391,6 +391,9 @@ class UIManager:
                 asr_compute_device_var = ctk.StringVar(value=self.config_manager.get_asr_compute_device())
                 asr_dtype_var = ctk.StringVar(value=self.config_manager.get_asr_dtype())
                 asr_ct2_compute_type_var = ctk.StringVar(value=self.config_manager.get_asr_ct2_compute_type())
+                ct2_quant_var = ctk.StringVar(
+                    value=self.config_manager.get("ct2_quantization", "float16")
+                )
                 asr_cache_dir_var = ctk.StringVar(value=self.config_manager.get_asr_cache_dir())
 
                 def update_text_correction_fields():


### PR DESCRIPTION
## Summary
- Initialize missing `ct2_quant_var` in settings GUI to avoid NameError

## Testing
- `python -m py_compile src/ui_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c309e35cb0833095f04b0177a6abb4