### PR TITLE
Refine quick bench imports for lint

### DIFF
--- a/scripts/quick_bench_asr.py
+++ b/scripts/quick_bench_asr.py
@@ -7,6 +7,7 @@ import sys
 import time
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -312,9 +313,32 @@ except Exception:
     sys.modules["PIL.Image"] = image_module
     sys.modules["PIL.ImageDraw"] = image_draw_module
 
-from src.config_manager import ConfigManager
-from src.transcription_handler import TranscriptionHandler
-import src.transcription_handler as transcription_handler_module
+if TYPE_CHECKING:
+    from src.config_manager import ConfigManager as ConfigManagerType
+    from src.transcription_handler import (
+        TranscriptionHandler as TranscriptionHandlerType,
+    )
+    import src.transcription_handler as transcription_handler_module_type
+
+
+def _load_runtime_dependencies():
+    from src.config_manager import ConfigManager as _ConfigManager
+    from src.transcription_handler import (
+        TranscriptionHandler as _TranscriptionHandler,
+    )
+    import src.transcription_handler as handler_module
+
+    return _ConfigManager, _TranscriptionHandler, handler_module
+
+
+ConfigManager: ConfigManagerType
+TranscriptionHandler: TranscriptionHandlerType
+transcription_handler_module: transcription_handler_module_type
+(
+    ConfigManager,
+    TranscriptionHandler,
+    transcription_handler_module,
+) = _load_runtime_dependencies()
 
 
 def main() -> None:

--- a/src/gemini_api.py
+++ b/src/gemini_api.py
@@ -13,8 +13,10 @@ try:
 except ImportError:
     GEMINI_API_AVAILABLE = False
     # Crie classes dummy para evitar erros de tipo se a biblioteca não estiver instalada
+
     class BrokenResponseError(Exception):
         pass
+
 
     class IncompleteIterationError(Exception):
         pass

--- a/src/main.py
+++ b/src/main.py
@@ -1,18 +1,15 @@
-import os  # Added for path handling
+import atexit
+import importlib
+import logging
+import os
 import sys
+import tkinter as tk
 
 # Add project root to path
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 PROJECT_ROOT = os.path.dirname(CURRENT_DIR)
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
-
-import tkinter as tk  # noqa: E402
-import logging  # noqa: E402
-import atexit  # noqa: E402
-import importlib  # noqa: E402
-
-from src.logging_utils import setup_logging  # noqa: E402
 
 
 ENV_DEFAULTS = {
@@ -112,6 +109,8 @@ def patch_tk_variable_cleanup() -> None:
 
 
 def main() -> None:
+    from src.logging_utils import setup_logging
+
     setup_logging()
     configure_environment()
     ensure_display_available()

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -650,8 +650,7 @@ class TranscriptionHandler:
 
         except Exception as exc:
             logging.error(f"Erro ao corrigir texto: {exc}")
-            if future \
-                    and not future.done():
+            if future and not future.done():
                 future.cancel()
         finally:
             self.correction_in_progress = False
@@ -1529,8 +1528,10 @@ class TranscriptionHandler:
                         )
                 except Exception as e:
                     logging.error(f"Erro ao processar o comando do agente: {e}", exc_info=True)
-                    if not self.is_state_transcribing_fn \
-                            or self.is_state_transcribing_fn():
+                    if (
+                        not self.is_state_transcribing_fn
+                        or self.is_state_transcribing_fn()
+                    ):
                         self.on_agent_result_callback(text_result)  # Falha, retorna o texto original
                     else:
                         logging.warning(


### PR DESCRIPTION
## Summary
- load quick bench ASR runtime dependencies through a helper after dummy backends are registered
- gate type-only imports behind TYPE_CHECKING to avoid runtime churn while satisfying static analyzers

## Testing
- flake8


------
https://chatgpt.com/codex/tasks/task_e_68d2caed4a9c8330a63b7e57797c3cdd