### PR TITLE
Handle invalid ASR cache directory errors

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import List
 
 import requests
+import tkinter.messagebox as messagebox
 
 from .model_manager import list_catalog, list_installed
 try:
@@ -281,6 +282,12 @@ class ConfigManager:
         cfg["asr_curated_catalog"] = list_catalog()
         try:
             cfg["asr_installed_models"] = list_installed(ASR_CACHE_DIR)
+        except OSError:
+            messagebox.showerror(
+                "Configuração",
+                "Diretório de cache inválido. Verifique as configurações.",
+            )
+            cfg["asr_installed_models"] = []
         except Exception as e:  # pragma: no cover - salvaguarda
             logging.warning(f"Falha ao listar modelos instalados: {e}")
             cfg["asr_installed_models"] = []

--- a/src/core.py
+++ b/src/core.py
@@ -69,6 +69,11 @@ class AppCore:
             cache_dir = self.config_manager.get("asr_cache_dir")
             installed = list_installed(cache_dir)
             self.config_manager.set_asr_installed_models(installed)
+        except OSError:
+            messagebox.showerror(
+                "Configuração",
+                "Diretório de cache inválido. Verifique as configurações.",
+            )
         except Exception as e:
             logging.warning(f"Failed to sync installed models: {e}")
 
@@ -128,6 +133,12 @@ class AppCore:
                     logging.info("Model download cancelled by user.")
                     messagebox.showinfo("Model", "Download canceled.")
                     self._set_state(STATE_LOADING_MODEL)
+                except OSError:
+                    messagebox.showerror(
+                        "Model",
+                        "Diretório de cache inválido. Verifique as configurações.",
+                    )
+                    self._set_state(STATE_ERROR_MODEL)
                 except Exception as e:
                     logging.error(f"Model download failed: {e}")
                     messagebox.showerror("Model", f"Download failed: {e}")

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -611,6 +611,14 @@ class TranscriptionHandler:
 
             self._asr_loaded = True
             self.on_model_ready_callback()
+        except OSError:
+            error_message = "Diretório de cache inválido. Verifique as configurações."
+            logging.error(error_message, exc_info=True)
+            try:
+                self.on_model_error_callback(error_message)
+            except Exception:
+                pass
+            return None, None
         except Exception as e:
             error_message = f"Falha ao carregar o modelo: {e}"
             logging.error(error_message, exc_info=True)

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -1007,9 +1007,16 @@ class UIManager:
                 ctk.CTkLabel(asr_model_frame, text="ASR Model:").pack(side="left", padx=(5, 10))
 
                 catalog = model_manager.list_catalog()
-                installed_ids = {
-                    m["id"] for m in model_manager.list_installed(asr_cache_dir_var.get())
-                }
+                try:
+                    installed_ids = {
+                        m["id"] for m in model_manager.list_installed(asr_cache_dir_var.get())
+                    }
+                except OSError:
+                    messagebox.showerror(
+                        "Configuração",
+                        "Diretório de cache inválido. Verifique as configurações.",
+                    )
+                    installed_ids = set()
                 all_ids = sorted({m["id"] for m in catalog} | installed_ids)
 
                 asr_model_menu = ctk.CTkOptionMenu(
@@ -1030,7 +1037,14 @@ class UIManager:
                     except Exception:
                         download_text = "?"
 
-                    installed_models = model_manager.list_installed(asr_cache_dir_var.get())
+                    try:
+                        installed_models = model_manager.list_installed(asr_cache_dir_var.get())
+                    except OSError:
+                        messagebox.showerror(
+                            "Configuração",
+                            "Diretório de cache inválido. Verifique as configurações.",
+                        )
+                        installed_models = []
                     entry = next((m for m in installed_models if m["id"] == choice), None)
                     if entry:
                         i_bytes, i_files = model_manager.get_installed_size(entry["path"])
@@ -1101,6 +1115,11 @@ class UIManager:
                         messagebox.showinfo("Model", "Download completed.")
                     except DownloadCancelledError:
                         messagebox.showinfo("Model", "Download canceled.")
+                    except OSError:
+                        messagebox.showerror(
+                            "Model",
+                            "Diretório de cache inválido. Verifique as configurações.",
+                        )
                     except Exception as e:
                         messagebox.showerror("Model", f"Download failed: {e}")
 


### PR DESCRIPTION
## Summary
- catch `OSError` for invalid ASR cache directory and show user-friendly message boxes
- handle cache directory errors during model installation and loading

## Testing
- `pytest`
- `python -m py_compile src/config_manager.py src/core.py src/transcription_handler.py src/ui_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c346a81f50833093e43f3151c50434