### PR TITLE
Restore original agent flow and handle empty responses safely

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -870,19 +870,20 @@ class AppCore:
         self.full_transcription = ""  # Reset para a próxima gravação
         self._delete_temp_audio_file()
 
-    def _handle_agent_result_final(self, agent_response_text: str):
+    def _handle_agent_result_final(self, agent_response_text: str | None):
         """
         Lida com o resultado final do modo agente (copia, cola e reseta o estado).
         Esta função é chamada pelo TranscriptionHandler após a API Gemini ser consultada.
         """
+        normalized_response = agent_response_text or ""
         try:
-            if not agent_response_text:
+            if not normalized_response:
                 logging.warning("Comando do agente retornou uma resposta vazia.")
                 self._log_status("Comando do agente sem resposta.", error=True)
                 return
 
             if pyperclip:
-                pyperclip.copy(agent_response_text)
+                pyperclip.copy(normalized_response)
                 logging.info("Agent response copied to clipboard.")
 
             if self.config_manager.get("agent_auto_paste", True): # Usa agent_auto_paste
@@ -895,7 +896,7 @@ class AppCore:
             logging.error(f"Erro ao manusear o resultado do agente: {e}", exc_info=True)
             self._log_status(f"Erro ao manusear o resultado do agente: {e}", error=True)
         finally:
-            response_size = len(agent_response_text)
+            response_size = len(normalized_response)
             self._set_state(
                 StateEvent.AGENT_COMMAND_COMPLETED,
                 details=f"Agent response delivered ({response_size} chars)",


### PR DESCRIPTION
## Summary
- revert the ActionOrchestrator rewrite to restore the previous AppCore-driven architecture
- guard AppCore._handle_agent_result_final so agent-mode clean-up still runs when Gemini returns no text

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3e863d70c8330a4d72c9e8cde4251