### PR TITLE
Persist installed ASR models in config

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -1008,7 +1008,7 @@ class UIManager:
 
                 catalog = model_manager.list_catalog()
                 installed_ids = {
-                    m["id"] for m in model_manager.list_installed(asr_cache_dir_var.get())
+                    m["id"] for m in self.config_manager.get_asr_installed_models()
                 }
                 all_ids = sorted({m["id"] for m in catalog} | installed_ids)
 
@@ -1030,7 +1030,7 @@ class UIManager:
                     except Exception:
                         download_text = "?"
 
-                    installed_models = model_manager.list_installed(asr_cache_dir_var.get())
+                    installed_models = self.config_manager.get_asr_installed_models()
                     entry = next((m for m in installed_models if m["id"] == choice), None)
                     if entry:
                         i_bytes, i_files = model_manager.get_installed_size(entry["path"])


### PR DESCRIPTION
## Summary
- Cache installed ASR models in the configuration file
- Load cached ASR models at startup and ignore missing paths
- Populate ASR model dropdown from cached list instead of rescanning

## Testing
- `python -m py_compile src/config_manager.py src/ui_manager.py`
- `flake8 src/config_manager.py src/ui_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3468c8a1483308ad1adfac7c5d17f