### PR TITLE
Registrar fallback de dispositivo e notificar estado

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -314,6 +314,37 @@ class AppCore:
         for message in pending:
             self.main_tk_root.after(0, lambda msg=message: ui_manager.show_status_tooltip(msg))
 
+    def emit_state_warning(
+        self,
+        code: str,
+        details: dict | None = None,
+        *,
+        message: str | None = None,
+        level: str = "warning",
+    ) -> None:
+        """Encaminha avisos para a UI usando o callback de estado."""
+        payload = {
+            "code": code,
+            "details": details or {},
+            "level": level,
+        }
+        if message:
+            payload["message"] = message
+        callback = self.state_update_callback
+        if callback:
+            try:
+                event = {"state": self.current_state, "warning": payload}
+                self.main_tk_root.after(0, lambda evt=event: callback(evt))
+            except Exception as error:
+                logging.error(
+                    "Falha ao propagar aviso de estado (%s): %s",
+                    code,
+                    error,
+                    exc_info=True,
+                )
+        if message:
+            self._queue_tooltip_update(message)
+
     # --- Callbacks de Módulos ---
     def set_state_update_callback(self, callback):
         self.state_update_callback = callback

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -132,6 +132,7 @@ class TranscriptionHandler:
         self.openrouter_client = None
         # self.gemini_client é injetado
         self.device_in_use = None # Nova variável para armazenar o dispositivo em uso
+        self.last_dynamic_batch_size = None
 
         self._init_api_clients()
 
@@ -420,22 +421,72 @@ class TranscriptionHandler:
             self.on_transcription_result_callback(corrected, text)
 
     def _get_dynamic_batch_size(self) -> int:
-        if not torch.cuda.is_available() or self.gpu_index < 0:
+        device_in_use = (str(self.device_in_use or "").lower())
+        if not (torch.cuda.is_available() and device_in_use.startswith("cuda")):
             logging.info("GPU não disponível ou não selecionada, usando batch size de CPU (4).")
+            self.last_dynamic_batch_size = 4
             return 4
 
         if self.batch_size_mode == "manual":
             logging.info(
                 f"Modo de batch size manual selecionado. Usando valor configurado: {self.manual_batch_size}"
             )
+            self.last_dynamic_batch_size = self.manual_batch_size
             return self.manual_batch_size
 
         # Lógica para modo "auto" (dinâmico)
-        return select_batch_size(
-            self.gpu_index,
+        resolved_index = self.gpu_index if isinstance(self.gpu_index, int) else 0
+        value = select_batch_size(
+            resolved_index,
             fallback=self.batch_size,
             chunk_length_sec=self.chunk_length_sec
         )
+        self.last_dynamic_batch_size = value
+        return value
+
+    def _emit_device_warning(self, preferred: str, actual: str, reason: str, *, level: str = "warning") -> None:
+        """Registra e propaga avisos de fallback de dispositivo."""
+        assert reason, "Fallback de dispositivo sem motivo documentado."
+        message = (
+            f"Configuração de dispositivo '{preferred}' não aplicada; utilizando '{actual}'. Motivo: {reason}."
+        )
+        log_level = logging.WARNING if level == "warning" else logging.INFO
+        logging.log(log_level, message)
+        core = getattr(self, "core_instance_ref", None)
+        if core and hasattr(core, "emit_state_warning"):
+            try:
+                core.emit_state_warning(
+                    "DEVICE_FALLBACK",
+                    {"preferred": preferred, "actual": actual, "reason": reason},
+                    message=message,
+                    level=level,
+                )
+            except Exception as callback_error:
+                logging.error(
+                    "Falha ao propagar aviso de fallback de dispositivo: %s",
+                    callback_error,
+                    exc_info=True,
+                )
+
+    def _resolve_effective_dtype(self, configured_dtype: str | None) -> str | None:
+        """Determina o dtype efetivo considerando o dispositivo em uso."""
+        dtype = (configured_dtype or "auto")
+        dtype_lower = dtype.lower() if isinstance(dtype, str) else "auto"
+        device_lower = str(self.device_in_use or "").lower()
+
+        if device_lower.startswith("cuda"):
+            if dtype_lower == "fp16":
+                return "float16"
+            return dtype_lower
+
+        # CPU ou dispositivo desconhecido: garantir float32 para evitar falhas.
+        if dtype_lower not in {"float32", "auto"}:
+            logging.info(
+                "Ajustando dtype para float32 porque o dispositivo ativo é %s (dtype configurado: %s).",
+                device_lower or "cpu",
+                dtype_lower,
+            )
+        return "float32"
 
     def start_model_loading(self):
         threading.Thread(target=self._load_model_task, daemon=True, name="ModelLoadThread").start()
@@ -457,6 +508,7 @@ class TranscriptionHandler:
 
     def _load_model_task(self):
         try:
+            self.device_in_use = "cpu"
             if make_backend is not None:
                 asr_model_id = self.config_manager.get("asr_model_id")
                 asr_backend = (self.config_manager.get("asr_backend") or "transformers")
@@ -468,22 +520,61 @@ class TranscriptionHandler:
                 backend_name = (asr_backend or "transformers").lower()
                 self.backend_resolved = backend_name
 
+                available_cuda = torch.cuda.is_available()
+                gpu_count = torch.cuda.device_count() if available_cuda else 0
                 gpu_index = self.gpu_index if isinstance(self.gpu_index, int) else -1
                 pref = asr_compute_device.lower() if isinstance(asr_compute_device, str) else "auto"
                 backend_device = "auto"
                 transformers_device = None
+                self.device_in_use = "cpu"
+
                 if pref == "cpu":
                     backend_device = "cpu"
                     transformers_device = -1
+                    self.gpu_index = -1
+                    logging.info("Dispositivo de ASR fixado em CPU conforme configuração explícita.")
                 elif pref == "cuda":
-                    target_idx = gpu_index if gpu_index is not None and gpu_index >= 0 else 0
-                    backend_device = f"cuda:{target_idx}"
-                    transformers_device = f"cuda:{target_idx}"
-                    if self.gpu_index is None or self.gpu_index < 0:
+                    if not available_cuda or gpu_count == 0:
+                        reason = "CUDA indisponível" if not available_cuda else "Nenhuma GPU detectada"
+                        self.gpu_index = -1
+                        self.device_in_use = "cpu"
+                        self._emit_device_warning("cuda", "cpu", reason)
+                        backend_device = "cpu"
+                        transformers_device = -1
+                    else:
+                        target_idx = gpu_index if (gpu_index is not None and 0 <= gpu_index < gpu_count) else 0
+                        if target_idx != gpu_index:
+                            logging.warning(
+                                "Índice de GPU %s inválido; usando GPU %s para carregamento.",
+                                gpu_index,
+                                target_idx,
+                            )
+                        backend_device = f"cuda:{target_idx}"
+                        transformers_device = f"cuda:{target_idx}"
                         self.gpu_index = target_idx
+                        self.device_in_use = backend_device
+                        logging.info("Dispositivo de ASR configurado em %s.", self.device_in_use)
                 else:
-                    backend_device = "auto"
-                    transformers_device = None
+                    if available_cuda and gpu_count > 0:
+                        target_idx = gpu_index if (gpu_index is not None and 0 <= gpu_index < gpu_count) else 0
+                        if target_idx != gpu_index and isinstance(gpu_index, int) and gpu_index >= 0:
+                            logging.info(
+                                "Modo auto: índice de GPU %s fora do intervalo; usando GPU %s.",
+                                gpu_index,
+                                target_idx,
+                            )
+                        self.gpu_index = target_idx
+                        self.device_in_use = f"cuda:{target_idx}"
+                        logging.info("Modo auto selecionou %s para ASR.", self.device_in_use)
+                    else:
+                        reason = "CUDA indisponível" if not available_cuda else "Nenhuma GPU detectada"
+                        self.gpu_index = -1
+                        self.device_in_use = "cpu"
+                        self._emit_device_warning("auto", "cpu", reason, level="info")
+                        backend_device = "cpu"
+                        transformers_device = -1
+
+                effective_dtype = self._resolve_effective_dtype(asr_dtype)
 
                 self._asr_backend = make_backend(backend_name)
                 if hasattr(self._asr_backend, "model_id"):
@@ -508,7 +599,7 @@ class TranscriptionHandler:
                         pass
                     load_kwargs = {
                         "device": transformers_device,
-                        "dtype": asr_dtype,
+                        "dtype": effective_dtype,
                         "cache_dir": asr_cache_dir,
                         "attn_implementation": attn_impl,
                     }
@@ -564,8 +655,16 @@ class TranscriptionHandler:
                     else:
                         logging.info("Nenhuma GPU disponível, usando CPU.")
                         self.gpu_index = -1
+                        level = "warning" if str(compute_device or "auto").lower() == "cuda" else "info"
+                        self._emit_device_warning(
+                            str(compute_device or "auto"),
+                            "cpu",
+                            "Nenhuma GPU disponível para carregamento.",
+                            level=level,
+                        )
 
             device = f"cuda:{self.gpu_index}" if self.gpu_index >= 0 and torch.cuda.is_available() else "cpu"
+            self.device_in_use = device
             torch_dtype_local = torch.float16 if device.startswith("cuda") else torch.float32
 
             logging.info(f"Dispositivo de carregamento do modelo definido explicitamente como: {device}")

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -197,8 +197,16 @@ class UIManager:
                 th = getattr(self.core_instance_ref, "transcription_handler", None)
                 if th is not None:
                     import torch
-                    device = f"cuda:{getattr(th, 'gpu_index', -1)}" if torch.cuda.is_available() and getattr(th, 'gpu_index', -1) >= 0 else "cpu"
-                    dtype = "fp16" if (torch.cuda.is_available() and getattr(th, 'gpu_index', -1) >= 0) else "fp32"
+                    device_in_use = getattr(th, "device_in_use", None)
+                    if device_in_use:
+                        device = str(device_in_use)
+                    else:
+                        device = (
+                            f"cuda:{getattr(th, 'gpu_index', -1)}"
+                            if torch.cuda.is_available() and getattr(th, 'gpu_index', -1) >= 0
+                            else "cpu"
+                        )
+                    dtype = "fp16" if str(device).startswith("cuda") else "fp32"
                     try:
                         import importlib.util as _spec_util
                         attn_impl = "FA2" if _spec_util.find_spec("flash_attn") is not None else "SDPA"
@@ -220,7 +228,17 @@ class UIManager:
             time.sleep(1)
 
     def update_tray_icon(self, state):
-        # Logic moved from global, adjusted to use self.tray_icon and self.core_instance_ref
+        # Logic moved from global, ajustado para lidar com payloads estruturados
+        warning_payload = None
+        if isinstance(state, dict):
+            warning_payload = state.get("warning")
+            state = state.get(
+                "state",
+                getattr(self.core_instance_ref, "current_state", "IDLE") if self.core_instance_ref else "IDLE",
+            )
+        if state is None:
+            state = getattr(self.core_instance_ref, "current_state", "IDLE") if self.core_instance_ref else "IDLE"
+
         if self.tray_icon:
             color1, color2 = self.ICON_COLORS.get(state, self.DEFAULT_ICON_COLOR)
             icon_image = self.create_image(64, 64, color1, color2)
@@ -263,8 +281,16 @@ class UIManager:
                         th = getattr(self.core_instance_ref, "transcription_handler", None)
                         if th is not None:
                             import torch
-                            device = f"cuda:{getattr(th, 'gpu_index', -1)}" if torch.cuda.is_available() and getattr(th, 'gpu_index', -1) >= 0 else "cpu"
-                            dtype = "fp16" if (torch.cuda.is_available() and getattr(th, 'gpu_index', -1) >= 0) else "fp32"
+                            device_in_use = getattr(th, "device_in_use", None)
+                            if device_in_use:
+                                device = str(device_in_use)
+                            else:
+                                device = (
+                                    f"cuda:{getattr(th, 'gpu_index', -1)}"
+                                    if torch.cuda.is_available() and getattr(th, 'gpu_index', -1) >= 0
+                                    else "cpu"
+                                )
+                            dtype = "fp16" if str(device).startswith("cuda") else "fp32"
                             # Determinar attn_impl conforme detecção feita no handler
                             try:
                                 import importlib.util as _spec_util
@@ -272,8 +298,9 @@ class UIManager:
                             except Exception:
                                 attn_impl = "SDPA"
                             chunk = getattr(th, "chunk_length_sec", None)
-                            # batch_size dinâmico só é conhecido no runtime; mostrar o valor padrão/configurado
-                            bs = getattr(th, "batch_size", None) if hasattr(th, "batch_size") else None
+                            bs = getattr(th, "last_dynamic_batch_size", None)
+                            if bs is None:
+                                bs = getattr(th, "batch_size", None) if hasattr(th, "batch_size") else None
                             self.tray_icon.title = f"Whisper Recorder (TRANSCRIBING) [{device} {dtype} | {attn_impl} | chunk={chunk}s | batch={bs}]"
                         else:
                             self.tray_icon.title = "Whisper Recorder (TRANSCRIBING - 00:00)"
@@ -314,6 +341,30 @@ class UIManager:
             self.tray_icon.title = tooltip
             self.tray_icon.update_menu()
             logging.debug(f"Tray icon updated for state: {state}")
+
+        if warning_payload:
+            warning_level = str(warning_payload.get("level", "info")).lower()
+            warning_message = warning_payload.get("message")
+            if not warning_message:
+                details = warning_payload.get("details", {}) or {}
+                preferred = details.get("preferred")
+                actual = details.get("actual")
+                reason = details.get("reason")
+                if preferred and actual and reason:
+                    warning_message = f"Fallback de dispositivo: {preferred} → {actual} ({reason})."
+                elif reason:
+                    warning_message = str(reason)
+            if warning_message:
+                log_level = logging.WARNING if warning_level == "warning" else logging.INFO
+                logging.log(log_level, "Aviso de estado recebido: %s", warning_message)
+                try:
+                    self.show_status_tooltip(warning_message)
+                except Exception as tooltip_err:
+                    logging.error(
+                        "Falha ao atualizar tooltip com aviso: %s",
+                        tooltip_err,
+                        exc_info=True,
+                    )
 
     def run_settings_gui(self):
         # Logic moved from global, adjusted to use self.


### PR DESCRIPTION
## Resumo
- adiciona rastreamento do dispositivo efetivo e logs de fallback no `TranscriptionHandler`, emitindo avisos via callback de estado
- expõe um método `emit_state_warning` no `AppCore` para encaminhar avisos estruturados à UI
- adapta o `UIManager` para tratar payloads de aviso e mostrar o dispositivo efetivo e batch dinâmico na tooltip

## Testes
- `python -m compileall src`


------
https://chatgpt.com/codex/tasks/task_e_68cc6857e76c8330a39600b0f8064d48