### PR TITLE
Fix state transitions after model download

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -191,7 +191,12 @@ class AppCore:
                 self.main_tk_root.after(0, lambda: messagebox.showerror("Model", f"Download failed: {e}"))
             else:
                 logging.info("Model download completed successfully.")
-                self.main_tk_root.after(0, self.transcription_handler.start_model_loading)
+
+                def _after_download():
+                    self._set_state(STATE_IDLE)
+                    self.transcription_handler.start_model_loading()
+
+                self.main_tk_root.after(0, _after_download)
         threading.Thread(target=_download, daemon=True, name="ModelDownloadThread").start()
 
     def _apply_initial_config_to_core_attributes(self):
@@ -364,6 +369,10 @@ class AppCore:
         logging.info("AppCore: Model loaded successfully.")
         self._set_state(STATE_IDLE)
         self._start_autohotkey()
+
+    def notify_model_loading_started(self):
+        """Expõe atualização explícita de estado para carregamento de modelo."""
+        self._set_state(STATE_LOADING_MODEL)
         
         # Iniciar serviços de estabilidade de hotkey se habilitados
         if self.hotkey_stability_service_enabled:

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -438,6 +438,13 @@ class TranscriptionHandler:
         )
 
     def start_model_loading(self):
+        core = getattr(self, "core_instance_ref", None)
+        if core is not None:
+            try:
+                if getattr(core, "current_state", None) != "LOADING_MODEL":
+                    core.notify_model_loading_started()
+            except AttributeError:
+                core._set_state("LOADING_MODEL")
         threading.Thread(target=self._load_model_task, daemon=True, name="ModelLoadThread").start()
 
     def is_transcription_running(self) -> bool:


### PR DESCRIPTION
## Summary
- set the application state back to IDLE immediately after a successful model download before triggering the load
- expose a helper on AppCore so the transcription handler can consistently flag the LOADING_MODEL state
- ensure start_model_loading re-asserts the loading state before spawning the worker thread

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cc684966e48330916acc20146a0475