### PR TITLE
Handle ASR cache dir defaulting and normalization

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -278,9 +278,20 @@ class ConfigManager:
             secrets_loaded = {}
             self._secrets_hash = None
 
+        # Validar caminho do cache de ASR
+        asr_cache_dir = cfg.get(ASR_CACHE_DIR_CONFIG_KEY, "")
+        asr_cache_dir = os.path.expanduser(str(asr_cache_dir)) if isinstance(asr_cache_dir, str) else ""
+        if not asr_cache_dir or not os.path.isdir(asr_cache_dir):
+            asr_cache_dir = os.path.expanduser(self.default_config[ASR_CACHE_DIR_CONFIG_KEY])
+            cfg[ASR_CACHE_DIR_CONFIG_KEY] = asr_cache_dir
+        try:
+            os.makedirs(asr_cache_dir, exist_ok=True)
+        except Exception as e:  # pragma: no cover - salvaguarda
+            logging.warning(f"Falha ao criar diretório de cache ASR '{asr_cache_dir}': {e}")
+
         cfg["asr_curated_catalog"] = list_catalog()
         try:
-            cfg["asr_installed_models"] = list_installed(ASR_CACHE_DIR)
+            cfg["asr_installed_models"] = list_installed(asr_cache_dir)
         except Exception as e:  # pragma: no cover - salvaguarda
             logging.warning(f"Falha ao listar modelos instalados: {e}")
             cfg["asr_installed_models"] = []

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -6,6 +6,7 @@ import threading
 import time
 import pystray
 from PIL import Image, ImageDraw
+import os
 
 # Importar constantes de configuração
 from .config_manager import (
@@ -408,7 +409,9 @@ class UIManager:
                 asr_dtype_var = ctk.StringVar(value=self.config_manager.get_asr_dtype())
                 asr_ct2_compute_type_var = ctk.StringVar(value=self.config_manager.get_asr_ct2_compute_type())
                 ct2_quant_var = ctk.StringVar(value=self.config_manager.get("ct2_quantization", "float16"))
-                asr_cache_dir_var = ctk.StringVar(value=self.config_manager.get_asr_cache_dir())
+                asr_cache_dir_var = ctk.StringVar(
+                    value=os.path.expanduser(self.config_manager.get_asr_cache_dir())
+                )
 
                 def update_text_correction_fields():
                     enabled = text_correction_enabled_var.get()


### PR DESCRIPTION
## Summary
- Validate and default the ASR cache directory during config loading
- Normalize ASR cache path when initializing the settings UI

## Testing
- `python -m py_compile src/config_manager.py src/ui_manager.py`
- Unable to launch the full settings window due to missing system dependencies (`torch`, display)`

------
https://chatgpt.com/codex/tasks/task_e_68c3467a328083309854e71b93774485