### PR TITLE
Ensure tray icon appears by using run_detached

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -1155,11 +1155,11 @@ class UIManager:
         self.core_instance_ref.set_state_update_callback(self.update_tray_icon)
         self.core_instance_ref.set_segment_callback(self.update_live_transcription_threadsafe) # Connect segment callback
 
-        def run_tray_icon_in_thread(icon):
-            icon.run()
-
-        tray_thread = threading.Thread(target=run_tray_icon_in_thread, args=(self.tray_icon,), daemon=True, name="PystrayThread")
-        tray_thread.start()
+        # pystray's run() blocks the main thread. Since the application uses
+        # Tkinter's mainloop, run the tray icon in detached mode so both loops
+        # can coexist without relying on an extra thread that might terminate
+        # prematurely.
+        self.tray_icon.run_detached()
     
     def _close_settings_window(self):
         """Closes the settings window and resets the flag."""


### PR DESCRIPTION
## Summary
- Start Pystray icon via `run_detached` to avoid hidden tray icon

## Testing
- `python -m py_compile src/ui_manager.py`
- `python -m py_compile src/main.py`
- `flake8 src/ui_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c341a9b274833098f62c518229c252