### PR TITLE
Refine settings model wiring

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -1,9 +1,11 @@
 import customtkinter as ctk
 import tkinter.messagebox as messagebox
-from tkinter import simpledialog # Adicionado para askstring
+from tkinter import simpledialog  # Adicionado para askstring
 import logging
 import threading
 import time
+from typing import Any, Dict, Optional
+
 import pystray
 from PIL import Image, ImageDraw
 from pathlib import Path
@@ -76,6 +78,11 @@ class UIManager:
         self.settings_thread_running = False
         self.settings_window_lock = threading.Lock()
 
+        # Contexto ativo da janela de configurações
+        self._settings_vars: Dict[str, Any] = {}
+        self._settings_meta: Dict[str, Any] = {}
+        self._pending_key_var_name: Optional[str] = None
+
         self.live_window = None
         self.live_textbox = None
 
@@ -106,6 +113,688 @@ class UIManager:
         # Controle interno para atualizar a tooltip durante a transcrição
         self.transcribing_timer_thread = None
         self.stop_transcribing_timer_event = threading.Event()
+
+    # ------------------------------------------------------------------
+    # Utilidades para gerenciamento da janela de configurações
+    # ------------------------------------------------------------------
+    def _set_settings_var(self, name: str, value: Any) -> None:
+        self._settings_vars[name] = value
+
+    def _get_settings_var(self, name: str) -> Any:
+        return self._settings_vars.get(name)
+
+    def _set_settings_meta(self, name: str, value: Any) -> None:
+        self._settings_meta[name] = value
+
+    def _get_settings_meta(self, name: str, default: Any = None) -> Any:
+        return self._settings_meta.get(name, default)
+
+    def _clear_settings_context(self) -> None:
+        self._settings_vars.clear()
+        self._settings_meta.clear()
+        self._pending_key_var_name = None
+
+    def _handle_detected_key(self, key: str) -> None:
+        target_var_name = self._pending_key_var_name
+        if not target_var_name:
+            return
+        var = self._get_settings_var(target_var_name)
+        if var is not None:
+            try:
+                var.set(key)
+            except Exception:
+                pass
+        self._pending_key_var_name = None
+
+    def _start_key_detection_for(self, var_name: str) -> None:
+        key_var = self._get_settings_var(var_name)
+        window = self._get_settings_var("window")
+        if key_var is None or window is None:
+            return
+        try:
+            key_var.set("PRESS KEY...")
+        except Exception:
+            return
+        try:
+            window.update_idletasks()
+        except Exception:
+            pass
+        self._pending_key_var_name = var_name
+        self.core_instance_ref.set_key_detection_callback(self._handle_detected_key)
+        self.core_instance_ref.start_key_detection_thread()
+
+    def _update_text_correction_fields(self) -> None:
+        enabled_var = self._get_settings_var("text_correction_enabled_var")
+        if enabled_var is None:
+            return
+        try:
+            enabled = bool(enabled_var.get())
+        except Exception:
+            enabled = False
+        state = "normal" if enabled else "disabled"
+        for widget_name in [
+            "service_menu",
+            "openrouter_key_entry",
+            "openrouter_model_entry",
+            "gemini_key_entry",
+            "gemini_model_menu",
+            "gemini_prompt_correction_textbox",
+            "agentico_prompt_textbox",
+            "gemini_models_textbox",
+        ]:
+            widget = self._get_settings_var(widget_name)
+            if widget is None:
+                continue
+            try:
+                widget.configure(state=state)
+            except Exception:
+                pass
+
+    def _on_service_menu_change(self, choice: str) -> None:
+        mapping = self._get_settings_meta("service_display_map", {})
+        service_var = self._get_settings_var("text_correction_service_var")
+        label_var = self._get_settings_var("text_correction_service_label_var")
+        if label_var is not None:
+            try:
+                label_var.set(choice)
+            except Exception:
+                pass
+        if service_var is not None:
+            try:
+                service_var.set(mapping.get(choice, SERVICE_NONE))
+            except Exception:
+                pass
+        self._update_text_correction_fields()
+
+    def _update_chunk_length_state(self) -> None:
+        mode_var = self._get_settings_var("chunk_length_mode_var")
+        entry = self._get_settings_var("chunk_len_entry")
+        if mode_var is None or entry is None:
+            return
+        try:
+            mode_val = str(mode_var.get()).lower()
+        except Exception:
+            mode_val = "manual"
+        state = "normal" if mode_val == "manual" else "disabled"
+        try:
+            entry.configure(state=state)
+        except Exception:
+            pass
+
+    def _on_chunk_mode_change(self, _choice: str) -> None:
+        self._update_chunk_length_state()
+
+    def _derive_backend_from_model(self, model_ref: str) -> Optional[str]:
+        display_to_id = self._get_settings_meta("display_to_id", {})
+        catalog = self._get_settings_meta("catalog", [])
+        model_id = display_to_id.get(model_ref, model_ref)
+        entry = next((m for m in catalog if m.get("id") == model_id), None)
+        if not entry:
+            cache_var = self._get_settings_var("asr_cache_dir_var")
+            cache_dir = cache_var.get() if cache_var is not None else ""
+            try:
+                installed = model_manager.list_installed(cache_dir)
+            except OSError:
+                installed = []
+            entry = next((m for m in installed if m.get("id") == model_id), None)
+        backend = entry.get("backend") if entry else None
+        if backend in ("faster-whisper", "ctranslate2"):
+            backend = "ct2"
+        if backend not in ("transformers", "ct2"):
+            return None
+        return backend
+
+    def _update_install_button_state(self) -> None:
+        model_var = self._get_settings_var("asr_model_id_var")
+        install_button = self._get_settings_var("install_button")
+        quant_menu = self._get_settings_var("asr_ct2_menu")
+        if model_var is None or install_button is None:
+            return
+        backend = self._derive_backend_from_model(model_var.get())
+        try:
+            install_button.configure(state="normal" if backend else "disabled")
+        except Exception:
+            pass
+        if quant_menu is not None:
+            try:
+                quant_menu.configure(state="normal" if backend == "ct2" else "disabled")
+            except Exception:
+                pass
+
+    def _update_model_info(self, model_ref: str) -> None:
+        display_to_id = self._get_settings_meta("display_to_id", {})
+        cache_var = self._get_settings_var("asr_cache_dir_var")
+        label = self._get_settings_var("model_size_label")
+        if label is None:
+            return
+        model_id = display_to_id.get(model_ref, model_ref)
+        try:
+            d_bytes, d_files = model_manager.get_model_download_size(model_id)
+            d_mb = d_bytes / (1024 * 1024)
+            download_text = f"{d_mb:.1f} MB ({d_files} files)"
+        except Exception:
+            download_text = "?"
+
+        installed_models = []
+        if cache_var is not None:
+            try:
+                installed_models = model_manager.list_installed(cache_var.get())
+            except OSError:
+                messagebox.showerror(
+                    "Settings",
+                    "Unable to list installed ASR models. Please verify the cache directory.",
+                )
+        entry = next((m for m in installed_models if m.get("id") == model_id), None)
+        if entry:
+            i_bytes, i_files = model_manager.get_installed_size(entry.get("path"))
+            i_mb = i_bytes / (1024 * 1024)
+            installed_text = f"{i_mb:.1f} MB ({i_files} files)"
+        else:
+            installed_text = "-"
+        try:
+            label.configure(text=f"Download: {download_text} | Installed: {installed_text}")
+        except Exception:
+            pass
+
+    def _on_backend_change(self, choice: str) -> None:
+        backend_var = self._get_settings_var("asr_backend_var")
+        if backend_var is not None:
+            try:
+                backend_var.set(choice)
+            except Exception:
+                pass
+        self._update_install_button_state()
+        model_var = self._get_settings_var("asr_model_id_var")
+        if model_var is not None:
+            self._update_model_info(model_var.get())
+
+    def _on_model_change(self, choice_display: str) -> None:
+        id_to_display = self._get_settings_meta("id_to_display", {})
+        display_to_id = self._get_settings_meta("display_to_id", {})
+        model_id = display_to_id.get(choice_display, choice_display)
+        model_var = self._get_settings_var("asr_model_id_var")
+        display_var = self._get_settings_var("asr_model_display_var")
+        backend_menu = self._get_settings_var("asr_backend_menu")
+        backend_var = self._get_settings_var("asr_backend_var")
+        if model_var is not None:
+            try:
+                model_var.set(model_id)
+            except Exception:
+                pass
+        if display_var is not None:
+            try:
+                display_var.set(id_to_display.get(model_id, model_id))
+            except Exception:
+                pass
+        backend = self._derive_backend_from_model(model_id)
+        if backend and backend_var is not None:
+            try:
+                backend_var.set(backend)
+            except Exception:
+                pass
+            if backend_menu is not None:
+                try:
+                    backend_menu.configure(state="disabled")
+                except Exception:
+                    pass
+        elif backend_menu is not None:
+            try:
+                backend_menu.configure(state="normal")
+            except Exception:
+                pass
+        backend_value = None
+        if backend_var is not None:
+            try:
+                backend_value = backend_var.get()
+            except Exception:
+                backend_value = None
+        elif backend is not None:
+            backend_value = backend
+
+        current_model = self.config_manager.get_asr_model_id()
+        current_backend = self.config_manager.get_asr_backend()
+        config_changed = False
+
+        if model_id != current_model:
+            self.config_manager.set_asr_model_id(model_id)
+            config_changed = True
+        if backend_value is not None and backend_value != current_backend:
+            self.config_manager.set_asr_backend(backend_value)
+            config_changed = True
+
+        if config_changed:
+            self.config_manager.save_config()
+        if backend_var is not None:
+            self._on_backend_change(backend_var.get())
+        self._update_model_info(model_id)
+
+    def _install_selected_model(self) -> None:
+        model_var = self._get_settings_var("asr_model_id_var")
+        cache_var = self._get_settings_var("asr_cache_dir_var")
+        if model_var is None or cache_var is None:
+            return
+        cache_dir = cache_var.get()
+        try:
+            Path(cache_dir).mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            messagebox.showerror("Invalid Path", f"ASR cache directory is invalid:\n{exc}")
+            return
+        model_id = model_var.get()
+        backend = self._derive_backend_from_model(model_id)
+        if backend is None:
+            messagebox.showerror("Model", "Unable to determine backend for selected model.")
+            return
+        try:
+            size_bytes, file_count = model_manager.get_model_download_size(model_id)
+            size_gb = size_bytes / (1024 ** 3)
+            detail = f"approximately {size_gb:.2f} GB ({file_count} files)"
+        except Exception:
+            detail = "an unspecified size"
+        if not messagebox.askyesno(
+            "Model Download",
+            f"Model '{model_id}' will download {detail}.\nContinue?",
+        ):
+            return
+        try:
+            compute_type_var = self._get_settings_var("asr_ct2_compute_type_var")
+            quant = compute_type_var.get() if compute_type_var is not None else None
+            model_manager.ensure_download(
+                model_id,
+                backend,
+                cache_dir,
+                quant if backend == "ct2" else None,
+            )
+            installed_models = model_manager.list_installed(cache_dir)
+            self.config_manager.set_asr_installed_models(installed_models)
+            self.config_manager.save_config()
+            self._update_model_info(model_id)
+            messagebox.showinfo("Model", "Download completed.")
+        except DownloadCancelledError:
+            messagebox.showinfo("Model", "Download canceled.")
+        except OSError:
+            messagebox.showerror(
+                "Model",
+                "Unable to write to the ASR cache directory. Please check permissions.",
+            )
+        except Exception as exc:
+            messagebox.showerror("Model", f"Download failed: {exc}")
+
+    def _reload_current_model(self) -> None:
+        handler = getattr(self.core_instance_ref, "transcription_handler", None)
+        if handler:
+            handler.reload_asr()
+
+    def _apply_settings_from_ui(self) -> None:
+        settings_win = self._get_settings_var("window")
+        if self.core_instance_ref.current_state in ["RECORDING", "TRANSCRIBING", "LOADING_MODEL"]:
+            messagebox.showwarning(
+                "Apply Settings",
+                "Cannot apply while recording/transcribing/loading model.",
+                parent=settings_win,
+            )
+            return
+
+        def _var(name: str):
+            return self._get_settings_var(name)
+
+        detected_key_var = _var("detected_key_var")
+        agent_key_var = _var("agent_key_var")
+        mode_var = _var("mode_var")
+        auto_paste_var = _var("auto_paste_var")
+        agent_model_var = _var("agent_model_var")
+        hotkey_stability_var = _var("hotkey_stability_service_enabled_var")
+        sound_enabled_var = _var("sound_enabled_var")
+        sound_frequency_var = _var("sound_frequency_var")
+        sound_duration_var = _var("sound_duration_var")
+        sound_volume_var = _var("sound_volume_var")
+        text_correction_enabled_var = _var("text_correction_enabled_var")
+        text_correction_service_var = _var("text_correction_service_var")
+        openrouter_api_key_var = _var("openrouter_api_key_var")
+        openrouter_model_var = _var("openrouter_model_var")
+        gemini_api_key_var = _var("gemini_api_key_var")
+        gemini_model_var = _var("gemini_model_var")
+        gemini_prompt_textbox = _var("gemini_prompt_correction_textbox")
+        agentico_prompt_textbox = _var("agentico_prompt_textbox")
+        gemini_models_textbox = _var("gemini_models_textbox")
+        batch_size_var = _var("batch_size_var")
+        min_transcription_duration_var = _var("min_transcription_duration_var")
+        min_record_duration_var = _var("min_record_duration_var")
+        use_vad_var = _var("use_vad_var")
+        vad_threshold_var = _var("vad_threshold_var")
+        vad_silence_duration_var = _var("vad_silence_duration_var")
+        save_temp_recordings_var = _var("save_temp_recordings_var")
+        display_transcripts_var = _var("display_transcripts_var")
+        record_storage_mode_var = _var("record_storage_mode_var")
+        max_memory_seconds_mode_var = _var("max_memory_seconds_mode_var")
+        max_memory_seconds_var = _var("max_memory_seconds_var")
+        chunk_length_mode_var = _var("chunk_length_mode_var")
+        chunk_length_sec_var = _var("chunk_length_sec_var")
+        launch_at_startup_var = _var("launch_at_startup_var")
+        asr_backend_var = _var("asr_backend_var")
+        asr_model_id_var = _var("asr_model_id_var")
+        asr_compute_device_var = _var("asr_compute_device_var")
+        asr_dtype_var = _var("asr_dtype_var")
+        asr_ct2_compute_type_var = _var("asr_ct2_compute_type_var")
+        asr_cache_dir_var = _var("asr_cache_dir_var")
+
+        if detected_key_var is None or mode_var is None or auto_paste_var is None:
+            return
+
+        record_key_value = detected_key_var.get()
+        key_to_apply = record_key_value.lower() if record_key_value != "PRESS KEY..." else self.config_manager.get("record_key")
+        agent_key_value = agent_key_var.get() if agent_key_var else self.config_manager.get("agent_key")
+        agent_key_to_apply = agent_key_value.lower() if agent_key_value != "PRESS KEY..." else self.config_manager.get("agent_key")
+        mode_to_apply = mode_var.get()
+        auto_paste_to_apply = bool(auto_paste_var.get())
+        agent_model_to_apply = agent_model_var.get() if agent_model_var else self.config_manager.get("gemini_agent_model")
+        hotkey_stability_to_apply = bool(hotkey_stability_var.get()) if hotkey_stability_var else True
+        sound_enabled_to_apply = bool(sound_enabled_var.get()) if sound_enabled_var else True
+
+        sound_freq_to_apply = self._safe_get_int(sound_frequency_var, "Frequência do Som", settings_win)
+        if sound_freq_to_apply is None:
+            return
+        sound_duration_to_apply = self._safe_get_float(sound_duration_var, "Duração do Som", settings_win)
+        if sound_duration_to_apply is None:
+            return
+        sound_volume_to_apply = self._safe_get_float(sound_volume_var, "Volume do Som", settings_win)
+        if sound_volume_to_apply is None:
+            return
+
+        text_correction_enabled_to_apply = bool(text_correction_enabled_var.get()) if text_correction_enabled_var else False
+        text_correction_service_to_apply = text_correction_service_var.get() if text_correction_service_var else SERVICE_NONE
+        openrouter_api_key_to_apply = openrouter_api_key_var.get() if openrouter_api_key_var else ""
+        openrouter_model_to_apply = openrouter_model_var.get() if openrouter_model_var else ""
+        gemini_api_key_to_apply = gemini_api_key_var.get() if gemini_api_key_var else ""
+        gemini_model_to_apply = gemini_model_var.get() if gemini_model_var else ""
+        gemini_prompt_correction_to_apply = (
+            gemini_prompt_textbox.get("1.0", "end-1c") if gemini_prompt_textbox else self.config_manager.get(GEMINI_PROMPT_CONFIG_KEY)
+        )
+        agentico_prompt_to_apply = (
+            agentico_prompt_textbox.get("1.0", "end-1c") if agentico_prompt_textbox else self.config_manager.get("prompt_agentico")
+        )
+
+        batch_size_to_apply = self._safe_get_int(batch_size_var, "Batch Size", settings_win)
+        if batch_size_to_apply is None:
+            return
+        min_transcription_duration_to_apply = self._safe_get_float(min_transcription_duration_var, "Duração Mínima", settings_win)
+        if min_transcription_duration_to_apply is None:
+            return
+        min_record_duration_to_apply = self._safe_get_float(min_record_duration_var, "Duração Mínima da Gravação", settings_win)
+        if min_record_duration_to_apply is None:
+            return
+
+        use_vad_to_apply = bool(use_vad_var.get()) if use_vad_var else False
+        vad_threshold_to_apply = self._safe_get_float(vad_threshold_var, "Limiar do VAD", settings_win)
+        if vad_threshold_to_apply is None:
+            return
+        vad_silence_duration_to_apply = self._safe_get_float(vad_silence_duration_var, "Duração do Silêncio", settings_win)
+        if vad_silence_duration_to_apply is None:
+            return
+
+        save_temp_recordings_to_apply = bool(save_temp_recordings_var.get()) if save_temp_recordings_var else False
+        display_transcripts_to_apply = bool(display_transcripts_var.get()) if display_transcripts_var else False
+        record_storage_mode_to_apply = record_storage_mode_var.get() if record_storage_mode_var else "auto"
+        max_memory_seconds_mode_to_apply = max_memory_seconds_mode_var.get() if max_memory_seconds_mode_var else "manual"
+        max_memory_seconds_to_apply = self._safe_get_float(max_memory_seconds_var, "Max Memory Retention", settings_win)
+        if max_memory_seconds_to_apply is None:
+            return
+        chunk_length_mode_to_apply = chunk_length_mode_var.get() if chunk_length_mode_var else "manual"
+        chunk_length_sec_to_apply = self._safe_get_float(chunk_length_sec_var, "Chunk Length", settings_win)
+        if chunk_length_sec_to_apply is None:
+            return
+        launch_at_startup_to_apply = bool(launch_at_startup_var.get()) if launch_at_startup_var else False
+        asr_backend_to_apply = asr_backend_var.get() if asr_backend_var else self.config_manager.get_asr_backend()
+        asr_model_id_to_apply = asr_model_id_var.get() if asr_model_id_var else self.config_manager.get_asr_model_id()
+        asr_compute_device_to_apply = "auto"
+        asr_dtype_to_apply = asr_dtype_var.get() if asr_dtype_var else self.config_manager.get_asr_dtype()
+        asr_ct2_compute_type_to_apply = asr_ct2_compute_type_var.get() if asr_ct2_compute_type_var else self.config_manager.get_asr_ct2_compute_type()
+        asr_cache_dir_to_apply = asr_cache_dir_var.get() if asr_cache_dir_var else self.config_manager.get_asr_cache_dir()
+
+        try:
+            Path(asr_cache_dir_to_apply).mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            messagebox.showerror("Invalid Path", f"ASR cache directory is invalid:\n{exc}", parent=settings_win)
+            return
+
+        selected_device_str = asr_compute_device_var.get() if asr_compute_device_var else "Auto-select (Recommended)"
+        gpu_index_to_apply = -1
+        if "Force CPU" in selected_device_str:
+            asr_compute_device_to_apply = "cpu"
+        elif selected_device_str.startswith("GPU"):
+            asr_compute_device_to_apply = "cuda"
+            try:
+                gpu_index_to_apply = int(selected_device_str.split(":")[0].replace("GPU", "").strip())
+            except (ValueError, IndexError):
+                messagebox.showerror("Valor inválido", "Índice de GPU inválido.", parent=settings_win)
+                return
+
+        models_text = gemini_models_textbox.get("1.0", "end-1c") if gemini_models_textbox else ""
+        new_models_list = [line.strip() for line in models_text.split("\n") if line.strip()]
+        if not new_models_list:
+            messagebox.showwarning("Invalid Value", "The model list cannot be empty. Please add at least one model.", parent=settings_win)
+            return
+
+        self.core_instance_ref.apply_settings_from_external(
+            new_key=key_to_apply,
+            new_mode=mode_to_apply,
+            new_auto_paste=auto_paste_to_apply,
+            new_sound_enabled=sound_enabled_to_apply,
+            new_sound_frequency=sound_freq_to_apply,
+            new_sound_duration=sound_duration_to_apply,
+            new_sound_volume=sound_volume_to_apply,
+            new_agent_key=agent_key_to_apply,
+            new_text_correction_enabled=text_correction_enabled_to_apply,
+            new_text_correction_service=text_correction_service_to_apply,
+            new_openrouter_api_key=openrouter_api_key_to_apply,
+            new_openrouter_model=openrouter_model_to_apply,
+            new_gemini_api_key=gemini_api_key_to_apply,
+            new_gemini_model=gemini_model_to_apply,
+            new_gemini_prompt=gemini_prompt_correction_to_apply,
+            prompt_agentico=agentico_prompt_to_apply,
+            new_agent_model=agent_model_to_apply,
+            new_gemini_model_options=new_models_list,
+            new_batch_size=batch_size_to_apply,
+            new_gpu_index=gpu_index_to_apply,
+            new_hotkey_stability_service_enabled=hotkey_stability_to_apply,
+            new_min_transcription_duration=min_transcription_duration_to_apply,
+            new_min_record_duration=min_record_duration_to_apply,
+            new_save_temp_recordings=save_temp_recordings_to_apply,
+            new_record_storage_mode=record_storage_mode_to_apply,
+            new_record_to_memory=(record_storage_mode_to_apply == "memory"),
+            new_max_memory_seconds_mode=max_memory_seconds_mode_to_apply,
+            new_max_memory_seconds=max_memory_seconds_to_apply,
+            new_use_vad=use_vad_to_apply,
+            new_vad_threshold=vad_threshold_to_apply,
+            new_vad_silence_duration=vad_silence_duration_to_apply,
+            new_display_transcripts_in_terminal=display_transcripts_to_apply,
+            new_launch_at_startup=launch_at_startup_to_apply,
+            new_chunk_length_mode=chunk_length_mode_to_apply,
+            new_chunk_length_sec=float(chunk_length_sec_to_apply),
+            new_enable_torch_compile=bool(self._get_settings_var("enable_torch_compile_var").get()) if self._get_settings_var("enable_torch_compile_var") else False,
+            new_asr_backend=asr_backend_to_apply,
+            new_asr_model_id=asr_model_id_to_apply,
+            new_asr_compute_device=asr_compute_device_to_apply,
+            new_asr_dtype=asr_dtype_to_apply,
+            new_asr_ct2_compute_type=asr_ct2_compute_type_to_apply,
+            new_asr_cache_dir=asr_cache_dir_to_apply,
+        )
+        self._close_settings_window()
+
+    def _restore_default_settings(self) -> None:
+        defaults = DEFAULT_CONFIG
+        settings_win = self._get_settings_var("window")
+
+        confirm_kwargs: Dict[str, Any] = {}
+        if settings_win is not None:
+            confirm_kwargs["parent"] = settings_win
+        if not messagebox.askyesno(
+            "Restore Defaults",
+            "Are you sure you want to restore all settings to their default values?",
+            **confirm_kwargs,
+        ):
+            return
+
+        self.core_instance_ref.apply_settings_from_external(**defaults)
+
+        def _set_var(name: str, value) -> None:
+            var = self._get_settings_var(name)
+            if var is not None:
+                try:
+                    var.set(value)
+                except Exception:
+                    pass
+
+        _set_var("auto_paste_var", defaults["auto_paste"])
+        _set_var("mode_var", defaults["record_mode"])
+        _set_var("detected_key_var", defaults["record_key"].upper())
+        _set_var("agent_key_var", defaults["agent_key"].upper())
+        _set_var("agent_model_var", defaults["gemini_agent_model"])
+        _set_var("hotkey_stability_service_enabled_var", defaults["hotkey_stability_service_enabled"])
+        _set_var("min_transcription_duration_var", defaults["min_transcription_duration"])
+        _set_var("min_record_duration_var", defaults["min_record_duration"])
+        _set_var("sound_enabled_var", defaults["sound_enabled"])
+        _set_var("sound_frequency_var", str(defaults["sound_frequency"]))
+        _set_var("sound_duration_var", str(defaults["sound_duration"]))
+        _set_var("sound_volume_var", defaults["sound_volume"])
+        _set_var("text_correction_enabled_var", defaults["text_correction_enabled"])
+        _set_var("text_correction_service_var", defaults["text_correction_service"])
+        _set_var("openrouter_api_key_var", defaults["openrouter_api_key"])
+        _set_var("openrouter_model_var", defaults["openrouter_model"])
+        _set_var("gemini_api_key_var", defaults["gemini_api_key"])
+        _set_var("gemini_model_var", defaults["gemini_model"])
+        _set_var("batch_size_var", str(defaults["batch_size"]))
+        _set_var("asr_backend_var", defaults["asr_backend"])
+        _set_var("asr_model_id_var", defaults["asr_model_id"])
+        _set_var("asr_dtype_var", defaults["asr_dtype"])
+        _set_var("asr_ct2_compute_type_var", defaults["asr_ct2_compute_type"])
+        _set_var("asr_cache_dir_var", defaults["asr_cache_dir"])
+        _set_var("use_vad_var", defaults["use_vad"])
+        _set_var("vad_threshold_var", defaults["vad_threshold"])
+        _set_var("vad_silence_duration_var", defaults["vad_silence_duration"])
+        _set_var("save_temp_recordings_var", defaults[SAVE_TEMP_RECORDINGS_CONFIG_KEY])
+        _set_var("display_transcripts_var", defaults["display_transcripts_in_terminal"])
+        _set_var("record_storage_mode_var", defaults["record_storage_mode"])
+        _set_var("max_memory_seconds_var", defaults["max_memory_seconds"])
+        _set_var("max_memory_seconds_mode_var", defaults["max_memory_seconds_mode"])
+        _set_var("launch_at_startup_var", defaults["launch_at_startup"])
+        _set_var("chunk_length_mode_var", defaults.get("chunk_length_mode", "manual"))
+        _set_var("chunk_length_sec_var", defaults["chunk_length_sec"])
+        _set_var("enable_torch_compile_var", defaults.get("enable_torch_compile", False))
+
+        gemini_prompt_textbox = self._get_settings_var("gemini_prompt_correction_textbox")
+        if gemini_prompt_textbox is not None:
+            gemini_prompt_textbox.delete("1.0", "end")
+            gemini_prompt_textbox.insert("1.0", defaults["gemini_prompt"])
+        agentico_prompt_textbox = self._get_settings_var("agentico_prompt_textbox")
+        if agentico_prompt_textbox is not None:
+            agentico_prompt_textbox.delete("1.0", "end")
+            agentico_prompt_textbox.insert("1.0", defaults["prompt_agentico"])
+        gemini_models_textbox = self._get_settings_var("gemini_models_textbox")
+        if gemini_models_textbox is not None:
+            gemini_models_textbox.delete("1.0", "end")
+            gemini_models_textbox.insert("1.0", "\n".join(defaults["gemini_model_options"]))
+
+        service_map = self._get_settings_meta("service_display_map", {})
+        service_label = next(
+            (label for label, val in service_map.items() if val == defaults["text_correction_service"]),
+            "None",
+        )
+        _set_var("text_correction_service_label_var", service_label)
+        service_menu = self._get_settings_var("service_menu")
+        if service_menu is not None:
+            try:
+                service_menu.set(service_label)
+            except Exception:
+                pass
+        self._on_service_menu_change(service_label)
+
+        available_devices = self._get_settings_meta("available_devices", get_available_devices_for_ui())
+        asr_compute_device_var = self._get_settings_var("asr_compute_device_var")
+        if asr_compute_device_var is not None:
+            selection = "Auto-select (Recommended)"
+            if defaults["asr_compute_device"] == "cpu":
+                selection = "Force CPU"
+            elif defaults["asr_compute_device"] == "cuda" and defaults.get("gpu_index", -1) >= 0:
+                selection = next(
+                    (dev for dev in available_devices if dev.startswith(f"GPU {defaults['gpu_index']}") ),
+                    selection,
+                )
+            try:
+                asr_compute_device_var.set(selection)
+            except Exception:
+                pass
+
+        id_to_display = self._get_settings_meta("id_to_display", {})
+        default_model_display = id_to_display.get(defaults["asr_model_id"], defaults["asr_model_id"])
+        _set_var("asr_model_display_var", default_model_display)
+        asr_model_menu = self._get_settings_var("asr_model_menu")
+        if asr_model_menu is not None:
+            try:
+                asr_model_menu.set(default_model_display)
+            except Exception:
+                pass
+        self._on_model_change(default_model_display)
+
+        self.config_manager.save_config()
+
+        self._update_text_correction_fields()
+        self._update_chunk_length_state()
+        model_var = self._get_settings_var("asr_model_id_var")
+        if model_var is not None:
+            self._update_model_info(model_var.get())
+        self._update_install_button_state()
+
+    def _reset_asr_settings(self) -> None:
+        id_to_display = self._get_settings_meta("id_to_display", {})
+        default_model_id = DEFAULT_CONFIG["asr_model_id"]
+        default_display = id_to_display.get(default_model_id, default_model_id)
+
+        def _set_var(name: str, value: Any) -> None:
+            var = self._get_settings_var(name)
+            if var is not None:
+                try:
+                    var.set(value)
+                except Exception:
+                    pass
+
+        _set_var("asr_model_id_var", default_model_id)
+        _set_var("asr_model_display_var", default_display)
+        model_menu = self._get_settings_var("asr_model_menu")
+        if model_menu is not None:
+            try:
+                model_menu.set(default_display)
+            except Exception:
+                pass
+
+        _set_var("asr_backend_var", DEFAULT_CONFIG["asr_backend"])
+        backend_menu = self._get_settings_var("asr_backend_menu")
+        if backend_menu is not None:
+            try:
+                backend_menu.set(DEFAULT_CONFIG["asr_backend"])
+            except Exception:
+                pass
+
+        _set_var("asr_ct2_compute_type_var", DEFAULT_CONFIG["asr_ct2_compute_type"])
+        ct2_menu = self._get_settings_var("asr_ct2_menu")
+        if ct2_menu is not None:
+            try:
+                ct2_menu.set(DEFAULT_CONFIG["asr_ct2_compute_type"])
+            except Exception:
+                pass
+
+        _set_var("asr_cache_dir_var", DEFAULT_CONFIG["asr_cache_dir"])
+
+        self.config_manager.set_asr_model_id(default_model_id)
+        self.config_manager.set_asr_backend(DEFAULT_CONFIG["asr_backend"])
+        self.config_manager.set_asr_ct2_compute_type(DEFAULT_CONFIG["asr_ct2_compute_type"])
+        self.config_manager.set_asr_cache_dir(DEFAULT_CONFIG["asr_cache_dir"])
+        self.config_manager.save_config()
+
+        backend_var = self._get_settings_var("asr_backend_var")
+        backend_choice = backend_var.get() if backend_var is not None else DEFAULT_CONFIG["asr_backend"]
+        self._on_backend_change(backend_choice)
+        self._update_model_info(default_model_id)
+        self._update_install_button_state()
 
     # Methods for the live transcription window
     def _show_live_transcription_window(self):
@@ -354,6 +1043,9 @@ class UIManager:
                 return
 
             try:
+                self._clear_settings_context()
+                self._set_settings_var("window", settings_win)
+
                 # Variables (adjust to use self.config_manager.get)
                 auto_paste_var = ctk.BooleanVar(value=self.config_manager.get("auto_paste"))
                 mode_var = ctk.StringVar(value=self.config_manager.get("record_mode"))
@@ -374,6 +1066,7 @@ class UIManager:
                     "OpenRouter": SERVICE_OPENROUTER,
                     "Gemini": SERVICE_GEMINI,
                 }
+                self._set_settings_meta("service_display_map", service_display_map)
                 text_correction_service_label_var = ctk.StringVar(
                     value=next((label for label, val in service_display_map.items()
                                 if val == text_correction_service_var.get()), "None")
@@ -406,25 +1099,54 @@ class UIManager:
                 asr_backend_var = ctk.StringVar(value=self.config_manager.get_asr_backend())
                 asr_model_id_var = ctk.StringVar(value=self.config_manager.get_asr_model_id())
                 asr_model_display_var = ctk.StringVar()
-                asr_model_var = asr_model_id_var
                 asr_dtype_var = ctk.StringVar(value=self.config_manager.get_asr_dtype())
                 asr_ct2_compute_type_var = ctk.StringVar(value=self.config_manager.get_asr_ct2_compute_type())
                 asr_cache_dir_var = ctk.StringVar(value=self.config_manager.get_asr_cache_dir())
 
-                def update_text_correction_fields():
-                    enabled = text_correction_enabled_var.get()
-                    state = "normal" if enabled else "disabled"
-                    service_menu.configure(state=state)
-                    openrouter_key_entry.configure(state=state)
-                    openrouter_model_entry.configure(state=state)
-                    gemini_key_entry.configure(state=state)
-                    gemini_model_menu.configure(state=state)
-                    gemini_prompt_correction_textbox.configure(state=state)
-                    agentico_prompt_textbox.configure(state=state)
-                    gemini_models_textbox.configure(state=state)
+                for name, var in [
+                    ("auto_paste_var", auto_paste_var),
+                    ("mode_var", mode_var),
+                    ("detected_key_var", detected_key_var),
+                    ("agent_key_var", agent_key_var),
+                    ("agent_model_var", agent_model_var),
+                    ("hotkey_stability_service_enabled_var", hotkey_stability_service_enabled_var),
+                    ("min_transcription_duration_var", min_transcription_duration_var),
+                    ("min_record_duration_var", min_record_duration_var),
+                    ("sound_enabled_var", sound_enabled_var),
+                    ("sound_frequency_var", sound_frequency_var),
+                    ("sound_duration_var", sound_duration_var),
+                    ("sound_volume_var", sound_volume_var),
+                    ("text_correction_enabled_var", text_correction_enabled_var),
+                    ("text_correction_service_var", text_correction_service_var),
+                    ("text_correction_service_label_var", text_correction_service_label_var),
+                    ("openrouter_api_key_var", openrouter_api_key_var),
+                    ("openrouter_model_var", openrouter_model_var),
+                    ("gemini_api_key_var", gemini_api_key_var),
+                    ("gemini_model_var", gemini_model_var),
+                    ("batch_size_var", batch_size_var),
+                    ("use_vad_var", use_vad_var),
+                    ("launch_at_startup_var", launch_at_startup_var),
+                    ("vad_threshold_var", vad_threshold_var),
+                    ("vad_silence_duration_var", vad_silence_duration_var),
+                    ("save_temp_recordings_var", save_temp_recordings_var),
+                    ("display_transcripts_var", display_transcripts_var),
+                    ("record_storage_mode_var", record_storage_mode_var),
+                    ("max_memory_seconds_mode_var", max_memory_seconds_mode_var),
+                    ("max_memory_seconds_var", max_memory_seconds_var),
+                    ("chunk_length_mode_var", chunk_length_mode_var),
+                    ("chunk_length_sec_var", chunk_length_sec_var),
+                    ("enable_torch_compile_var", enable_torch_compile_var),
+                    ("asr_backend_var", asr_backend_var),
+                    ("asr_model_id_var", asr_model_id_var),
+                    ("asr_dtype_var", asr_dtype_var),
+                    ("asr_ct2_compute_type_var", asr_ct2_compute_type_var),
+                    ("asr_cache_dir_var", asr_cache_dir_var),
+                ]:
+                    self._set_settings_var(name, var)
 
                 # Compute device selection variable
                 available_devices = get_available_devices_for_ui()
+                self._set_settings_meta("available_devices", available_devices)
                 current_device_selection = "Auto-select (Recommended)"
                 compute_device_cfg = self.config_manager.get("asr_compute_device")
                 gpu_index_cfg = self.config_manager.get("gpu_index")
@@ -436,245 +1158,8 @@ class UIManager:
                             current_device_selection = dev
                             break
                 asr_compute_device_var = ctk.StringVar(value=current_device_selection)
+                self._set_settings_var("asr_compute_device_var", asr_compute_device_var)
                 self._gpu_selection_var = asr_compute_device_var
-
-                # Internal GUI functions (detect_key_task_internal, apply_settings, close_settings, etc.)
-                # Will need to be adapted to call methods of self.core_instance_ref and self.config_manager
-                # Example of adapted apply_settings:
-                def apply_settings():
-                    logging.info("Apply settings clicked (in Tkinter thread).")
-                    # State validations (moved to AppCore or handled via callbacks)
-                    if self.core_instance_ref.current_state in ["RECORDING", "TRANSCRIBING", "LOADING_MODEL"]:
-                        messagebox.showwarning("Apply Settings", "Cannot apply while recording/transcribing/loading model.", parent=settings_win)
-                        return
-
-                    # Collect UI values
-                    key_to_apply = detected_key_var.get().lower() if detected_key_var.get() != "PRESS KEY..." else self.config_manager.get("record_key")
-                    mode_to_apply = mode_var.get()
-                    auto_paste_to_apply = auto_paste_var.get() # Now unified
-                    agent_key_to_apply = agent_key_var.get().lower() if agent_key_var.get() != "PRESS KEY..." else self.config_manager.get("agent_key")
-                    model_to_apply = agent_model_var.get()
-                    hotkey_stability_service_enabled_to_apply = hotkey_stability_service_enabled_var.get() # Coleta o valor da nova variável
-                    sound_enabled_to_apply = sound_enabled_var.get()
-                    sound_freq_to_apply = self._safe_get_int(sound_frequency_var, "Frequência do Som", settings_win)
-                    if sound_freq_to_apply is None:
-                        return
-                    sound_duration_to_apply = self._safe_get_float(sound_duration_var, "Duração do Som", settings_win)
-                    if sound_duration_to_apply is None:
-                        return
-                    sound_volume_to_apply = self._safe_get_float(sound_volume_var, "Volume do Som", settings_win)
-                    if sound_volume_to_apply is None:
-                        return
-                    text_correction_enabled_to_apply = text_correction_enabled_var.get()
-                    text_correction_service_to_apply = text_correction_service_var.get()
-                    openrouter_api_key_to_apply = openrouter_api_key_var.get()
-                    openrouter_model_to_apply = openrouter_model_var.get()
-                    gemini_api_key_to_apply = gemini_api_key_var.get()
-                    gemini_model_to_apply = gemini_model_var.get()
-                    gemini_prompt_correction_to_apply = gemini_prompt_correction_textbox.get("1.0", "end-1c")
-                    agentico_prompt_to_apply = agentico_prompt_textbox.get("1.0", "end-1c")
-                    batch_size_to_apply = self._safe_get_int(batch_size_var, "Batch Size", settings_win)
-                    if batch_size_to_apply is None:
-                        return
-                    min_transcription_duration_to_apply = self._safe_get_float(min_transcription_duration_var, "Duração Mínima", settings_win)
-                    if min_transcription_duration_to_apply is None:
-                        return
-                    min_record_duration_to_apply = self._safe_get_float(min_record_duration_var, "Duração Mínima da Gravação", settings_win)
-                    if min_record_duration_to_apply is None:
-                        return
-                    use_vad_to_apply = use_vad_var.get()
-                    vad_threshold_to_apply = self._safe_get_float(vad_threshold_var, "Limiar do VAD", settings_win)
-                    if vad_threshold_to_apply is None:
-                        return
-                    vad_silence_duration_to_apply = self._safe_get_float(vad_silence_duration_var, "Duração do Silêncio", settings_win)
-                    if vad_silence_duration_to_apply is None:
-                        return
-                    save_temp_recordings_to_apply = save_temp_recordings_var.get()
-                    display_transcripts_to_apply = display_transcripts_var.get()
-                    max_memory_seconds_mode_to_apply = max_memory_seconds_mode_var.get()
-                    max_memory_seconds_to_apply = self._safe_get_float(max_memory_seconds_var, "Max Memory Retention", settings_win)
-                    if max_memory_seconds_to_apply is None:
-                        return
-                    asr_backend_to_apply = asr_backend_var.get()
-                    asr_model_id_to_apply = asr_model_id_var.get()
-                    asr_compute_device_to_apply = "auto"
-                    asr_dtype_to_apply = asr_dtype_var.get()
-                    asr_ct2_compute_type_to_apply = asr_ct2_compute_type_var.get()
-                    asr_cache_dir_to_apply = asr_cache_dir_var.get()
-                    try:
-                        Path(asr_cache_dir_to_apply).mkdir(parents=True, exist_ok=True)
-                    except Exception as e:
-                        messagebox.showerror("Invalid Path", f"ASR cache directory is invalid:\n{e}", parent=settings_win)
-                        return
-
-                    # Logic for converting UI to GPU index
-                    selected_device_str = asr_compute_device_var.get()
-                    gpu_index_to_apply = -1 # Default to "Auto-select"
-                    if "Force CPU" in selected_device_str:
-                        asr_compute_device_to_apply = "cpu"
-                    elif selected_device_str.startswith("GPU"):
-                        asr_compute_device_to_apply = "cuda"
-                        try:
-                            gpu_index_to_apply = int(selected_device_str.split(":")[0].replace("GPU", "").strip())
-                        except (ValueError, IndexError):
-                            messagebox.showerror("Valor inválido", "Índice de GPU inválido.", parent=settings_win)
-                            return
-                    asr_dtype_to_apply = asr_dtype_var.get()
-                    asr_ct2_compute_type_to_apply = asr_ct2_compute_type_var.get()
-                    asr_cache_dir_to_apply = asr_cache_dir_var.get()
-
-                    models_text = gemini_models_textbox.get("1.0", "end-1c")
-                    new_models_list = [line.strip() for line in models_text.split("\n") if line.strip()]
-                    if not new_models_list:
-                        messagebox.showwarning("Invalid Value", "The model list cannot be empty. Please add at least one model.", parent=settings_win)
-                        return
-
-                    # Call AppCore method to apply settings
-                    self.core_instance_ref.apply_settings_from_external(
-                        new_key=key_to_apply,
-                        new_mode=mode_to_apply,
-                        new_auto_paste=auto_paste_to_apply,
-                        new_sound_enabled=sound_enabled_to_apply,
-                        new_sound_frequency=sound_freq_to_apply,
-                        new_sound_duration=sound_duration_to_apply,
-                        new_sound_volume=sound_volume_to_apply,
-                        new_agent_key=agent_key_to_apply,
-                        new_text_correction_enabled=text_correction_enabled_to_apply,
-                        new_text_correction_service=text_correction_service_to_apply,
-                        new_openrouter_api_key=openrouter_api_key_to_apply,
-                        new_openrouter_model=openrouter_model_to_apply,
-                        new_gemini_api_key=gemini_api_key_to_apply,
-                        new_gemini_model=gemini_model_to_apply,
-                        new_gemini_prompt=gemini_prompt_correction_to_apply,
-                        prompt_agentico=agentico_prompt_to_apply,
-                        new_agent_model=model_to_apply,
-                        new_gemini_model_options=new_models_list,
-                        new_batch_size=batch_size_to_apply,
-                        new_gpu_index=gpu_index_to_apply,
-                        new_hotkey_stability_service_enabled=hotkey_stability_service_enabled_to_apply, # Nova configuração unificada
-                        new_min_transcription_duration=min_transcription_duration_to_apply,
-                        new_min_record_duration=min_record_duration_to_apply,
-                        new_save_temp_recordings=save_temp_recordings_to_apply,
-                        new_record_storage_mode=record_storage_mode_var.get(),
-                        new_record_to_memory=(record_storage_mode_var.get() == "memory"),
-                        new_max_memory_seconds_mode=max_memory_seconds_mode_to_apply,
-                        new_max_memory_seconds=max_memory_seconds_to_apply,
-                        new_use_vad=use_vad_to_apply,
-                        new_vad_threshold=vad_threshold_to_apply,
-                        new_vad_silence_duration=vad_silence_duration_to_apply,
-                        new_display_transcripts_in_terminal=display_transcripts_to_apply,
-                        new_launch_at_startup=launch_at_startup_var.get(),
-                        # New chunk settings
-                        new_chunk_length_mode=chunk_length_mode_var.get(),
-                        new_chunk_length_sec=float(chunk_length_sec_var.get()),
-                        # New: torch compile setting
-                        new_enable_torch_compile=bool(enable_torch_compile_var.get()),
-                        new_asr_backend=asr_backend_to_apply,
-                        new_asr_model_id=asr_model_id_to_apply,
-                        new_asr_compute_device=asr_compute_device_to_apply,
-                        new_asr_dtype=asr_dtype_to_apply,
-                        new_asr_ct2_compute_type=asr_ct2_compute_type_to_apply,
-                        new_asr_cache_dir=asr_cache_dir_to_apply
-                    )
-                    self._close_settings_window() # Call class method
-
-                def restore_defaults():
-                    if not messagebox.askyesno(
-                        "Restore Defaults",
-                        "Are you sure you want to restore all settings to their default values?",
-                        parent=settings_win,
-                    ):
-                        return
-
-                    self.core_instance_ref.apply_settings_from_external(**DEFAULT_CONFIG)
-
-                    auto_paste_var.set(DEFAULT_CONFIG["auto_paste"])
-                    mode_var.set(DEFAULT_CONFIG["record_mode"])
-                    detected_key_var.set(DEFAULT_CONFIG["record_key"].upper())
-                    agent_key_var.set(DEFAULT_CONFIG["agent_key"].upper())
-                    agent_model_var.set(DEFAULT_CONFIG["gemini_agent_model"])
-                    hotkey_stability_service_enabled_var.set(DEFAULT_CONFIG["hotkey_stability_service_enabled"])
-                    min_transcription_duration_var.set(DEFAULT_CONFIG["min_transcription_duration"])
-                    min_record_duration_var.set(DEFAULT_CONFIG["min_record_duration"])
-                    sound_enabled_var.set(DEFAULT_CONFIG["sound_enabled"])
-                    sound_frequency_var.set(str(DEFAULT_CONFIG["sound_frequency"]))
-                    sound_duration_var.set(str(DEFAULT_CONFIG["sound_duration"]))
-                    sound_volume_var.set(DEFAULT_CONFIG["sound_volume"])
-                    text_correction_enabled_var.set(DEFAULT_CONFIG["text_correction_enabled"])
-                    text_correction_service_var.set(DEFAULT_CONFIG["text_correction_service"])
-                    text_correction_service_label_var.set(
-                        next(
-                            (
-                                label
-                                for label, val in service_display_map.items()
-                                if val == DEFAULT_CONFIG["text_correction_service"]
-                            ),
-                            "None",
-                        )
-                    )
-                    # Sincroniza os campos de correção de texto caso os widgets existam
-                    try:
-                        service_menu  # Verifica se os widgets foram criados
-                    except NameError:
-                        pass
-                    else:
-                        service_menu.set(text_correction_service_label_var.get())
-                        update_text_correction_fields()
-                    openrouter_api_key_var.set(DEFAULT_CONFIG["openrouter_api_key"])
-                    openrouter_model_var.set(DEFAULT_CONFIG["openrouter_model"])
-                    gemini_api_key_var.set(DEFAULT_CONFIG["gemini_api_key"])
-                    gemini_model_var.set(DEFAULT_CONFIG["gemini_model"])
-                    asr_model_var.set(DEFAULT_CONFIG["asr_model_id"])
-                    asr_model_display_var.set(
-                        id_to_display.get(
-                            DEFAULT_CONFIG["asr_model_id"],
-                            DEFAULT_CONFIG["asr_model_id"],
-                        )
-                    )
-                    gemini_prompt_correction_textbox.delete("1.0", "end")
-                    gemini_prompt_correction_textbox.insert("1.0", DEFAULT_CONFIG["gemini_prompt"])
-                    agentico_prompt_textbox.delete("1.0", "end")
-                    agentico_prompt_textbox.insert("1.0", DEFAULT_CONFIG["prompt_agentico"])
-                    gemini_models_textbox.delete("1.0", "end")
-                    gemini_models_textbox.insert("1.0", "\n".join(DEFAULT_CONFIG["gemini_model_options"]))
-                    batch_size_var.set(str(DEFAULT_CONFIG["batch_size"]))
-                    asr_backend_var.set(DEFAULT_CONFIG["asr_backend"])
-                    asr_model_var.set(DEFAULT_CONFIG["asr_model_id"])
-                    asr_model_display_var.set(
-                        id_to_display.get(
-                            DEFAULT_CONFIG["asr_model_id"],
-                            DEFAULT_CONFIG["asr_model_id"],
-                        )
-                    )
-
-                    if DEFAULT_CONFIG["asr_compute_device"] == "cpu":
-                        asr_compute_device_var.set("Force CPU")
-                    elif DEFAULT_CONFIG["asr_compute_device"] == "cuda" and DEFAULT_CONFIG["gpu_index"] >= 0:
-                        found = "Auto-select (Recommended)"
-                        for dev in available_devices:
-                            if dev.startswith(f"GPU {DEFAULT_CONFIG['gpu_index']}"):
-                                found = dev
-                                break
-                        asr_compute_device_var.set(found)
-                    else:
-                        asr_compute_device_var.set("Auto-select (Recommended)")
-
-                    use_vad_var.set(DEFAULT_CONFIG["use_vad"])
-                    vad_threshold_var.set(DEFAULT_CONFIG["vad_threshold"])
-                    vad_silence_duration_var.set(DEFAULT_CONFIG["vad_silence_duration"])
-                    save_temp_recordings_var.set(DEFAULT_CONFIG[SAVE_TEMP_RECORDINGS_CONFIG_KEY])
-                    display_transcripts_var.set(DEFAULT_CONFIG["display_transcripts_in_terminal"])
-                    record_storage_mode_var.set(DEFAULT_CONFIG["record_storage_mode"])
-                    max_memory_seconds_var.set(DEFAULT_CONFIG["max_memory_seconds"])
-                    max_memory_seconds_mode_var.set(DEFAULT_CONFIG["max_memory_seconds_mode"])
-                    launch_at_startup_var.set(DEFAULT_CONFIG["launch_at_startup"])
-                    asr_backend_var.set(DEFAULT_CONFIG["asr_backend"])
-                    asr_compute_device_var.set(DEFAULT_CONFIG["asr_compute_device"])
-                    asr_dtype_var.set(DEFAULT_CONFIG["asr_dtype"])
-                    asr_ct2_compute_type_var.set(DEFAULT_CONFIG["asr_ct2_compute_type"])
-                    asr_cache_dir_var.set(DEFAULT_CONFIG["asr_cache_dir"])
-
-                    self.config_manager.save_config()
 
                 scrollable_frame = ctk.CTkScrollableFrame(settings_win, fg_color="transparent")
                 scrollable_frame.pack(fill="both", expand=True, padx=10, pady=10)
@@ -695,14 +1180,11 @@ class UIManager:
                 key_display.pack(side="left", padx=5)
                 Tooltip(key_display, "Current hotkey for recording.")
                 
-                def detect_key_task_internal(key_var):
-                    key_var.set("PRESS KEY...")
-                    settings_win.update_idletasks()
-                    # Pass the callback to AppCore to update the StringVar
-                    self.core_instance_ref.set_key_detection_callback(lambda key: key_var.set(key))
-                    self.core_instance_ref.start_key_detection_thread()
-
-                detect_key_button = ctk.CTkButton(key_frame, text="Detect Key", command=lambda: detect_key_task_internal(detected_key_var))
+                detect_key_button = ctk.CTkButton(
+                    key_frame,
+                    text="Detect Key",
+                    command=lambda: self._start_key_detection_for("detected_key_var"),
+                )
                 detect_key_button.pack(side="left", padx=5)
                 Tooltip(detect_key_button, "Capture a new recording hotkey.")
 
@@ -713,7 +1195,11 @@ class UIManager:
                 agent_key_display = ctk.CTkLabel(agent_key_frame, textvariable=agent_key_var, fg_color="gray20", corner_radius=5, width=120)
                 agent_key_display.pack(side="left", padx=5)
                 Tooltip(agent_key_display, "Current hotkey for agent mode.")
-                detect_agent_key_button = ctk.CTkButton(agent_key_frame, text="Detect Key", command=lambda: detect_key_task_internal(agent_key_var))
+                detect_agent_key_button = ctk.CTkButton(
+                    agent_key_frame,
+                    text="Detect Key",
+                    command=lambda: self._start_key_detection_for("agent_key_var"),
+                )
                 detect_agent_key_button.pack(side="left", padx=5)
                 Tooltip(detect_agent_key_button, "Capture a new agent hotkey.")
 
@@ -781,7 +1267,12 @@ class UIManager:
 
                 text_correction_frame = ctk.CTkFrame(ai_frame)
                 text_correction_frame.pack(fill="x", pady=5)
-                correction_switch = ctk.CTkSwitch(text_correction_frame, text="Enable Text Correction", variable=text_correction_enabled_var, command=update_text_correction_fields)
+                correction_switch = ctk.CTkSwitch(
+                    text_correction_frame,
+                    text="Enable Text Correction",
+                    variable=text_correction_enabled_var,
+                    command=self._update_text_correction_fields,
+                )
                 correction_switch.pack(side="left", padx=5)
                 Tooltip(correction_switch, "Use an AI service to polish the text.")
 
@@ -792,9 +1283,10 @@ class UIManager:
                     service_frame,
                     variable=text_correction_service_label_var,
                     values=list(service_display_map.keys()),
-                    command=lambda choice: text_correction_service_var.set(service_display_map[choice]),
+                    command=self._on_service_menu_change,
                 )
                 service_menu.pack(side="left", padx=5)
+                self._set_settings_var("service_menu", service_menu)
                 Tooltip(service_menu, "Select the service for text correction.")
 
                 # --- OpenRouter Settings ---
@@ -803,10 +1295,12 @@ class UIManager:
                 ctk.CTkLabel(openrouter_frame, text="OpenRouter API Key:").pack(side="left", padx=(5, 10))
                 openrouter_key_entry = ctk.CTkEntry(openrouter_frame, textvariable=openrouter_api_key_var, show="*", width=250)
                 openrouter_key_entry.pack(side="left", padx=5)
+                self._set_settings_var("openrouter_key_entry", openrouter_key_entry)
                 Tooltip(openrouter_key_entry, "API key for the OpenRouter service.")
                 ctk.CTkLabel(openrouter_frame, text="OpenRouter Model:").pack(side="left", padx=(5, 10))
                 openrouter_model_entry = ctk.CTkEntry(openrouter_frame, textvariable=openrouter_model_var, width=200)
                 openrouter_model_entry.pack(side="left", padx=5)
+                self._set_settings_var("openrouter_model_entry", openrouter_model_entry)
                 Tooltip(openrouter_model_entry, "Model name for OpenRouter.")
 
                 # --- Gemini Settings ---
@@ -815,12 +1309,14 @@ class UIManager:
                 ctk.CTkLabel(gemini_frame, text="Gemini API Key:").pack(side="left", padx=(5, 10))
                 gemini_key_entry = ctk.CTkEntry(gemini_frame, textvariable=gemini_api_key_var, show="*", width=250)
                 gemini_key_entry.pack(side="left", padx=5)
+                self._set_settings_var("gemini_key_entry", gemini_key_entry)
                 Tooltip(gemini_key_entry, "API key for the Gemini service.")
                 ctk.CTkLabel(gemini_frame, text="Gemini Model:").pack(side="left", padx=(5, 10))
                 gemini_model_menu = ctk.CTkOptionMenu(gemini_frame, variable=gemini_model_var, values=self.config_manager.get("gemini_model_options", []))
                 gemini_model_menu.pack(side="left", padx=5)
+                self._set_settings_var("gemini_model_menu", gemini_model_menu)
                 Tooltip(gemini_model_menu, "Model used for Gemini requests.")
-                
+
                 # --- Gemini Prompt ---
                 gemini_prompt_frame = ctk.CTkFrame(ai_frame)
                 gemini_prompt_frame.pack(fill="x", pady=5)
@@ -828,18 +1324,21 @@ class UIManager:
                 gemini_prompt_correction_textbox = ctk.CTkTextbox(gemini_prompt_frame, height=100, wrap="word")
                 gemini_prompt_correction_textbox.pack(fill="x", expand=True, pady=5)
                 gemini_prompt_correction_textbox.insert("1.0", self.config_manager.get(GEMINI_PROMPT_CONFIG_KEY))
+                self._set_settings_var("gemini_prompt_correction_textbox", gemini_prompt_correction_textbox)
                 Tooltip(gemini_prompt_correction_textbox, "Prompt used to refine text.")
 
                 ctk.CTkLabel(gemini_prompt_frame, text="Prompt do Modo Agêntico:").pack(anchor="w", pady=(5,0))
                 agentico_prompt_textbox = ctk.CTkTextbox(gemini_prompt_frame, height=60, wrap="word")
                 agentico_prompt_textbox.pack(fill="x", expand=True, pady=5)
                 agentico_prompt_textbox.insert("1.0", self.config_manager.get("prompt_agentico"))
+                self._set_settings_var("agentico_prompt_textbox", agentico_prompt_textbox)
                 Tooltip(agentico_prompt_textbox, "Prompt executed in agent mode.")
 
                 ctk.CTkLabel(gemini_prompt_frame, text="Gemini Models (one per line):").pack(anchor="w", pady=(5,0))
                 gemini_models_textbox = ctk.CTkTextbox(gemini_prompt_frame, height=60, wrap="word")
                 gemini_models_textbox.pack(fill="x", expand=True, pady=5)
                 gemini_models_textbox.insert("1.0", "\n".join(self.config_manager.get("gemini_model_options", [])))
+                self._set_settings_var("gemini_models_textbox", gemini_models_textbox)
                 Tooltip(gemini_models_textbox, "List of models to try, one per line.")
 
                 # --- ASR Settings ---
@@ -874,7 +1373,12 @@ class UIManager:
                 chunk_mode_frame = ctk.CTkFrame(transcription_frame)
                 chunk_mode_frame.pack(fill="x", pady=5)
                 ctk.CTkLabel(chunk_mode_frame, text="Chunk Length Mode:").pack(side="left", padx=(5, 10))
-                chunk_mode_menu = ctk.CTkOptionMenu(chunk_mode_frame, variable=chunk_length_mode_var, values=["auto", "manual"])
+                chunk_mode_menu = ctk.CTkOptionMenu(
+                    chunk_mode_frame,
+                    variable=chunk_length_mode_var,
+                    values=["auto", "manual"],
+                    command=self._on_chunk_mode_change,
+                )
                 chunk_mode_menu.pack(side="left", padx=5)
                 Tooltip(chunk_mode_menu, "Choose how chunk size is determined.")
 
@@ -884,23 +1388,8 @@ class UIManager:
                 ctk.CTkLabel(chunk_len_frame, text="Chunk Length (sec):").pack(side="left", padx=(5, 10))
                 chunk_len_entry = ctk.CTkEntry(chunk_len_frame, textvariable=chunk_length_sec_var, width=80)
                 chunk_len_entry.pack(side="left", padx=5)
+                self._set_settings_var("chunk_len_entry", chunk_len_entry)
                 Tooltip(chunk_len_entry, "Fixed chunk duration when in manual mode.")
-
-                def update_chunk_length_state():
-                    try:
-                        mode_val = chunk_length_mode_var.get().lower()
-                    except Exception:
-                        mode_val = "manual"
-                    state = "normal" if mode_val == "manual" else "disabled"
-                    try:
-                        chunk_len_entry.configure(state=state)
-                    except Exception:
-                        pass
-
-                # initialize state
-                update_chunk_length_state()
-                # bind changes
-                chunk_mode_menu.configure(command=lambda _: update_chunk_length_state())
     
                 # New: Ignore Transcriptions Shorter Than
                 min_transcription_duration_frame = ctk.CTkFrame(transcription_frame)
@@ -1021,18 +1510,14 @@ class UIManager:
                 quant_menu.pack(side="left", padx=5)
                 Tooltip(quant_menu, "Available compute types for the CTranslate2 backend.")
 
-                def _on_backend_change(choice: str) -> None:
-                    asr_backend_var.set(choice)
-                    _update_install_button_state()
-                    _update_model_info(asr_model_id_var.get())
-
                 asr_backend_menu = ctk.CTkOptionMenu(
                     asr_backend_frame,
                     variable=asr_backend_var,
                     values=["auto", "transformers", "ct2"],
-                    command=_on_backend_change,
+                    command=self._on_backend_change,
                 )
                 asr_backend_menu.pack(side="left", padx=5)
+                self._set_settings_var("asr_backend_menu", asr_backend_menu)
                 Tooltip(
                     asr_backend_menu,
                     "Inference backend for speech recognition.\nDerived from selected model; override in advanced mode.",
@@ -1043,6 +1528,7 @@ class UIManager:
                 ctk.CTkLabel(asr_model_frame, text="ASR Model:").pack(side="left", padx=(5, 10))
 
                 catalog = model_manager.list_catalog()
+                self._set_settings_meta("catalog", catalog)
                 catalog_display_map = {entry["id"]: entry.get("display_name", entry["id"]) for entry in catalog}
                 try:
                     installed_ids = {
@@ -1050,116 +1536,39 @@ class UIManager:
                     }
                 except OSError:
                     messagebox.showerror(
-                        "Configuração",
+                        "Settings",
+                        "Unable to list installed ASR models. Please verify the cache directory.",
                     )
                     installed_ids = set()
                 all_ids = sorted({m["id"] for m in catalog} | installed_ids)
                 id_to_display = {mid: catalog_display_map.get(mid, mid) for mid in all_ids}
                 display_to_id = {v: k for k, v in id_to_display.items()}
+                self._set_settings_meta("id_to_display", id_to_display)
+                self._set_settings_meta("display_to_id", display_to_id)
                 asr_model_display_var = ctk.StringVar(
                     value=id_to_display.get(asr_model_id_var.get(), asr_model_id_var.get())
                 )
+                self._set_settings_var("asr_model_display_var", asr_model_display_var)
 
                 asr_model_menu = ctk.CTkOptionMenu(
                     asr_model_frame,
                     variable=asr_model_display_var,
                     values=[id_to_display[mid] for mid in all_ids],
+                    command=self._on_model_change,
                 )
                 asr_model_menu.pack(side="left", padx=5)
+                self._set_settings_var("asr_model_menu", asr_model_menu)
                 Tooltip(asr_model_menu, "Model identifier from curated catalog.")
 
-                def _reset_asr() -> None:
-                    default_model_id = DEFAULT_CONFIG["asr_model_id"]
-                    default_display = id_to_display.get(default_model_id, default_model_id)
-                    asr_model_id_var.set(default_model_id)
-                    asr_model_display_var.set(default_display)
-                    asr_model_menu.set(default_display)
-                    asr_backend_var.set(DEFAULT_CONFIG["asr_backend"])
-                    asr_backend_menu.set(DEFAULT_CONFIG["asr_backend"])
-                    asr_ct2_compute_type_var.set(DEFAULT_CONFIG["asr_ct2_compute_type"])
-                    asr_ct2_menu.set(DEFAULT_CONFIG["asr_ct2_compute_type"])
-                    asr_cache_dir_var.set(DEFAULT_CONFIG["asr_cache_dir"])
-                    _on_backend_change(asr_backend_var.get())
-                    _update_model_info(default_model_id)
-                    self.config_manager.set_asr_model_id(default_model_id)
-                    self.config_manager.set_asr_backend(DEFAULT_CONFIG["asr_backend"])
-                    self.config_manager.set_asr_ct2_compute_type(DEFAULT_CONFIG["asr_ct2_compute_type"])
-                    self.config_manager.set_asr_cache_dir(DEFAULT_CONFIG["asr_cache_dir"])
-                    self.config_manager.save_config()
-
                 reset_asr_button = ctk.CTkButton(
-                    asr_model_frame, text="Reset ASR", command=_reset_asr
+                    asr_model_frame, text="Reset ASR", command=self._reset_asr_settings
                 )
                 reset_asr_button.pack(side="left", padx=5)
                 Tooltip(reset_asr_button, "Restore default ASR settings.")
 
                 model_size_label = ctk.CTkLabel(asr_model_frame, text="")
                 model_size_label.pack(side="left", padx=5)
-
-                def _update_model_info(model_ref: str) -> None:
-                    model_id = display_to_id.get(model_ref, model_ref)
-                    try:
-                        d_bytes, d_files = model_manager.get_model_download_size(model_id)
-                        d_mb = d_bytes / (1024 * 1024)
-                        download_text = f"{d_mb:.1f} MB ({d_files} files)"
-                    except Exception:
-                        download_text = "?"
-
-                    try:
-                        installed_models = model_manager.list_installed(asr_cache_dir_var.get())
-                    except OSError:
-                        messagebox.showerror(
-                            "Configuração",
-                        )
-                        installed_models = []
-                    entry = next((m for m in installed_models if m["id"] == model_id), None)
-                    if entry:
-                        i_bytes, i_files = model_manager.get_installed_size(entry["path"])
-                        i_mb = i_bytes / (1024 * 1024)
-                        installed_text = f"{i_mb:.1f} MB ({i_files} files)"
-                    else:
-                        installed_text = "-"
-
-                    model_size_label.configure(
-                        text=f"Download: {download_text} | Installed: {installed_text}"
-                    )
-
-                def _derive_backend_from_model(model_ref: str) -> str | None:
-                    model_id = display_to_id.get(model_ref, model_ref)
-                    entry = next((m for m in catalog if m["id"] == model_id), None)
-                    if not entry:
-                        installed = model_manager.list_installed(asr_cache_dir_var.get())
-                        entry = next((m for m in installed if m["id"] == model_id), None)
-                    backend = entry.get("backend") if entry else None
-                    if backend in ("faster-whisper", "ctranslate2"):
-                        backend = "ct2"
-                    if backend not in ("transformers", "ct2"):
-                        return None
-                    return backend
-
-                def _update_install_button_state() -> None:
-                    backend = _derive_backend_from_model(asr_model_id_var.get())
-                    install_button.configure(state="normal" if backend else "disabled")
-                    quant_menu.configure(state="normal" if backend == "ct2" else "disabled")
-
-                def _on_model_change(choice_display: str) -> None:
-                    model_id = display_to_id.get(choice_display, choice_display)
-                    asr_model_id_var.set(model_id)
-                    asr_model_display_var.set(id_to_display.get(model_id, model_id))
-                    backend = _derive_backend_from_model(model_id)
-                    if backend:
-                        asr_backend_var.set(backend)
-                        asr_backend_menu.configure(state="disabled")
-                    else:
-                        asr_backend_menu.configure(state="normal")
-                    self.config_manager.set_asr_model_id(model_id)
-                    self.config_manager.set_asr_backend(asr_backend_var.get())
-                    self.config_manager.save_config()
-                    _on_backend_change(asr_backend_var.get())
-                    _update_model_info(model_id)
-
-                asr_model_menu.configure(command=_on_model_change)
-                _on_model_change(asr_model_display_var.get())
+                self._set_settings_var("model_size_label", model_size_label)
 
                 asr_device_frame = ctk.CTkFrame(asr_frame)
                 asr_device_frame.pack(fill="x", pady=5)
@@ -1204,6 +1613,7 @@ class UIManager:
                     values=["auto", "float16", "float32", "int8_float16", "int8_float32"],
                 )
                 asr_ct2_menu.pack(side="left", padx=5)
+                self._set_settings_var("asr_ct2_menu", asr_ct2_menu)
                 Tooltip(asr_ct2_menu, "Compute type for CTranslate2 backend.")
 
                 asr_cache_frame = ctk.CTkFrame(transcription_frame)
@@ -1217,76 +1627,26 @@ class UIManager:
                 asr_cache_entry.pack(side="left", padx=5)
                 Tooltip(asr_cache_entry, "Diretório para modelos de ASR em cache.")
 
-                def _install_model():
-                    cache_dir = asr_cache_dir_var.get()
-                    try:
-                        Path(cache_dir).mkdir(parents=True, exist_ok=True)
-                    except Exception as e:
-                        messagebox.showerror("Invalid Path", f"ASR cache directory is invalid:\n{e}")
-                        return
-
-                    model_id = asr_model_id_var.get()
-                    backend = _derive_backend_from_model(model_id)
-                    if backend is None:
-                        messagebox.showerror(
-                            "Model", "Unable to determine backend for selected model.",
-                        )
-                        return
-
-                    try:
-                        size_bytes, file_count = model_manager.get_model_download_size(model_id)
-                        size_gb = size_bytes / (1024 ** 3)
-                        detail = f"approximately {size_gb:.2f} GB ({file_count} files)"
-                    except Exception:
-                        detail = "an unspecified size"
-
-                    if not messagebox.askyesno(
-                        "Model Download",
-                        f"Model '{model_id}' will download {detail}.\nContinue?",
-                    ):
-                        return
-
-                    try:
-                        model_manager.ensure_download(
-                            model_id,
-                            backend,
-                            cache_dir,
-                            asr_ct2_compute_type_var.get() if backend == "ct2" else None,
-                        )
-                        installed_models = model_manager.list_installed(cache_dir)
-                        self.config_manager.set_asr_installed_models(installed_models)
-                        self.config_manager.save_config()
-                        _update_model_info(model_id)
-                        messagebox.showinfo("Model", "Download completed.")
-                    except DownloadCancelledError:
-                        messagebox.showinfo("Model", "Download canceled.")
-                    except OSError:
-                        messagebox.showerror(
-                            "Model",
-                        )
-                    except Exception as e:
-                        messagebox.showerror("Model", f"Download failed: {e}")
-
-                def _reload_model():
-                    handler = getattr(self.core_instance_ref, "transcription_handler", None)
-                    if handler:
-                        handler.reload_asr()
-
-
                 install_button = ctk.CTkButton(
-                    asr_frame, text="Install/Update", command=_install_model
+                    asr_frame, text="Install/Update", command=self._install_selected_model
                 )
                 install_button.pack(pady=5)
+                self._set_settings_var("install_button", install_button)
                 reload_button = ctk.CTkButton(
-                    asr_frame, text="Reload Model", command=_reload_model
+                    asr_frame, text="Reload Model", command=self._reload_current_model
                 )
                 reload_button.pack(pady=5)
 
-                _update_model_info(asr_model_id_var.get())
-                _update_install_button_state()
-                _on_backend_change(asr_backend_var.get())
-
-                update_text_correction_fields()
+                self._on_service_menu_change(text_correction_service_label_var.get())
+                self._update_text_correction_fields()
+                self._update_chunk_length_state()
+                initial_model_display = asr_model_display_var.get()
+                if initial_model_display:
+                    self._on_model_change(initial_model_display)
+                else:
+                    self._update_model_info(asr_model_id_var.get())
+                    self._update_install_button_state()
+                    self._on_backend_change(asr_backend_var.get())
 
             except Exception as e:
                 logging.error(f"Failed to create Toplevel for settings: {e}", exc_info=True)
@@ -1295,14 +1655,14 @@ class UIManager:
                     button_frame = ctk.CTkFrame(settings_win)  # Move outside scrollable_frame to keep fixed
                     button_frame.pack(side="bottom", fill="x", padx=10, pady=(20, 10))
 
-                    apply_button = ctk.CTkButton(button_frame, text="Apply and Close", command=apply_settings)
+                    apply_button = ctk.CTkButton(button_frame, text="Apply and Close", command=self._apply_settings_from_ui)
                     apply_button.pack(side="right", padx=5)
                     Tooltip(apply_button, "Save all settings and exit.")
                     close_button = ctk.CTkButton(button_frame, text="Cancel", command=self._close_settings_window, fg_color="gray50")
                     close_button.pack(side="right", padx=5)
                     Tooltip(close_button, "Discard changes and exit.")
 
-                    restore_button = ctk.CTkButton(button_frame, text="Restore Defaults", command=restore_defaults)
+                    restore_button = ctk.CTkButton(button_frame, text="Restore Defaults", command=self._restore_default_settings)
                     restore_button.pack(side="left", padx=5)
 
                     force_reregister_button = ctk.CTkButton(
@@ -1357,6 +1717,7 @@ class UIManager:
                 self.settings_window_instance.destroy()
                 self.settings_window_instance = None
             self.settings_thread_running = False
+            self._clear_settings_context()
 
     def create_dynamic_menu(self):
         # Logic moved from global, adjusted to use self.core_instance_ref


### PR DESCRIPTION
## Summary
- refactor the settings window to register configuration variables/widgets in the shared context and wire the UI callbacks to `UIManager` instance methods
- add helpers such as `_reset_asr_settings` and ensure the settings context is cleared when closing the window
- streamline ASR model handling by removing redundant aliases and skipping unnecessary config writes on initial load

## Testing
- python -m py_compile src/ui_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68cc6860c7108330a90de997ab62a95e