### PR TITLE
Gracefully handle canceled model downloads

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -33,7 +33,7 @@ from .audio_handler import AudioHandler, AUDIO_SAMPLE_RATE # AUDIO_SAMPLE_RATE a
 from .transcription_handler import TranscriptionHandler
 from .keyboard_hotkey_manager import KeyboardHotkeyManager # Assumindo que está na raiz
 from .gemini_api import GeminiAPI # Adicionado para correção de texto
-from .model_manager import ensure_download
+from .model_manager import DownloadCancelledError, ensure_download
 
 # Estados da aplicação (movidos de global)
 STATE_IDLE = "IDLE"
@@ -115,6 +115,10 @@ class AppCore:
             ):
                 try:
                     ensure_download(model_id, backend, cache_dir, quant=ct2_type)
+                except DownloadCancelledError:
+                    logging.info("Model download cancelled by user.")
+                    messagebox.showinfo("Model", "Download canceled.")
+                    self._set_state(STATE_LOADING_MODEL)
                 except Exception as e:
                     logging.error(f"Model download failed: {e}")
                     messagebox.showerror("Model", f"Download failed: {e}")

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -40,6 +40,12 @@ except Exception:  # pragma: no cover - fallback caso o módulo não exista
 
     model_manager = _DummyModelManager()
 
+try:
+    from .model_manager import DownloadCancelledError
+except Exception:  # pragma: no cover - fallback se a exceção não existir
+    class DownloadCancelledError(Exception):
+        pass
+
 def get_available_devices_for_ui():
     """Returns a list of devices for the settings interface."""
     devices = ["Auto-select (Recommended)"]
@@ -1069,6 +1075,8 @@ class UIManager:
                         self.config_manager.save_config()
                         _update_model_info(asr_model_id_var.get())
                         messagebox.showinfo("Model", "Download completed.")
+                    except DownloadCancelledError:
+                        messagebox.showinfo("Model", "Download canceled.")
                     except Exception as e:
                         messagebox.showerror("Model", f"Download failed: {e}")
 


### PR DESCRIPTION
## Summary
- Add `DownloadCancelledError` to distinguish user-initiated cancellations
- Avoid switching to error state when a model download is canceled
- Show informational messages for canceled downloads in the UI

## Testing
- `python -m py_compile src/model_manager.py src/core.py src/ui_manager.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c30a0b6dd08330ad6e41cf0d8c6b04