### PR TITLE
Fix Flake8 issues in core modules

### DIFF
--- a/scripts/quick_bench_asr.py
+++ b/scripts/quick_bench_asr.py
@@ -312,12 +312,28 @@ except Exception:
     sys.modules["PIL.Image"] = image_module
     sys.modules["PIL.ImageDraw"] = image_draw_module
 
-from src.config_manager import ConfigManager
-from src.transcription_handler import TranscriptionHandler
-import src.transcription_handler as transcription_handler_module
+
+def _load_config_manager():
+    from src.config_manager import ConfigManager
+
+    return ConfigManager
+
+
+def _load_transcription_handler():
+    from src.transcription_handler import TranscriptionHandler
+
+    return TranscriptionHandler
+
+
+def _load_transcription_handler_module():
+    import src.transcription_handler as transcription_handler_module
+
+    return transcription_handler_module
 
 
 def main() -> None:
+    ConfigManager = _load_config_manager()
+    TranscriptionHandler = _load_transcription_handler()
     cfg = ConfigManager()
 
     handler = TranscriptionHandler(
@@ -345,7 +361,8 @@ def main() -> None:
 # --- Tests ---------------------------------------------------------------
 
 
-def _make_handler_for_tests(chunk: float = 30.0, gpu_index: int = 0) -> TranscriptionHandler:
+def _make_handler_for_tests(chunk: float = 30.0, gpu_index: int = 0):
+    TranscriptionHandler = _load_transcription_handler()
     handler = TranscriptionHandler.__new__(TranscriptionHandler)
     handler.chunk_length_sec = chunk
     handler.gpu_index = gpu_index
@@ -376,6 +393,7 @@ def _mock_cuda_env(
 
         fake_cuda.mem_get_info = _mem_info
 
+    transcription_handler_module = _load_transcription_handler_module()
     monkeypatch.setattr(transcription_handler_module.torch, "cuda", fake_cuda)
     monkeypatch.setattr(transcription_handler_module.torch, "device", lambda spec: spec)
 

--- a/src/gemini_api.py
+++ b/src/gemini_api.py
@@ -13,8 +13,10 @@ try:
 except ImportError:
     GEMINI_API_AVAILABLE = False
     # Crie classes dummy para evitar erros de tipo se a biblioteca não estiver instalada
+
     class BrokenResponseError(Exception):
         pass
+
 
     class IncompleteIterationError(Exception):
         pass

--- a/src/main.py
+++ b/src/main.py
@@ -1,18 +1,15 @@
-import os  # Added for path handling
+import atexit
+import importlib
+import logging
+import os
 import sys
+import tkinter as tk
 
 # Add project root to path
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 PROJECT_ROOT = os.path.dirname(CURRENT_DIR)
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
-
-import tkinter as tk  # noqa: E402
-import logging  # noqa: E402
-import atexit  # noqa: E402
-import importlib  # noqa: E402
-
-from src.logging_utils import setup_logging  # noqa: E402
 
 
 ENV_DEFAULTS = {
@@ -112,6 +109,8 @@ def patch_tk_variable_cleanup() -> None:
 
 
 def main() -> None:
+    from src.logging_utils import setup_logging
+
     setup_logging()
     configure_environment()
     ensure_display_available()

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -650,8 +650,7 @@ class TranscriptionHandler:
 
         except Exception as exc:
             logging.error(f"Erro ao corrigir texto: {exc}")
-            if future \
-                    and not future.done():
+            if future and not future.done():
                 future.cancel()
         finally:
             self.correction_in_progress = False
@@ -1529,8 +1528,10 @@ class TranscriptionHandler:
                         )
                 except Exception as e:
                     logging.error(f"Erro ao processar o comando do agente: {e}", exc_info=True)
-                    if not self.is_state_transcribing_fn \
-                            or self.is_state_transcribing_fn():
+                    if (
+                        not self.is_state_transcribing_fn
+                        or self.is_state_transcribing_fn()
+                    ):
                         self.on_agent_result_callback(text_result)  # Falha, retorna o texto original
                     else:
                         logging.warning(


### PR DESCRIPTION
## Summary
- ensure Gemini API fallbacks have proper spacing and file termination for linting
- normalize main entrypoint imports by loading setup helper inside main
- clean transcription and UI handlers to remove redundant line continuations and undefined references
- lazily import runtime-heavy modules in the quick ASR benchmark so stub injection still happens before loading project code

## Testing
- flake8 src/core.py src/transcription_handler.py src/gemini_api.py src/audio_handler.py src/main.py src/model_manager.py src/ui_manager.py src/utils/memory.py
- flake8


------
https://chatgpt.com/codex/tasks/task_e_68d2caed4a9c8330a63b7e57797c3cdd