### PR TITLE
Documenta fallback do backend automático

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,10 @@ The speech recognition engine supports multiple backends. The following keys in 
 Values such as `faster-whisper` or `ctranslate2` are automatically mapped to
 `ct2`.
 
+> When `asr_backend` is set to `"auto"`, the loader prefers the `transformers`
+> backend and falls back to `ct2` if the first choice is unavailable or
+> incompatible.
+
 Examples:
 
 ```json

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -993,7 +993,13 @@ class UIManager:
                     command=_on_backend_change,
                 )
                 asr_backend_menu.pack(side="left", padx=5)
-                Tooltip(asr_backend_menu, "Inference backend for speech recognition.")
+                Tooltip(
+                    asr_backend_menu,
+                    (
+                        "Backend de ASR. Em 'auto', tenta primeiro 'transformers' e, "
+                        "se indisponível, cai para 'ct2'."
+                    ),
+                )
 
                 quant_frame.pack(fill="x", pady=5)
                 ctk.CTkLabel(quant_frame, text="Quantization:").pack(side="left", padx=(5, 10))


### PR DESCRIPTION
## Resumo
- adiciona tooltip em português explicando a heurística do backend `auto`
- documenta no README a ordem de fallback entre `transformers` e `ct2`

## Testes
- `python -m flake8 src/ui_manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c346a973bc8330a6ede998673e048f