### PR TITLE
Standardize ASR backend naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ With your virtual environment activated, you can now install the libraries the a
     ```
 The `pip` command is Python's package installer. The `-r requirements.txt` part tells pip to install everything listed in that file. This step will download and install all necessary packages, including large ones like `torch` and `transformers`. This might take several minutes depending on your internet speed.
 
-2.  **Optional: Install faster-whisper backend (for ctranslate2 support):**
-    These packages provide an alternative Whisper backend powered by CTranslate2. They require AVX2 support or a recent GPU and may fail on older CPUs. Install them only if your hardware supports these features.
+2.  **Optional: Install CTranslate2 backend (via faster-whisper):**
+    These packages provide an alternative Whisper backend powered by CTranslate2 through the `faster-whisper` library. They require AVX2 support or a recent GPU and may fail on older CPUs. Install them only if your hardware supports these features.
     ```bash
     pip install -r requirements-optional.txt
     ```
@@ -287,11 +287,15 @@ The speech recognition engine supports multiple backends. The following keys in 
 | Key | Description | Example |
 | --- | ----------- | ------- |
 | `asr_model_id` | Model identifier to download. | `"openai/whisper-large-v3"` |
-| `asr_backend` | Backend implementation (`transformers`, `ct2`, etc.). | `"transformers"` |
+| `asr_backend` | Backend implementation (`transformers` or `ct2`). The value `faster-whisper` is accepted as an alias for `ct2`. | `"transformers"` |
 | `asr_compute_device` | Target device such as `cpu`, `cuda:0`, or `auto`. | `"cuda:0"` |
 | `asr_dtype` | Numerical precision (`float16`, `float32`, ...). | `"float16"` |
 | `asr_ct2_compute_type` | Compute type for the CTranslate2 backend. | `"default"` |
 | `asr_cache_dir` | Optional path to cache downloaded models. | `"/models"` |
+
+> **Note:** When loading settings, the application normalizes backend names.
+Values such as `faster-whisper` or `ctranslate2` are automatically mapped to
+`ct2`.
 
 Examples:
 

--- a/src/asr/backends.py
+++ b/src/asr/backends.py
@@ -6,13 +6,19 @@ from typing import Protocol
 class ASRBackend(Protocol):
     """Minimal interface for ASR backends."""
 
-    def load(self, *args, **kwargs) -> None: ...
+    def load(self, *args, **kwargs) -> None:
+        ...
 
-    def warmup(self) -> None: ...
+    def warmup(self) -> None:
+        ...
 
-    def transcribe(self, audio: str | bytes | list[float] | None, **kwargs) -> dict: ...
+    def transcribe(
+        self, audio: str | bytes | list[float] | None, **kwargs
+    ) -> dict:
+        ...
 
-    def unload(self) -> None: ...
+    def unload(self) -> None:
+        ...
 
 
 def make_backend(name: str) -> ASRBackend:
@@ -21,7 +27,7 @@ def make_backend(name: str) -> ASRBackend:
     if normalized == "transformers":
         from .backend_transformers import TransformersBackend
         return TransformersBackend()
-    if normalized in {"faster-whisper", "faster_whisper"}:
+    if normalized in {"faster-whisper", "faster_whisper", "ct2", "ctranslate2"}:
         from .backend_faster_whisper import FasterWhisperBackend
         return FasterWhisperBackend()
     raise ValueError(f"Unknown ASR backend: {name}")

--- a/src/asr_backends.py
+++ b/src/asr_backends.py
@@ -100,6 +100,8 @@ class _AdapterBackend:
 backend_registry.update(
     {
         "transformers": lambda h: _AdapterBackend(h, "transformers"),
+        "ct2": lambda h: _AdapterBackend(h, "faster-whisper"),
+        "ctranslate2": lambda h: _AdapterBackend(h, "faster-whisper"),
         "faster-whisper": lambda h: _AdapterBackend(h, "faster-whisper"),
     }
 )

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -950,7 +950,7 @@ class UIManager:
                 asr_backend_menu = ctk.CTkOptionMenu(
                     asr_backend_frame,
                     variable=asr_backend_var,
-                    values=["auto", "transformers", "faster-whisper", "ct2"],
+                    values=["auto", "transformers", "ct2"],
                     command=_on_backend_change,
                 )
                 asr_backend_menu.pack(side="left", padx=5)
@@ -960,7 +960,7 @@ class UIManager:
                 quant_frame.pack(fill="x", pady=5)
                 ctk.CTkLabel(quant_frame, text="Quantization:").pack(side="left", padx=(5, 10))
                 quant_menu = ctk.CTkOptionMenu(
-                    quant_frame, variable=ct2_quant_var, values=["float16", "int8", "int8_float16"]
+                    quant_frame, variable=asr_ct2_compute_type_var, values=["float16", "int8", "int8_float16"]
                 )
                 quant_menu.pack(side="left", padx=5)
 
@@ -1053,10 +1053,10 @@ class UIManager:
                 def _install_model():
                     try:
                         backend = asr_backend_var.get()
-                        if backend == "faster-whisper":
-                            backend = "ct2"
-                        elif backend == "auto":
+                        if backend == "auto":
                             backend = "transformers"
+                        elif backend in ("faster-whisper", "ctranslate2"):
+                            backend = "ct2"
 
                         model_manager.ensure_download(
                             asr_model_id_var.get(),


### PR DESCRIPTION
## Summary
- normalize ASR backend names and map legacy aliases to `ct2`
- drop duplicate `faster-whisper` option from backend menu
- document backend normalization in README

## Testing
- `flake8 src/config_manager.py src/ui_manager.py src/asr_backends.py src/asr/backends.py --extend-ignore=F811,F821,W503`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c30a0416088330927dae889cb959d4