### PR TITLE
Refactor VAD pipeline contract and tests

### DIFF
--- a/src/vad_manager.py
+++ b/src/vad_manager.py
@@ -23,41 +23,45 @@ logging.info("VAD model path set to '%s'", MODEL_PATH)
 
 
 class VADManager:
-    """Gerencia a deteccao de voz usando o modelo Silero."""
+    """Gerencia a detecção de voz usando o modelo Silero."""
 
     @staticmethod
     def is_model_available() -> bool:
-        """Verifica se o arquivo do modelo Silero VAD esta presente."""
+        """Verifica se o arquivo do modelo Silero VAD está presente."""
         return MODEL_PATH.exists()
 
     def __init__(
         self,
-        threshold: float = 0.5,
+        threshold: float | None = None,
         sampling_rate: int = 16000,
-        pre_speech_padding_ms: int = 150,
-        post_speech_padding_ms: int = 300,
+        pre_speech_padding_ms: int | None = None,
+        post_speech_padding_ms: int | None = None,
+        *,
+        config_manager=None,
     ):
         """Inicializa o VAD Manager."""
 
-        self.threshold = threshold
-        self.sr = sampling_rate
-        self.vad_pre_speech_padding_ms = vad_pre_speech_padding_ms
-        self.vad_post_speech_padding_ms = vad_post_speech_padding_ms
+        self.config_manager = config_manager
+        self.sr = int(sampling_rate)
+        self.threshold = float(
+            self._resolve_config_value("vad_threshold", threshold, fallback=0.5)
+        )
+        self.pre_speech_padding_ms = int(
+            max(0, self._resolve_config_value("vad_pre_speech_padding_ms", pre_speech_padding_ms, fallback=150))
+        )
+        self.post_speech_padding_ms = int(
+            max(0, self._resolve_config_value("vad_post_speech_padding_ms", post_speech_padding_ms, fallback=300))
+        )
         self.enabled = False
         self._chunk_counter = 0
         self.session = None
         self._use_energy_fallback = False
         self._fallback_notified = False
-        self.pre_speech_padding_ms = max(0, int(pre_speech_padding_ms))
-        self.post_speech_padding_ms = max(0, int(post_speech_padding_ms))
         self._pre_buffer: deque[np.ndarray] = deque()
         self._pre_buffer_samples = 0
         self._speech_active = False
         self._post_silence_samples = 0
         self._update_padding_samples()
-
-        self.pre_speech_buffer = np.array([], dtype=np.float32)
-        self.post_speech_cooldown = 0
 
         if not self.is_model_available():
             logging.error(
@@ -106,60 +110,48 @@ class VADManager:
         self._speech_active = False
         self._post_silence_samples = 0
 
-    def is_speech(self, audio_chunk: np.ndarray) -> tuple[bool, np.ndarray | None]:
-        """Retorna ``True`` se o chunk contem fala."""
+    def is_speech(self, audio_chunk: np.ndarray) -> bool:
+        """Retorna ``True`` se o chunk contém fala."""
 
         if audio_chunk is None:
             logging.debug("VAD received chunk None; assuming speech to keep recording.")
-            return True, None
+            return True
 
         self._chunk_counter += 1
         raw_array = np.asarray(audio_chunk)
         if raw_array.size == 0:
             logging.debug("VAD received an empty chunk; returning False.")
-            return False, None
+            return False
 
-        prepared, peak = self._prepare_input(raw_array)
+        prepared, _ = self._prepare_input(raw_array)
         mono_view = prepared.reshape(-1) if prepared.size else np.empty(0, dtype=np.float32)
 
         if self.session is None or self._use_energy_fallback:
             detected, _, _, _ = self._energy_gate(mono_view, self.threshold)
-        else:
-            ort_inputs = {
-                "input": prepared,
-                "state": self._state,
-                "sr": np.array([self.sr], dtype=np.int64),
+            return detected
+
+        ort_inputs = {
+            "input": prepared,
+            "state": self._state,
+            "sr": np.array([self.sr], dtype=np.int64),
+        }
+        try:
+            outs = self.session.run(None, ort_inputs)
+            speech_prob = float(outs[0][0][0])
+            self._state = outs[1]
+            return speech_prob > self.threshold
+        except Exception as exc:
+            self.reset_states()
+            raw_meta = {
+                "raw_max_abs": float(np.max(np.abs(raw_array))) if raw_array.size else 0.0,
+                "raw_shape": list(raw_array.shape),
+                "raw_dtype": str(raw_array.dtype),
+                "preview": raw_array.reshape(-1)[:10].tolist(),
             }
-            try:
-                outs = self.session.run(None, ort_inputs)
-                speech_prob = float(outs[0][0][0])
-                self._state = outs[1]
-                detected = speech_prob > self.threshold
-            except Exception as exc:
-                self.reset_states()
-                self._log_failure(exc, prepared, {})
-                self._activate_energy_fallback("inference failure", exc)
-                detected, _, _, _ = self._energy_gate(mono_view, self.threshold)
-
-        if detected:
-            self.post_speech_cooldown = int(self.vad_post_speech_padding_ms / 1000 * self.sr)
-            if self.pre_speech_buffer.size > 0:
-                # Retorna o buffer de pre-speech e o chunk atual
-                returning_buffer = np.concatenate([self.pre_speech_buffer, raw_array])
-                self.pre_speech_buffer = np.array([], dtype=np.float32)
-                return True, returning_buffer
-            return True, raw_array
-        else:
-            if self.post_speech_cooldown > 0:
-                self.post_speech_cooldown -= len(raw_array)
-                return True, raw_array
-
-            # Adiciona ao buffer de pre-speech
-            self.pre_speech_buffer = np.concatenate([self.pre_speech_buffer, raw_array])
-            max_buffer_size = int(self.vad_pre_speech_padding_ms / 1000 * self.sr)
-            if self.pre_speech_buffer.size > max_buffer_size:
-                self.pre_speech_buffer = self.pre_speech_buffer[-max_buffer_size:]
-            return False, None
+            self._log_failure(exc, prepared, raw_meta)
+            self._activate_energy_fallback("inference failure", exc)
+            detected, _, _, _ = self._energy_gate(mono_view, self.threshold)
+            return detected
 
     def configure(
         self,
@@ -172,36 +164,83 @@ class VADManager:
 
         if threshold is not None:
             self.threshold = float(threshold)
+        elif self.config_manager is not None:
+            try:
+                self.threshold = float(self.config_manager.get("vad_threshold", self.threshold))
+            except Exception:
+                logging.debug("Failed to read VAD threshold from config manager.", exc_info=True)
+
         if pre_padding_ms is not None:
             self.pre_speech_padding_ms = max(0, int(pre_padding_ms))
+        elif self.config_manager is not None:
+            try:
+                value = self.config_manager.get("vad_pre_speech_padding_ms", self.pre_speech_padding_ms)
+                self.pre_speech_padding_ms = max(0, int(value))
+            except Exception:
+                logging.debug("Failed to read VAD pre padding from config manager.", exc_info=True)
+
         if post_padding_ms is not None:
             self.post_speech_padding_ms = max(0, int(post_padding_ms))
+        elif self.config_manager is not None:
+            try:
+                value = self.config_manager.get("vad_post_speech_padding_ms", self.post_speech_padding_ms)
+                self.post_speech_padding_ms = max(0, int(value))
+            except Exception:
+                logging.debug("Failed to read VAD post padding from config manager.", exc_info=True)
         self._update_padding_samples()
 
-    def process_chunk(self, chunk: np.ndarray) -> list[np.ndarray]:
-        """Retorna os frames que devem ser escritos considerando padding."""
+    def process_chunk(self, chunk: np.ndarray) -> tuple[bool, list[np.ndarray]]:
+        """Avalia um chunk e retorna (``is_speech``, ``frames``).
+
+        ``is_speech`` indica se o chunk está dentro de uma janela ativa de fala
+        (incluindo o período de pós-fala). ``frames`` contém os buffers que devem
+        ser persistidos imediatamente. Quando não há fala detectada o método
+        retorna ``(False, [])`` e o chunk é mantido no buffer de pré-fala.
+        """
 
         frames: list[np.ndarray] = []
         speech_detected = self.is_speech(chunk)
+        chunk_array = np.asarray(chunk, dtype=np.float32).copy()
 
         if speech_detected:
             if not self._speech_active:
                 frames.extend(self._drain_pre_buffer())
                 self._speech_active = True
             self._post_silence_samples = 0
-            frames.append(np.asarray(chunk, dtype=np.float32).copy())
-            return frames
+            frames.append(chunk_array)
+            return True, frames
 
         if self._speech_active:
-            self._post_silence_samples += len(chunk)
-            frames.append(np.asarray(chunk, dtype=np.float32).copy())
+            self._post_silence_samples += len(chunk_array)
+            frames.append(chunk_array)
             if self._post_silence_samples >= self._post_padding_samples:
                 self._speech_active = False
                 self._post_silence_samples = 0
-            return frames
+            return True, frames
 
-        self._append_to_pre_buffer(np.asarray(chunk, dtype=np.float32))
-        return frames
+        self._append_to_pre_buffer(chunk_array)
+        return False, frames
+
+    def enable_energy_fallback(self, reason: str, exc: Exception | None = None) -> None:
+        """Expõe o modo de fallback por energia para o pipeline externo."""
+
+        self._activate_energy_fallback(reason, exc)
+
+    def _resolve_config_value(self, key: str, override, *, fallback):
+        if override is not None:
+            return override
+        if self.config_manager is None:
+            return fallback
+        try:
+            return self.config_manager.get(key, fallback)
+        except Exception:
+            logging.debug(
+                "Failed to read '%s' from config manager. Using fallback %s.",
+                key,
+                fallback,
+                exc_info=True,
+            )
+            return fallback
 
 
     @staticmethod


### PR DESCRIPTION
## Summary
- align `VADManager` with configuration defaults, expose a `(is_speech, frames)` contract, and add an energy fallback hook
- rework `AudioHandler` VAD integration to consume the new contract and harden exception handling/reset paths
- update the VAD pipeline tests to construct `VADManager` realistically and validate the revised API

## Testing
- flake8 src/audio_handler.py src/vad_manager.py tests/test_vad_pipeline.py
- pytest tests/test_vad_pipeline.py


------
https://chatgpt.com/codex/tasks/task_e_68d3f4d98e2483309f1dea0272e44479