### PR TITLE
refactor: unify compute device selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ To access and change settings:
 *   **Gemini Correction Prompt:** Customize the prompt sent to Gemini for text correction.
 *   **Agent Mode Prompt:** Customize the prompt sent to Gemini when using "Agent Mode".
 *   **Gemini Models (one per line):** Manage the list of available Gemini models in the dropdown.
-*   **Processing Device:** Select whether to use "Auto-select (Recommended)", a specific "GPU", or "Force CPU" for transcription.
+*   **ASR Compute Device:** Choose "Auto-select (Recommended)", "Force CPU", or a specific "GPU" for transcription.
 *   **Batch Size:** Configure the batch size for transcription.
 *   **Chunk Length (s):** Controls how long each audio segment sent to Whisper is. Smaller values reduce memory use but may slow processing.
 *   **Record Storage Mode:** Choose between always using memory, always using disk, or automatically selecting based on free RAM.


### PR DESCRIPTION
## Summary
- unify GPU and ASR device choice into single menu
- drop redundant Processing Device section
- document ASR compute device options

## Testing
- `flake8 src/ui_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c34689874483309cfc78cb32e3c22d