### PR TITLE
Fix orchestrator init and implement key detection

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -206,6 +206,20 @@ class UIManager:
         window = self._get_settings_var("window")
         if key_var is None or window is None:
             return
+
+        try:
+            current_value = key_var.get()
+        except Exception:
+            current_value = None
+
+        detection_target = "agent" if var_name == "agent_key_var" else "record"
+        core = getattr(self, "core_instance_ref", None)
+        if core and hasattr(core, "prepare_key_detection"):
+            try:
+                core.prepare_key_detection(detection_target, current_value=current_value)
+            except Exception:
+                logging.error("Falha ao preparar contexto de detecção de tecla.", exc_info=True)
+
         try:
             key_var.set("PRESS KEY...")
         except Exception:


### PR DESCRIPTION
## Summary
* reuse the ActionOrchestrator instance created during AppCore bootstrap and bind the freshly constructed TranscriptionHandler instead of rebuilding the orchestrator
* track key-detection context in AppCore and run the detection logic in a guarded background thread that restores the previous value on timeout
* prepare the detection context from the UI before launching the capture thread so that hotkey edits remain responsive

## Testing
* python -m flake8 src/core.py src/action_orchestrator.py

------
https://chatgpt.com/codex/tasks/task_e_68d3f4cf31288330ac8042d03caaa261