### PR TITLE
Remove unused alias in UIManager configuration workflow

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -1926,7 +1926,6 @@ class UIManager:
 
                 self._clear_settings_context()
                 self._set_settings_var("window", settings_win)
-                model_manager = self.model_manager
                 service_values_allowed = {SERVICE_NONE, SERVICE_OPENROUTER, SERVICE_GEMINI}
                 self._set_settings_meta("service_values_allowed", service_values_allowed)
 


### PR DESCRIPTION
## Summary
- delete the redundant `model_manager` alias inside the settings window bootstrap to eliminate an unused-local warning.

## Testing
- flake8
- python -m compileall src/ui_manager.py
- pytest *(fails: missing optional dependency `onnxruntime` required by vad_manager)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fc5e63688330b5ec2cedf52c53b3