### PR TITLE
Padroniza logs de modelos e transcrições

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -95,6 +95,9 @@ class TranscriptionHandler:
         )
         # Evento para sinalizar cancelamento de transcrição em andamento
         self.transcription_cancel_event = threading.Event()
+        # Contexto reutilizado para logs padronizados sobre o backend/modelo
+        self._model_log_context: dict[str, object] = {}
+        self._model_load_started_at: float | None = None
 
         # Configurações de modelo e API (carregadas do config_manager)
         self.batch_size = self.config_manager.get(BATCH_SIZE_CONFIG_KEY) # Agora é o batch_size padrão para o modo auto
@@ -238,6 +241,92 @@ class TranscriptionHandler:
             model_id = default_gpu_model if compute_device.startswith("cuda") else default_cpu_model
 
         return backend, model_id, compute_device, dtype
+
+    def _update_model_log_context(self, **entries: object) -> None:
+        filtered = {k: v for k, v in entries.items() if v not in (None, "")}
+        if filtered:
+            self._model_log_context.update(filtered)
+
+    @staticmethod
+    def _format_log_value(value: object) -> str:
+        if isinstance(value, float):
+            magnitude = abs(value)
+            if magnitude == 0:
+                return "0.00"
+            return f"{value:.2f}" if magnitude >= 0.01 else f"{value:.4f}"
+        if isinstance(value, bool):
+            return str(value).lower()
+        return str(value)
+
+    def _log_model_event(self, event: str, *, level: int = logging.INFO, **fields: object) -> None:
+        context: dict[str, object] = {}
+        context.update(self._model_log_context)
+        context.update({k: v for k, v in fields.items() if v not in (None, "")})
+
+        backend = context.get("backend") or self.backend_resolved or self.asr_backend
+        if backend:
+            context["backend"] = backend
+        model_id = (
+            context.get("model")
+            or context.get("model_id")
+            or getattr(self._asr_backend, "model_id", None)
+            or self.asr_model_id
+        )
+        if model_id:
+            context["model"] = model_id
+        context.pop("model_id", None)
+
+        message_order = [
+            "event",
+            "backend",
+            "model",
+            "device",
+            "dtype",
+            "compute_type",
+            "chunk_length_s",
+            "batch_size",
+            "size",
+            "duration_ms",
+            "agent_mode",
+            "status",
+            "error",
+        ]
+
+        parts: list[str] = []
+        used_keys: set[str] = set()
+        context["event"] = event
+        for key in message_order:
+            if key in context:
+                parts.append(f"{key}={self._format_log_value(context[key])}")
+                used_keys.add(key)
+        for key in sorted(context.keys()):
+            if key not in used_keys:
+                parts.append(f"{key}={self._format_log_value(context[key])}")
+
+        logging.log(level, "[ASR] " + " ".join(parts))
+
+    def _format_audio_source(self, audio_source: str | np.ndarray | bytes | bytearray | list[float] | None) -> str:
+        if audio_source is None:
+            return "none"
+        try:
+            if isinstance(audio_source, np.ndarray):
+                samples = int(audio_source.size)
+                if samples and AUDIO_SAMPLE_RATE:
+                    duration = samples / float(AUDIO_SAMPLE_RATE)
+                    return f"array_samples={samples} duration_s={duration:.2f}"
+                return f"array_samples={samples}"
+            if isinstance(audio_source, (bytes, bytearray)):
+                return f"bytes={len(audio_source)}"
+            if isinstance(audio_source, list):
+                return f"list_samples={len(audio_source)}"
+            if isinstance(audio_source, str):
+                path = Path(audio_source)
+                if path.exists():
+                    return f"file_bytes={path.stat().st_size}"
+                return "file"
+        except Exception:
+            pass
+        return "unknown"
 
     def _initialize_model_and_processor(self):
         # Este método será chamado para orquestrar o carregamento do modelo e a criação da pipeline
@@ -524,11 +613,78 @@ class TranscriptionHandler:
                 if "cache_dir" in load_kwargs and load_kwargs["cache_dir"]:
                     load_kwargs["cache_dir"] = str(load_kwargs["cache_dir"])
 
-                self._asr_backend.load(**load_kwargs)
+                self._update_model_log_context(
+                    backend=backend_name,
+                    model=asr_model_id,
+                    device=backend_device,
+                    dtype=load_kwargs.get("dtype", asr_dtype),
+                    compute_type=load_kwargs.get("ct2_compute_type", asr_ct2_compute_type),
+                    chunk_length_s=float(self.chunk_length_sec),
+                    batch_size=self.batch_size,
+                )
+                load_started_at = time.perf_counter()
+                self._model_load_started_at = load_started_at
+                self._log_model_event(
+                    "load_start",
+                    backend=backend_name,
+                    model_id=asr_model_id,
+                    device=backend_device,
+                    dtype=load_kwargs.get("dtype", asr_dtype),
+                    compute_type=load_kwargs.get("ct2_compute_type", asr_ct2_compute_type),
+                    chunk_length_s=float(self.chunk_length_sec),
+                    batch_size=self.batch_size,
+                )
+                try:
+                    self._asr_backend.load(**load_kwargs)
+                except Exception as load_error:
+                    duration_ms = (time.perf_counter() - load_started_at) * 1000.0
+                    self._log_model_event(
+                        "load_failure",
+                        level=logging.ERROR,
+                        backend=backend_name,
+                        model_id=asr_model_id,
+                        device=backend_device,
+                        dtype=load_kwargs.get("dtype", asr_dtype),
+                        compute_type=load_kwargs.get("ct2_compute_type", asr_ct2_compute_type),
+                        chunk_length_s=float(self.chunk_length_sec),
+                        batch_size=self.batch_size,
+                        duration_ms=duration_ms,
+                        error=str(load_error),
+                    )
+                    self._model_load_started_at = None
+                    raise
+
+                warmup_failed = None
                 try:
                     self._asr_backend.warmup()
                 except Exception as warmup_error:
+                    warmup_failed = warmup_error
                     logging.debug(f"Falha no warmup do backend ASR: {warmup_error}")
+
+                duration_ms = (time.perf_counter() - load_started_at) * 1000.0
+                resolved_device = getattr(self._asr_backend, "device", backend_device)
+                resolved_model = getattr(self._asr_backend, "model_id", asr_model_id)
+                resolved_dtype = load_kwargs.get("dtype", asr_dtype)
+                resolved_compute = load_kwargs.get("ct2_compute_type", asr_ct2_compute_type)
+                self._update_model_log_context(
+                    backend=backend_name,
+                    model=resolved_model,
+                    device=resolved_device,
+                    dtype=resolved_dtype,
+                    compute_type=resolved_compute,
+                    chunk_length_s=float(self.chunk_length_sec),
+                    batch_size=self.batch_size,
+                )
+                self._log_model_event(
+                    "load_success",
+                    backend=backend_name,
+                    device=resolved_device,
+                    dtype=resolved_dtype,
+                    compute_type=resolved_compute,
+                    duration_ms=duration_ms,
+                    status="warmup_failed" if warmup_failed else "ready",
+                )
+                self._model_load_started_at = None
                 self.pipe = getattr(self._asr_backend, "pipe", None)
                 self._asr_loaded = True
                 self.on_model_ready_callback()
@@ -543,6 +699,27 @@ class TranscriptionHandler:
                 raise FileNotFoundError(
                     f"Modelo '{model_id}' não encontrado. Instale-o nas configurações."
                 )
+            self._update_model_log_context(
+                backend=backend,
+                model=model_id,
+                device=compute_device,
+                dtype=self.asr_dtype,
+                compute_type=self.asr_ct2_compute_type,
+                chunk_length_s=float(self.chunk_length_sec),
+                batch_size=self.batch_size,
+            )
+            load_started_at = time.perf_counter()
+            self._model_load_started_at = load_started_at
+            self._log_model_event(
+                "load_start",
+                backend=backend,
+                model_id=model_id,
+                device=compute_device,
+                dtype=self.asr_dtype,
+                compute_type=self.asr_ct2_compute_type,
+                chunk_length_s=float(self.chunk_length_sec),
+                batch_size=self.batch_size,
+            )
             logging.info(f"Carregando processador de {model_id}...")
             processor = AutoProcessor.from_pretrained(str(model_path))
 
@@ -567,6 +744,9 @@ class TranscriptionHandler:
 
             device = f"cuda:{self.gpu_index}" if self.gpu_index >= 0 and torch.cuda.is_available() else "cpu"
             torch_dtype_local = torch.float16 if device.startswith("cuda") else torch.float32
+            resolved_device = device
+            resolved_dtype_label = str(torch_dtype_local).replace("torch.", "")
+            self._update_model_log_context(device=resolved_device, dtype=resolved_dtype_label)
 
             logging.info(f"Dispositivo de carregamento do modelo definido explicitamente como: {device}")
 
@@ -655,10 +835,31 @@ class TranscriptionHandler:
             except Exception as e:
                 logging.debug(f"Falha no warmup da pipeline: {e}")
 
+            duration_ms = (time.perf_counter() - load_started_at) * 1000.0
+            self._update_model_log_context(device=resolved_device, dtype=resolved_dtype_label)
+            self._log_model_event(
+                "load_success",
+                backend=backend,
+                device=resolved_device,
+                dtype=resolved_dtype_label,
+                compute_type=self.asr_ct2_compute_type,
+                duration_ms=duration_ms,
+                status="legacy_ready",
+            )
+            self._model_load_started_at = None
             self._asr_loaded = True
             self.on_model_ready_callback()
         except OSError:
             error_message = "Diretório de cache inválido. Verifique as configurações."
+            if self._model_load_started_at is not None:
+                duration_ms = (time.perf_counter() - self._model_load_started_at) * 1000.0
+                self._log_model_event(
+                    "load_failure",
+                    level=logging.ERROR,
+                    duration_ms=duration_ms,
+                    error=error_message,
+                )
+                self._model_load_started_at = None
             logging.error(error_message, exc_info=True)
             try:
                 self.on_model_error_callback(error_message)
@@ -667,6 +868,15 @@ class TranscriptionHandler:
             return None, None
         except Exception as e:
             error_message = f"Falha ao carregar o modelo: {e}"
+            if self._model_load_started_at is not None:
+                duration_ms = (time.perf_counter() - self._model_load_started_at) * 1000.0
+                self._log_model_event(
+                    "load_failure",
+                    level=logging.ERROR,
+                    duration_ms=duration_ms,
+                    error=str(e),
+                )
+                self._model_load_started_at = None
             logging.error(error_message, exc_info=True)
             try:
                 self.on_model_error_callback(error_message)
@@ -684,42 +894,152 @@ class TranscriptionHandler:
         self.transcription_cancel_event.clear()
 
         if self.transcription_cancel_event.is_set():
+            self._log_model_event(
+                "transcription_cancelled",
+                status="pre_start",
+                agent_mode=agent_mode,
+            )
             logging.info("Transcrição interrompida por stop signal antes do início do processamento.")
             return
 
-        dynamic_batch_size = self._get_dynamic_batch_size()
-        result = self._asr_backend.transcribe(
-            audio_source,
-            chunk_length_s=float(self.chunk_length_sec),
-            batch_size=dynamic_batch_size,
-        )
-        text_result = result.get("text", "").strip() or "[No speech detected]"
-        if agent_mode and self.on_agent_result_callback:
-            self.on_agent_result_callback(text_result)
-        elif self.on_transcription_result_callback:
-            self.on_transcription_result_callback(text_result, text_result)
-        return
+        dynamic_batch_size = None
+        size_descriptor = self._format_audio_source(audio_source)
+        if self._asr_backend is not None:
+            try:
+                dynamic_batch_size = self._get_dynamic_batch_size()
+            except Exception as batch_error:
+                self._log_model_event(
+                    "transcription_failure",
+                    level=logging.ERROR,
+                    batch_size=dynamic_batch_size,
+                    chunk_length_s=float(self.chunk_length_sec),
+                    size=size_descriptor,
+                    agent_mode=agent_mode,
+                    error=f"dynamic_batch:{batch_error}",
+                )
+                raise
+
+            self._update_model_log_context(
+                chunk_length_s=float(self.chunk_length_sec),
+                batch_size=dynamic_batch_size,
+            )
+            start_ts = time.perf_counter()
+            self._log_model_event(
+                "transcription_start",
+                batch_size=dynamic_batch_size,
+                chunk_length_s=float(self.chunk_length_sec),
+                size=size_descriptor,
+                agent_mode=agent_mode,
+            )
+            try:
+                result = self._asr_backend.transcribe(
+                    audio_source,
+                    chunk_length_s=float(self.chunk_length_sec),
+                    batch_size=dynamic_batch_size,
+                )
+            except Exception as transcribe_error:
+                duration_ms = (time.perf_counter() - start_ts) * 1000.0
+                self._log_model_event(
+                    "transcription_failure",
+                    level=logging.ERROR,
+                    batch_size=dynamic_batch_size,
+                    chunk_length_s=float(self.chunk_length_sec),
+                    size=size_descriptor,
+                    agent_mode=agent_mode,
+                    duration_ms=duration_ms,
+                    error=str(transcribe_error),
+                )
+                logging.error(f"Erro durante a transcrição via backend unificado: {transcribe_error}", exc_info=True)
+            else:
+                duration_ms = (time.perf_counter() - start_ts) * 1000.0
+                text_result = result.get("text", "").strip() or "[No speech detected]"
+                self._log_model_event(
+                    "transcription_success",
+                    batch_size=dynamic_batch_size,
+                    chunk_length_s=float(self.chunk_length_sec),
+                    size=size_descriptor,
+                    agent_mode=agent_mode,
+                    duration_ms=duration_ms,
+                )
+                if agent_mode and self.on_agent_result_callback:
+                    self.on_agent_result_callback(text_result)
+                elif self.on_transcription_result_callback:
+                    self.on_transcription_result_callback(text_result, text_result)
+                return
 
         # Legacy pipeline (desativado após retorno antecipado)
         text_result = None
         # Garantir que dynamic_batch_size esteja definido mesmo quando o backend
         # for CTranslate2, evitando UnboundLocalError no bloco de exceção.
         dynamic_batch_size = None
+        legacy_started_at: float | None = None
+        logged_failure = False
         try:
             if self.backend_resolved == "ctranslate2":
+                self._update_model_log_context(
+                    chunk_length_s=float(self.chunk_length_sec),
+                )
+                legacy_started_at = time.perf_counter()
+                self._log_model_event(
+                    "transcription_start",
+                    chunk_length_s=float(self.chunk_length_sec),
+                    size=size_descriptor,
+                    agent_mode=agent_mode,
+                )
                 segments, _ = self.pipe.transcribe(audio_source, language=None)
                 text_result = "".join(seg.text for seg in segments).strip()
                 if not text_result:
                     text_result = "[No speech detected]"
+                duration_ms = (time.perf_counter() - legacy_started_at) * 1000.0
+                self._log_model_event(
+                    "transcription_success",
+                    chunk_length_s=float(self.chunk_length_sec),
+                    size=size_descriptor,
+                    agent_mode=agent_mode,
+                    duration_ms=duration_ms,
+                )
                 logging.info("Transcrição via CTranslate2 concluída.")
             else:
                 if self.pipe is None:
                     error_message = "Pipeline de transcrição indisponível. Modelo não carregado ou falhou."
+                    self._log_model_event(
+                        "transcription_failure",
+                        level=logging.ERROR,
+                        chunk_length_s=float(self.chunk_length_sec),
+                        size=size_descriptor,
+                        agent_mode=agent_mode,
+                        error="pipeline_unavailable",
+                    )
                     logging.error(error_message)
                     self.on_model_error_callback(error_message)
                     return
 
-                dynamic_batch_size = self._get_dynamic_batch_size()
+                try:
+                    dynamic_batch_size = self._get_dynamic_batch_size()
+                except Exception as batch_error:
+                    logged_failure = True
+                    self._log_model_event(
+                        "transcription_failure",
+                        level=logging.ERROR,
+                        chunk_length_s=float(self.chunk_length_sec),
+                        size=size_descriptor,
+                        agent_mode=agent_mode,
+                        error=f"dynamic_batch:{batch_error}",
+                    )
+                    raise
+
+                self._update_model_log_context(
+                    chunk_length_s=float(self.chunk_length_sec),
+                    batch_size=dynamic_batch_size,
+                )
+                legacy_started_at = time.perf_counter()
+                self._log_model_event(
+                    "transcription_start",
+                    batch_size=dynamic_batch_size,
+                    chunk_length_s=float(self.chunk_length_sec),
+                    size=size_descriptor,
+                    agent_mode=agent_mode,
+                )
                 logging.info(f"Iniciando transcrição de segmento com batch_size={dynamic_batch_size}...")
 
                 generate_kwargs = {
@@ -746,7 +1066,7 @@ class TranscriptionHandler:
                 except Exception:
                     attn_impl = "sdpa"
 
-                t_total_start = time.perf_counter()
+                t_total_start = legacy_started_at if legacy_started_at is not None else time.perf_counter()
                 t_pre_start = time.perf_counter()
                 t_pre_end = time.perf_counter()
                 t_pre_ms = (t_pre_end - t_pre_start) * 1000.0
@@ -783,6 +1103,15 @@ class TranscriptionHandler:
                 t_post_end = time.perf_counter()
                 t_post_ms = (t_post_end - t_post_start) * 1000.0
                 t_total_ms = (t_post_end - t_total_start) * 1000.0
+
+                self._log_model_event(
+                    "transcription_success",
+                    batch_size=dynamic_batch_size,
+                    chunk_length_s=float(self.chunk_length_sec),
+                    size=size_descriptor,
+                    agent_mode=agent_mode,
+                    duration_ms=t_total_ms,
+                )
 
                 try:
                     logging.info(f"[METRIC] stage=t_pre value_ms={t_pre_ms:.2f} device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} dtype={dtype} attn={attn_impl}")
@@ -834,11 +1163,41 @@ class TranscriptionHandler:
                 # Continua fluxo normal de erro
             except Exception as _oom_adj_e:
                 logging.debug(f"Falha ao ajustar parâmetros após OOM: {_oom_adj_e}")
+
+            if not logged_failure:
+                if legacy_started_at is not None:
+                    duration_ms = (time.perf_counter() - legacy_started_at) * 1000.0
+                    self._log_model_event(
+                        "transcription_failure",
+                        level=logging.ERROR,
+                        batch_size=dynamic_batch_size,
+                        chunk_length_s=float(self.chunk_length_sec),
+                        size=size_descriptor,
+                        agent_mode=agent_mode,
+                        duration_ms=duration_ms,
+                        error=str(e),
+                    )
+                else:
+                    self._log_model_event(
+                        "transcription_failure",
+                        level=logging.ERROR,
+                        batch_size=dynamic_batch_size,
+                        chunk_length_s=float(self.chunk_length_sec),
+                        size=size_descriptor,
+                        agent_mode=agent_mode,
+                        error=str(e),
+                    )
+
             logging.error(f"Erro durante a transcrição de segmento: {e}", exc_info=True)
             text_result = f"[Transcription Error: {e}]"
 
         finally:
             if self.transcription_cancel_event.is_set():
+                self._log_model_event(
+                    "transcription_cancelled",
+                    status="inference_cancelled",
+                    agent_mode=agent_mode,
+                )
                 logging.info("Transcrição interrompida por stop signal. Resultado descartado.")
                 self.transcription_cancel_event.clear()
                 return


### PR DESCRIPTION
## Resumo
- centraliza a formatação de logs relacionados a backend/modelo na TranscriptionHandler
- registra tempos e metadados completos ao carregar modelos e processar transcrições
- adiciona métricas de cancelamento e descrição do tamanho de entrada para facilitar diagnóstico

## Testes
- python - <<'PY' ... (execução manual cobrindo cenários de sucesso, cancelamento e falha)
- python -m compileall src/transcription_handler.py

------
https://chatgpt.com/codex/tasks/task_e_68cc684c9b10833095186ffc8569b5bd