### PR TITLE
Refatorar restauro de configurações padrão

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -3,6 +3,7 @@ import threading
 import time
 import os
 from collections.abc import Callable
+from typing import Iterable
 from threading import RLock
 from pathlib import Path
 import atexit
@@ -1133,7 +1134,13 @@ class AppCore:
         )
 
     # --- Settings Application Logic (delegando para ConfigManager e outros) ---
-    def apply_settings_from_external(self, **kwargs):
+    def apply_settings_from_external(
+        self,
+        *,
+        force_reload: bool = False,
+        forced_keys: Iterable[str] | None = None,
+        **kwargs,
+    ):
         logging.info("AppCore: Applying new configuration from external source.")
 
         config_key_map = {
@@ -1192,6 +1199,7 @@ class AppCore:
         }
 
         normalized_updates: dict[str, object] = {}
+        forced_key_set = set(forced_keys or [])
         sentinel = object()
         for raw_key, value in kwargs.items():
             if value is None:
@@ -1210,10 +1218,19 @@ class AppCore:
             normalized_updates[mapped_key] = value
 
         if not normalized_updates:
-            logging.info("Nenhuma configuração alterada.")
+            if force_reload:
+                logging.info(
+                    "AppCore: nenhum parâmetro recebido para reaplicar as configurações forçadas.")
+            else:
+                logging.info("Nenhuma configuração alterada.")
             return
 
         changed_mapped_keys, warnings = self.config_manager.apply_updates(normalized_updates)
+        if force_reload:
+            if forced_key_set:
+                changed_mapped_keys |= forced_key_set
+            else:
+                changed_mapped_keys |= set(normalized_updates.keys())
         if warnings:
             summary = "\n".join(f"- {message}" for message in warnings)
             message = (
@@ -1226,8 +1243,18 @@ class AppCore:
 
             self.main_tk_root.after(0, _show_warning)
         if not changed_mapped_keys:
-            logging.info("Nenhuma configuração alterada.")
-            return
+            if force_reload:
+                logging.info(
+                    "AppCore: nenhuma configuração alterada, mas forçando reaplicação dos parâmetros.")
+            else:
+                logging.info("Nenhuma configuração alterada.")
+                return
+
+        if force_reload and changed_mapped_keys:
+            logging.debug(
+                "AppCore: reaplicando configurações para as chaves: %s",
+                ", ".join(sorted(changed_mapped_keys)),
+            )
 
         reload_keys = {
             ASR_BACKEND_CONFIG_KEY,


### PR DESCRIPTION
## Summary
- add a helper in `ConfigManager` to reset and persist the default configuration
- allow `AppCore.apply_settings_from_external` to force the runtime to reapply a snapshot of settings
- refactor the UI reset flow to delegate to the config manager and rebuild the settings window from scratch

## Testing
- python -m compileall src
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68d555d1ea6883309f0b3eee403c1ad5