### PR TITLE
Improve API resilience and logging

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -5,7 +5,7 @@ import copy
 import hashlib
 import time
 from pathlib import Path
-from typing import List
+from typing import Any, List
 
 import requests
 import tkinter.messagebox as messagebox
@@ -49,6 +49,8 @@ DEFAULT_CONFIG = {
     "gemini_api_key": "",
     "gemini_model": "gemini-2.5-flash-lite",
     "gemini_agent_model": "gemini-2.5-flash-lite",
+    "openrouter_timeout": 30,
+    "gemini_timeout": 120,
     "ai_provider": "gemini",
     "openrouter_prompt": "",
     "prompt_agentico": (
@@ -160,10 +162,13 @@ SERVICE_OPENROUTER = "openrouter"
 SERVICE_GEMINI = "gemini"
 OPENROUTER_API_KEY_CONFIG_KEY = "openrouter_api_key"
 OPENROUTER_MODEL_CONFIG_KEY = "openrouter_model"
+OPENROUTER_TIMEOUT_CONFIG_KEY = "openrouter_timeout"
 GEMINI_API_KEY_CONFIG_KEY = "gemini_api_key"
 GEMINI_MODEL_CONFIG_KEY = "gemini_model"
 GEMINI_AGENT_MODEL_CONFIG_KEY = "gemini_agent_model"
 GEMINI_MODEL_OPTIONS_CONFIG_KEY = "gemini_model_options"
+# Novas constantes de timeout de APIs externas
+GEMINI_TIMEOUT_CONFIG_KEY = "gemini_timeout"
 # Novas constantes para otimizações de desempenho
 CHUNK_LENGTH_MODE_CONFIG_KEY = "chunk_length_mode"
 ENABLE_TORCH_COMPILE_CONFIG_KEY = "enable_torch_compile"
@@ -213,6 +218,7 @@ class ConfigManager:
         self.config = {}
         self._config_hash = None
         self._secrets_hash = None
+        self._invalid_timeout_cache: dict[str, Any] = {}
         self.load_config()
         url = self.config.get(ASR_CURATED_CATALOG_URL_CONFIG_KEY, "")
         if url:
@@ -739,6 +745,29 @@ class ConfigManager:
         if key == ASR_BACKEND_CONFIG_KEY:
             value = _normalize_asr_backend(value)
         return value
+
+    def get_timeout(self, key: str, default: float | int) -> float:
+        """Retorna um timeout positivo em segundos para a chave informada."""
+        value = self.get(key, default)
+        try:
+            timeout_value = float(value)
+            if timeout_value <= 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            cached_value = self._invalid_timeout_cache.get(key)
+            if value != cached_value:
+                logging.warning(
+                    "Invalid timeout '%s' for key '%s'; using default %.2f seconds.",
+                    value,
+                    key,
+                    float(default),
+                )
+                self._invalid_timeout_cache[key] = value
+            return float(default)
+        else:
+            if key in self._invalid_timeout_cache:
+                self._invalid_timeout_cache.pop(key, None)
+            return timeout_value
 
     def set(self, key, value):
         if key == ASR_BACKEND_CONFIG_KEY:

--- a/src/core.py
+++ b/src/core.py
@@ -43,6 +43,7 @@ from .config_manager import (
     ASR_DTYPE_CONFIG_KEY,
     ASR_CT2_CPU_THREADS_CONFIG_KEY,
     ASR_CACHE_DIR_CONFIG_KEY,
+    OPENROUTER_TIMEOUT_CONFIG_KEY,
 )
 from .audio_handler import AudioHandler, AUDIO_SAMPLE_RATE # AUDIO_SAMPLE_RATE ainda é usado em _handle_transcription_result
 from .transcription_handler import TranscriptionHandler
@@ -1811,9 +1812,14 @@ class AppCore:
             if self.transcription_handler.gemini_client:
                 self.transcription_handler.gemini_client.reinitialize_client()
             if self.transcription_handler.openrouter_client:
+                openrouter_timeout = self.config_manager.get_timeout(
+                    OPENROUTER_TIMEOUT_CONFIG_KEY,
+                    self.transcription_handler.openrouter_client.request_timeout,
+                )
                 self.transcription_handler.openrouter_client.reinitialize_client(
                     api_key=self.config_manager.get("openrouter_api_key"),
                     model_id=self.config_manager.get("openrouter_model"),
+                    request_timeout=openrouter_timeout,
                 )
 
             hotkey_related_keys = {"record_key", "record_mode", "agent_key"}
@@ -1918,9 +1924,14 @@ class AppCore:
             if self.transcription_handler.gemini_client:
                 self.transcription_handler.gemini_client.reinitialize_client()
             if self.transcription_handler.openrouter_client:
+                openrouter_timeout = self.config_manager.get_timeout(
+                    OPENROUTER_TIMEOUT_CONFIG_KEY,
+                    self.transcription_handler.openrouter_client.request_timeout,
+                )
                 self.transcription_handler.openrouter_client.reinitialize_client(
                     api_key=self.config_manager.get("openrouter_api_key"),
-                    model_id=self.config_manager.get("openrouter_model")
+                    model_id=self.config_manager.get("openrouter_model"),
+                    request_timeout=openrouter_timeout,
                 )
             logging.info(f"Clientes API re-inicializados via update_setting para '{key}'.")
 

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -45,6 +45,7 @@ from .config_manager import (
     SERVICE_GEMINI,
     OPENROUTER_API_KEY_CONFIG_KEY,
     OPENROUTER_MODEL_CONFIG_KEY,
+    OPENROUTER_TIMEOUT_CONFIG_KEY,
     GEMINI_API_KEY_CONFIG_KEY,
     GEMINI_AGENT_PROMPT_CONFIG_KEY,
     OPENROUTER_AGENT_PROMPT_CONFIG_KEY,
@@ -198,7 +199,15 @@ class TranscriptionHandler:
         self.openrouter_api = None
         if self.text_correction_enabled and self.text_correction_service == SERVICE_OPENROUTER and self.openrouter_api_key and OpenRouterAPI:
             try:
-                self.openrouter_client = OpenRouterAPI(api_key=self.openrouter_api_key, model_id=self.openrouter_model)
+                openrouter_timeout = self.config_manager.get_timeout(
+                    OPENROUTER_TIMEOUT_CONFIG_KEY,
+                    OpenRouterAPI.DEFAULT_TIMEOUT,
+                )
+                self.openrouter_client = OpenRouterAPI(
+                    api_key=self.openrouter_api_key,
+                    model_id=self.openrouter_model,
+                    request_timeout=openrouter_timeout,
+                )
                 self.openrouter_api = self.openrouter_client
                 logging.info("OpenRouter API client initialized.")
             except Exception as e:


### PR DESCRIPTION
## Summary
- add configurable timeout settings and helper accessors in the configuration manager
- harden Gemini requests with configurable deadlines, richer logging, and clearer error handling
- refactor OpenRouter client to log payloads/responses, reuse retry logic, and honor configurable request timeouts across the app

## Testing
- python -m compileall src


------
https://chatgpt.com/codex/tasks/task_e_68d30715978c8330ab7252323736bea6