### PR TITLE
Refresh installed model list after config load

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -1008,7 +1008,7 @@ class UIManager:
 
                 catalog = model_manager.list_catalog()
                 installed_ids = {
-                    m["id"] for m in model_manager.list_installed(asr_cache_dir_var.get())
+                    m["id"] for m in self.config_manager.get_asr_installed_models()
                 }
                 all_ids = sorted({m["id"] for m in catalog} | installed_ids)
 
@@ -1030,7 +1030,7 @@ class UIManager:
                     except Exception:
                         download_text = "?"
 
-                    installed_models = model_manager.list_installed(asr_cache_dir_var.get())
+                    installed_models = self.config_manager.get_asr_installed_models()
                     entry = next((m for m in installed_models if m["id"] == choice), None)
                     if entry:
                         i_bytes, i_files = model_manager.get_installed_size(entry["path"])


### PR DESCRIPTION
## Summary
- sync installed ASR models in a background thread after configuration load
- drive ASR model dropdown from ConfigManager's cached installed models

## Testing
- `python -m py_compile src/core.py src/ui_manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c346a61e5c8330879c5a5f637e7e4f