### PR TITLE
Fix state initialization and lint regressions

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -80,6 +80,8 @@ class AppCore:
 
         # --- Módulos ---
         self.config_manager = ConfigManager()
+        self.state_manager = sm.StateManager(sm.STATE_LOADING_MODEL, main_tk_root)
+        self._ui_manager = None  # Será setado externamente pelo main.py
         self._pending_tray_tooltips: list[str] = []
 
         self.model_manager = model_manager_module
@@ -121,9 +123,6 @@ class AppCore:
             is_state_transcribing_fn=self.is_state_transcribing,
         )
         self.transcription_handler.core_instance_ref = self  # Expõe referência do núcleo ao handler
-
-        self.state_manager = sm.StateManager(sm.STATE_LOADING_MODEL, main_tk_root)
-        self._ui_manager = None # Será setado externamente pelo main.py
         # --- Estado da Aplicação ---
         self.shutting_down = False
         self.full_transcription = "" # Acumula transcrição completa

--- a/src/openrouter_api.py
+++ b/src/openrouter_api.py
@@ -14,6 +14,7 @@ class OpenRouterAPI:
     """
 
     DEFAULT_TIMEOUT = 30.0
+
     def __init__(
         self,
         api_key: str,

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -47,8 +47,6 @@ from .config_manager import (
     OPENROUTER_MODEL_CONFIG_KEY,
     OPENROUTER_TIMEOUT_CONFIG_KEY,
     GEMINI_API_KEY_CONFIG_KEY,
-    GEMINI_AGENT_PROMPT_CONFIG_KEY,
-    OPENROUTER_AGENT_PROMPT_CONFIG_KEY,
     GEMINI_PROMPT_CONFIG_KEY,
     OPENROUTER_PROMPT_CONFIG_KEY,
     MIN_TRANSCRIPTION_DURATION_CONFIG_KEY,
@@ -1595,6 +1593,7 @@ class TranscriptionHandler:
             logging.debug(
                 "Cache da GPU preservado para transcrições consecutivas."
             )
+
     def _effective_chunk_length(self) -> float:
         """
         Heurística simples para chunk_length_sec quando em modo 'auto'.

--- a/tests/test_vad_pipeline.py
+++ b/tests/test_vad_pipeline.py
@@ -1,12 +1,14 @@
-import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
+import sys
 import unittest
 
 import numpy as np
 
-from src.vad_manager import VADManager
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.vad_manager import VADManager  # noqa: E402
 
 
 class TestVADPipeline(unittest.TestCase):


### PR DESCRIPTION
## Summary
- instantiate the StateManager before any AppCore collaborators consume it
- address lint failures by removing unused imports and adjusting OpenRouter formatting
- update the VAD pipeline test bootstrap to keep flake8 happy while preserving path setup

## Testing
- flake8 src tests
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3d80eac4c8330a5df8a8c0f694186