### PR TITLE
Improve model observability and headless tests

### DIFF
--- a/scripts/quick_bench_asr.py
+++ b/scripts/quick_bench_asr.py
@@ -2,11 +2,319 @@
 
 from __future__ import annotations
 
+import os
+import sys
 import time
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
 import numpy as np
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+try:  # pragma: no cover - apenas para ambientes de teste sem PortAudio
+    import sounddevice  # type: ignore  # noqa: F401
+except Exception:
+    class _DummyStream:
+        def __init__(self, *_, **__):
+            self.active = False
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def start(self):
+            self.active = True
+
+        def stop(self):
+            self.active = False
+
+        def close(self):
+            self.active = False
+
+    sys.modules["sounddevice"] = SimpleNamespace(
+        InputStream=_DummyStream,
+        OutputStream=_DummyStream,
+        sleep=lambda _ms: None,
+        PortAudioError=RuntimeError,
+        CallbackStop=Exception,
+    )
+
+try:  # pragma: no cover - ambientes de CI sem libsndfile
+    import soundfile  # type: ignore  # noqa: F401
+except Exception:
+    class _DummySoundFile:
+        def __init__(self, *_args, **_kwargs):
+            self.closed = False
+
+        def write(self, *_args, **_kwargs):
+            return None
+
+        def close(self):
+            self.closed = True
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+            return False
+
+    def _dummy_sf_write(filename, *_args, **_kwargs):
+        try:
+            Path(filename).touch()
+        except Exception:
+            pass
+
+    sys.modules["soundfile"] = SimpleNamespace(
+        SoundFile=_DummySoundFile,
+        write=_dummy_sf_write,
+    )
+
+try:  # pragma: no cover - ambientes de CI sem onnxruntime
+    import onnxruntime  # type: ignore  # noqa: F401
+except Exception:
+    class _DummyInferenceSession:
+        def __init__(self, *_args, **_kwargs):
+            self._state = np.zeros((2, 1, 128), dtype=np.float32)
+
+        def run(self, _outputs=None, inputs=None):
+            if isinstance(inputs, dict) and "state" in inputs:
+                self._state = inputs["state"]
+            prob = np.array([[[0.0]]], dtype=np.float32)
+            return [prob, self._state]
+
+    sys.modules["onnxruntime"] = SimpleNamespace(
+        InferenceSession=_DummyInferenceSession,
+        get_available_providers=lambda: ["CPUExecutionProvider"],
+    )
+
+try:  # pragma: no cover - ambientes headless sem customtkinter
+    import customtkinter  # type: ignore  # noqa: F401
+except Exception:
+    class _DummyVar:
+        def __init__(self, value=None):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, value):
+            self._value = value
+
+    class _DummyWidget:
+        def __init__(self, *args, **kwargs):
+            self._value = kwargs.get("value")
+            self._text = ""
+
+        # Tk-like geometry methods -------------------------------------------------
+        def pack(self, *args, **kwargs):
+            return None
+
+        def grid(self, *args, **kwargs):
+            return None
+
+        def place(self, *args, **kwargs):
+            return None
+
+        # Widget lifecycle --------------------------------------------------------
+        def destroy(self):
+            return None
+
+        def withdraw(self):
+            return None
+
+        def lift(self):
+            return None
+
+        def focus_force(self):
+            return None
+
+        def update_idletasks(self):
+            return None
+
+        def winfo_exists(self):
+            return False
+
+        def winfo_screenwidth(self):
+            return 1920
+
+        def winfo_screenheight(self):
+            return 1080
+
+        # Configuration -----------------------------------------------------------
+        def configure(self, *args, **kwargs):
+            if "state" in kwargs:
+                self._state = kwargs["state"]
+            return None
+
+        config = configure
+
+        def set(self, value):
+            self._value = value
+
+        def get(self, *args, **kwargs):
+            if self._text:
+                return self._text
+            return getattr(self, "_value", None)
+
+        def insert(self, *args, **kwargs):
+            if args:
+                self._text += str(args[-1])
+            return None
+
+        def delete(self, *args, **kwargs):
+            self._text = ""
+            return None
+
+        def see(self, *args, **kwargs):
+            return None
+
+        def title(self, *args, **kwargs):
+            return None
+
+        def resizable(self, *args, **kwargs):
+            return None
+
+        def attributes(self, *args, **kwargs):
+            return None
+
+        def geometry(self, *args, **kwargs):
+            return None
+
+        def after(self, *args, **kwargs):
+            return None
+
+        def update_menu(self):
+            return None
+
+    class _DummyScrollableFrame(_DummyWidget):
+        def pack(self, *args, **kwargs):
+            return None
+
+    class _DummyOptionMenu(_DummyWidget):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._command = kwargs.get("command")
+
+        def configure(self, *args, **kwargs):
+            if "command" in kwargs:
+                self._command = kwargs["command"]
+            return super().configure(*args, **kwargs)
+
+        config = configure
+
+        def set(self, value):
+            super().set(value)
+            if callable(self._command):
+                self._command(value)
+
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTk=_DummyWidget,
+        CTkToplevel=_DummyWidget,
+        CTkFrame=_DummyWidget,
+        CTkLabel=_DummyWidget,
+        CTkButton=_DummyWidget,
+        CTkSwitch=_DummyWidget,
+        CTkTextbox=_DummyWidget,
+        CTkOptionMenu=_DummyOptionMenu,
+        CTkEntry=_DummyWidget,
+        CTkScrollableFrame=_DummyScrollableFrame,
+        CTkSlider=_DummyWidget,
+        BooleanVar=_DummyVar,
+        StringVar=_DummyVar,
+        DoubleVar=_DummyVar,
+        IntVar=_DummyVar,
+        set_appearance_mode=lambda *args, **kwargs: None,
+        set_default_color_theme=lambda *args, **kwargs: None,
+        CTkFont=lambda *args, **kwargs: None,
+    )
+
+try:  # pragma: no cover - ambientes headless sem pystray
+    import pystray  # type: ignore  # noqa: F401
+except Exception:
+    class _DummyMenuItem:
+        def __init__(self, text, action=None, *, default=False, enabled=True, radio=False, checked=None):
+            self.text = text
+            self.action = action
+            self.default = default
+            self.enabled = enabled
+            self.radio = radio
+            self.checked = checked
+
+        def __call__(self, icon=None, item=None):  # pragma: no cover - compatibility helper
+            if callable(self.action):
+                return self.action(icon, item)
+            return None
+
+    class _DummyMenu(tuple):
+        SEPARATOR = object()
+
+        def __new__(cls, *items):
+            return super().__new__(cls, items)
+
+    class _DummyIcon:
+        def __init__(self, name, icon, title, menu=None):
+            self.name = name
+            self.icon = icon
+            self.title = title
+            self.menu = menu
+
+        def run_detached(self):
+            return None
+
+        def stop(self):
+            return None
+
+        def update_menu(self):
+            return None
+
+    sys.modules["pystray"] = SimpleNamespace(
+        Icon=_DummyIcon,
+        MenuItem=_DummyMenuItem,
+        Menu=_DummyMenu,
+    )
+
+try:  # pragma: no cover - ambientes headless sem Pillow
+    from PIL import Image as _PILImage  # type: ignore  # noqa: F401
+    from PIL import ImageDraw as _PILImageDraw  # type: ignore  # noqa: F401
+except Exception:
+    pil_module = ModuleType("PIL")
+
+    class _DummyImageModule(ModuleType):
+        def __init__(self):
+            super().__init__("PIL.Image")
+
+        @staticmethod
+        def new(mode, size, color):
+            return {"mode": mode, "size": size, "color": color}
+
+    class _DummyImageDrawModule(ModuleType):
+        def __init__(self):
+            super().__init__("PIL.ImageDraw")
+
+        class Draw:
+            def __init__(self, _image):
+                self._image = _image
+
+            def rectangle(self, *_args, **_kwargs):
+                return None
+
+    image_module = _DummyImageModule()
+    image_draw_module = _DummyImageDrawModule()
+
+    pil_module.Image = image_module
+    pil_module.ImageDraw = image_draw_module
+
+    sys.modules["PIL"] = pil_module
+    sys.modules["PIL.Image"] = image_module
+    sys.modules["PIL.ImageDraw"] = image_draw_module
 
 from src.config_manager import ConfigManager
 from src.transcription_handler import TranscriptionHandler
+import src.transcription_handler as transcription_handler_module
 
 
 def main() -> None:
@@ -32,6 +340,97 @@ def main() -> None:
         times.append(time.perf_counter() - start)
     median = sorted(times)[len(times) // 2]
     print(f"median_time={median:.2f}s")
+
+
+# --- Tests ---------------------------------------------------------------
+
+
+def _make_handler_for_tests(chunk: float = 30.0, gpu_index: int = 0) -> TranscriptionHandler:
+    handler = TranscriptionHandler.__new__(TranscriptionHandler)
+    handler.chunk_length_sec = chunk
+    handler.gpu_index = gpu_index
+    return handler
+
+
+def _mock_cuda_env(
+    monkeypatch,
+    *,
+    available: bool,
+    free_gb: float = 0.0,
+    total_gb: float = 16.0,
+    raise_error: bool = False,
+) -> None:
+    """Configure torch.cuda mocks for TranscriptionHandler tests."""
+
+    fake_cuda = SimpleNamespace()
+    fake_cuda.is_available = lambda: available
+
+    if raise_error:
+        def _fail(_device):
+            raise RuntimeError("mock mem_get_info failure")
+
+        fake_cuda.mem_get_info = _fail
+    else:
+        def _mem_info(_device):
+            return (int(free_gb * (1024 ** 3)), int(total_gb * (1024 ** 3)))
+
+        fake_cuda.mem_get_info = _mem_info
+
+    monkeypatch.setattr(transcription_handler_module.torch, "cuda", fake_cuda)
+    monkeypatch.setattr(transcription_handler_module.torch, "device", lambda spec: spec)
+
+
+def test_effective_chunk_length_cpu(monkeypatch):
+    handler = _make_handler_for_tests(chunk=37.0, gpu_index=-1)
+    _mock_cuda_env(monkeypatch, available=False)
+    assert handler._effective_chunk_length() == 37.0
+
+
+def test_effective_chunk_length_gpu_buckets(monkeypatch):
+    handler = _make_handler_for_tests(chunk=30.0, gpu_index=0)
+    scenarios = [
+        (12.5, 60.0),
+        (8.2, 45.0),
+        (6.4, 30.0),
+        (4.3, 20.0),
+        (3.0, 15.0),
+    ]
+    for free_gb, expected in scenarios:
+        _mock_cuda_env(monkeypatch, available=True, free_gb=free_gb)
+        assert handler._effective_chunk_length() == expected
+
+
+def test_effective_chunk_length_meminfo_failure(monkeypatch):
+    handler = _make_handler_for_tests(chunk=42.0, gpu_index=0)
+    _mock_cuda_env(monkeypatch, available=True, raise_error=True)
+    assert handler._effective_chunk_length() == 42.0
+
+
+def test_apply_settings_payload_headless():
+    from src.ui_manager import UIManager
+
+    class CoreStub:
+        def __init__(self):
+            self.received = None
+
+        def apply_settings_from_external(self, **kwargs):
+            self.received = kwargs
+
+    core_stub = CoreStub()
+    config_stub = SimpleNamespace()
+    root_stub = SimpleNamespace()
+    ui = UIManager(root_stub, config_stub, core_stub)
+
+    payload = {
+        "new_key": "f5",
+        "new_mode": "press",
+        "new_chunk_length_sec": 48.0,
+        "new_enable_torch_compile": True,
+    }
+
+    ui.apply_settings_payload(payload)
+
+    assert core_stub.received == payload
 
 
 if __name__ == "__main__":

--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+import time
 from pathlib import Path
 from typing import Dict, List
 
 from huggingface_hub import HfApi, scan_cache_dir, snapshot_download
+
+
+MODEL_LOGGER = logging.getLogger("whisper_recorder.model")
 
 
 class DownloadCancelledError(Exception):
@@ -51,6 +56,7 @@ def list_installed(cache_dir: str | Path) -> List[Dict[str, str]]:
     seen = set()
 
     cache_dir = Path(cache_dir)
+    MODEL_LOGGER.debug("Listing curated models installed under %s", cache_dir)
     if cache_dir.is_dir():
         for backend_dir in cache_dir.iterdir():
             if not backend_dir.is_dir():
@@ -115,6 +121,12 @@ def get_model_download_size(model_id: str) -> tuple[int, int]:
     for sibling in getattr(info, "siblings", []):
         total += sibling.size or 0
         files += 1
+    MODEL_LOGGER.debug(
+        "Computed download size for model %s: %.2f GB across %s files",
+        model_id,
+        total / (1024 ** 3) if total else 0.0,
+        files,
+    )
     return total, files
 
 
@@ -157,10 +169,24 @@ def ensure_download(
     cache_dir = Path(cache_dir)
     local_dir = cache_dir / backend / model_id
     if local_dir.is_dir() and any(local_dir.iterdir()):
+        MODEL_LOGGER.info(
+            "[METRIC] stage=model_download status=skip model=%s backend=%s path=%s",
+            model_id,
+            backend,
+            local_dir,
+        )
         return str(local_dir)
 
     local_dir.parent.mkdir(parents=True, exist_ok=True)
 
+    start_time = time.perf_counter()
+    MODEL_LOGGER.info(
+        "Starting model download: model=%s backend=%s quant=%s target=%s",
+        model_id,
+        backend,
+        quant or "default",
+        local_dir,
+    )
     try:
         if backend == "transformers":
             snapshot_download(repo_id=model_id, local_dir=str(local_dir), allow_patterns=None)
@@ -176,6 +202,36 @@ def ensure_download(
         else:
             raise ValueError(f"Unknown backend: {backend}")
     except KeyboardInterrupt as exc:
+        duration_ms = (time.perf_counter() - start_time) * 1000.0
+        MODEL_LOGGER.info(
+            "[METRIC] stage=model_download status=cancelled model=%s backend=%s duration_ms=%.2f",
+            model_id,
+            backend,
+            duration_ms,
+        )
         raise DownloadCancelledError("Model download cancelled by user.") from exc
+    except Exception:
+        duration_ms = (time.perf_counter() - start_time) * 1000.0
+        MODEL_LOGGER.exception(
+            "Model download failed: model=%s backend=%s target=%s",
+            model_id,
+            backend,
+            local_dir,
+        )
+        MODEL_LOGGER.info(
+            "[METRIC] stage=model_download status=error model=%s backend=%s duration_ms=%.2f",
+            model_id,
+            backend,
+            duration_ms,
+        )
+        raise
 
+    duration_ms = (time.perf_counter() - start_time) * 1000.0
+    MODEL_LOGGER.info(
+        "[METRIC] stage=model_download status=success model=%s backend=%s duration_ms=%.2f path=%s",
+        model_id,
+        backend,
+        duration_ms,
+        local_dir,
+    )
     return str(local_dir)

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -168,6 +168,17 @@ class UIManager:
             messagebox.showerror("Valor inválido", f"Valor inválido para {field_name}.", parent=parent)
             return None
 
+    def apply_settings_payload(self, payload: dict) -> None:
+        """Apply settings in headless mode or via unit tests."""
+
+        if not isinstance(payload, dict):  # Salvaguarda para chamadas incorretas
+            raise TypeError("payload must be a dict of keyword arguments")
+        if not self.core_instance_ref:
+            raise RuntimeError("core_instance_ref is not configured")
+
+        logging.info("UIManager: forwarding settings payload to AppCore (%d keys).", len(payload))
+        self.core_instance_ref.apply_settings_from_external(**payload)
+
     def _recording_tooltip_updater(self):
         """Atualiza a tooltip com a duração da gravação a cada segundo."""
         while not self.stop_recording_timer_event.is_set():
@@ -530,51 +541,53 @@ class UIManager:
                         return
 
                     # Call AppCore method to apply settings
-                    self.core_instance_ref.apply_settings_from_external(
-                        new_key=key_to_apply,
-                        new_mode=mode_to_apply,
-                        new_auto_paste=auto_paste_to_apply,
-                        new_sound_enabled=sound_enabled_to_apply,
-                        new_sound_frequency=sound_freq_to_apply,
-                        new_sound_duration=sound_duration_to_apply,
-                        new_sound_volume=sound_volume_to_apply,
-                        new_agent_key=agent_key_to_apply,
-                        new_text_correction_enabled=text_correction_enabled_to_apply,
-                        new_text_correction_service=text_correction_service_to_apply,
-                        new_openrouter_api_key=openrouter_api_key_to_apply,
-                        new_openrouter_model=openrouter_model_to_apply,
-                        new_gemini_api_key=gemini_api_key_to_apply,
-                        new_gemini_model=gemini_model_to_apply,
-                        new_gemini_prompt=gemini_prompt_correction_to_apply,
-                        prompt_agentico=agentico_prompt_to_apply,
-                        new_agent_model=model_to_apply,
-                        new_gemini_model_options=new_models_list,
-                        new_batch_size=batch_size_to_apply,
-                        new_gpu_index=gpu_index_to_apply,
-                        new_hotkey_stability_service_enabled=hotkey_stability_service_enabled_to_apply, # Nova configuração unificada
-                        new_min_transcription_duration=min_transcription_duration_to_apply,
-                        new_min_record_duration=min_record_duration_to_apply,
-                        new_save_temp_recordings=save_temp_recordings_to_apply,
-                        new_record_storage_mode=record_storage_mode_var.get(),
-                        new_record_to_memory=(record_storage_mode_var.get() == "memory"),
-                        new_max_memory_seconds_mode=max_memory_seconds_mode_to_apply,
-                        new_max_memory_seconds=max_memory_seconds_to_apply,
-                        new_use_vad=use_vad_to_apply,
-                        new_vad_threshold=vad_threshold_to_apply,
-                        new_vad_silence_duration=vad_silence_duration_to_apply,
-                        new_display_transcripts_in_terminal=display_transcripts_to_apply,
-                        new_launch_at_startup=launch_at_startup_var.get(),
-                        # New chunk settings
-                        new_chunk_length_mode=chunk_length_mode_var.get(),
-                        new_chunk_length_sec=float(chunk_length_sec_var.get()),
-                        # New: torch compile setting
-                        new_enable_torch_compile=bool(enable_torch_compile_var.get()),
-                        new_asr_backend=asr_backend_to_apply,
-                        new_asr_model_id=asr_model_id_to_apply,
-                        new_asr_compute_device=asr_compute_device_to_apply,
-                        new_asr_dtype=asr_dtype_to_apply,
-                        new_asr_ct2_compute_type=asr_ct2_compute_type_to_apply,
-                        new_asr_cache_dir=asr_cache_dir_to_apply
+                    self.apply_settings_payload(
+                        {
+                            "new_key": key_to_apply,
+                            "new_mode": mode_to_apply,
+                            "new_auto_paste": auto_paste_to_apply,
+                            "new_sound_enabled": sound_enabled_to_apply,
+                            "new_sound_frequency": sound_freq_to_apply,
+                            "new_sound_duration": sound_duration_to_apply,
+                            "new_sound_volume": sound_volume_to_apply,
+                            "new_agent_key": agent_key_to_apply,
+                            "new_text_correction_enabled": text_correction_enabled_to_apply,
+                            "new_text_correction_service": text_correction_service_to_apply,
+                            "new_openrouter_api_key": openrouter_api_key_to_apply,
+                            "new_openrouter_model": openrouter_model_to_apply,
+                            "new_gemini_api_key": gemini_api_key_to_apply,
+                            "new_gemini_model": gemini_model_to_apply,
+                            "new_gemini_prompt": gemini_prompt_correction_to_apply,
+                            "prompt_agentico": agentico_prompt_to_apply,
+                            "new_agent_model": model_to_apply,
+                            "new_gemini_model_options": new_models_list,
+                            "new_batch_size": batch_size_to_apply,
+                            "new_gpu_index": gpu_index_to_apply,
+                            "new_hotkey_stability_service_enabled": hotkey_stability_service_enabled_to_apply, # Nova configuração unificada
+                            "new_min_transcription_duration": min_transcription_duration_to_apply,
+                            "new_min_record_duration": min_record_duration_to_apply,
+                            "new_save_temp_recordings": save_temp_recordings_to_apply,
+                            "new_record_storage_mode": record_storage_mode_var.get(),
+                            "new_record_to_memory": (record_storage_mode_var.get() == "memory"),
+                            "new_max_memory_seconds_mode": max_memory_seconds_mode_to_apply,
+                            "new_max_memory_seconds": max_memory_seconds_to_apply,
+                            "new_use_vad": use_vad_to_apply,
+                            "new_vad_threshold": vad_threshold_to_apply,
+                            "new_vad_silence_duration": vad_silence_duration_to_apply,
+                            "new_display_transcripts_in_terminal": display_transcripts_to_apply,
+                            "new_launch_at_startup": launch_at_startup_var.get(),
+                            # New chunk settings
+                            "new_chunk_length_mode": chunk_length_mode_var.get(),
+                            "new_chunk_length_sec": float(chunk_length_sec_var.get()),
+                            # New: torch compile setting
+                            "new_enable_torch_compile": bool(enable_torch_compile_var.get()),
+                            "new_asr_backend": asr_backend_to_apply,
+                            "new_asr_model_id": asr_model_id_to_apply,
+                            "new_asr_compute_device": asr_compute_device_to_apply,
+                            "new_asr_dtype": asr_dtype_to_apply,
+                            "new_asr_ct2_compute_type": asr_ct2_compute_type_to_apply,
+                            "new_asr_cache_dir": asr_cache_dir_to_apply,
+                        }
                     )
                     self._close_settings_window() # Call class method
 


### PR DESCRIPTION
## Summary
- add the dedicated `whisper_recorder.model` logger throughout model management routines
- instrument model download timing metrics and share the settings payload plumbing with the UI manager
- extend the quick benchmark harness with dependency stubs plus GPU chunk heuristics and headless apply_settings tests

## Testing
- pytest scripts/quick_bench_asr.py

------
https://chatgpt.com/codex/tasks/task_e_68cc6884fd608330873c221cd895e6c8