### PR TITLE
Fix startup ASR handling and legacy state compatibility

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -301,7 +301,7 @@ class ConfigManager:
 
         cfg["asr_curated_catalog"] = list_catalog()
         try:
-            cfg["asr_installed_models"] = list_installed(ASR_CACHE_DIR)
+            cfg["asr_installed_models"] = list_installed(asr_cache_dir)
         except OSError:
             messagebox.showerror(
                 "Configuração",

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -120,13 +120,11 @@ class TranscriptionHandler:
         self.chunk_length_mode = self.config_manager.get("chunk_length_mode", "manual")
         self.enable_torch_compile = bool(self.config_manager.get("enable_torch_compile", False))
         # Configurações de ASR
-        # Inicializar atributos internos antes de usar os setters
-        self._asr_backend_name = None
-        self._asr_model_id = None
+        # Inicializar atributos internos sem acionar recarga imediata do backend
+        self._asr_backend_name = self.config_manager.get(ASR_BACKEND_CONFIG_KEY)
+        self._asr_model_id = self.config_manager.get(ASR_MODEL_ID_CONFIG_KEY)
         self._asr_backend = None
 
-        self.asr_backend = self.config_manager.get(ASR_BACKEND_CONFIG_KEY)
-        self.asr_model_id = self.config_manager.get(ASR_MODEL_ID_CONFIG_KEY)
         self.asr_compute_device = self.config_manager.get(ASR_COMPUTE_DEVICE_CONFIG_KEY)
         self.asr_dtype = self.config_manager.get(ASR_DTYPE_CONFIG_KEY)
         self.asr_ct2_compute_type = self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY)


### PR DESCRIPTION
## Summary
- ensure the configuration loader queries installed ASR models using the resolved cache directory instead of an undefined constant
- avoid eager ASR backend reloads during `TranscriptionHandler` initialization so that models are only loaded after explicit requests
- extend `AppCore._set_state` with legacy string handling and default details to keep existing callers functional while emitting structured state notifications

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cd78be7cf88330959107c9d5b66f5d