### PR TITLE
Evita deadlock ao fechar janela de configurações

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -346,7 +346,9 @@ class UIManager:
                 logging.error("Failed to initialize settings UI", exc_info=True)
                 self.settings_thread_running = False
                 if self.settings_window_instance:
-                    self._close_settings_window()
+                    # Avoid deadlock: destroy directly without reacquiring the lock
+                    self.settings_window_instance.destroy()
+                    self.settings_window_instance = None
                 return
 
             try:


### PR DESCRIPTION
## Summary
- Destroi diretamente a janela de configurações quando ocorre falha na inicialização para evitar reaquisição de `settings_window_lock`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c3435beb70833091aa0b1490d569f5