### PR TITLE
Fix missing typing imports in UI manager

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import pystray
 from PIL import Image, ImageDraw
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional
 
 # Importar constantes de configuração
 from .config_manager import (


### PR DESCRIPTION
## Summary
- import TYPE_CHECKING along with Dict and Optional in `ui_manager`
- ensure runtime availability of typing hints used throughout the module

## Testing
- python -m compileall src/ui_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68cd760995708330b3581221934f2fc4