### PR TITLE
Fix faster-whisper model normalization for ct2 backend

### DIFF
--- a/src/asr/backend_faster_whisper.py
+++ b/src/asr/backend_faster_whisper.py
@@ -1,35 +1,71 @@
 from __future__ import annotations
 
+import logging
+from pathlib import Path
 from typing import Any
+
+DEFAULT_MODEL_ID = "large-v3-turbo"
 
 
 class FasterWhisperBackend:
     """ASR backend powered by faster-whisper."""
 
-    def __init__(self, model_id: str = "whisper-large-v3", device: str = "auto") -> None:
+    def __init__(self, model_id: str = DEFAULT_MODEL_ID, device: str = "auto") -> None:
         self.model_id = model_id
         self.device = device
         self.model = None
+        self._resolved_model_id: str | None = None
 
-    def load(self, ct2_compute_type: str = "default", cache_dir: str | None = None, **kwargs) -> None:
+    def load(
+        self,
+        *,
+        model_id: str | None = None,
+        device: str | None = None,
+        ct2_compute_type: str = "default",
+        cache_dir: str | None = None,
+        **kwargs,
+    ) -> None:
         """Load the WhisperModel with the given compute type."""
         from faster_whisper import WhisperModel
 
-        device = self.device
-        if device == "auto":
-            device = "cuda" if _has_cuda() else "cpu"
-        if ct2_compute_type == "default":
-            ct2_compute_type = "int8_float16" if device == "cuda" else "int8"
+        if model_id:
+            self.model_id = model_id
+        if device:
+            self.device = device
 
-        model_id = self.model_id.split("/")[-1]
+        requested_device = self.device or "auto"
+        device_kind, device_index = self._parse_device(requested_device)
+        if device_kind == "auto":
+            device_kind = "cuda" if _has_cuda() else "cpu"
+        if ct2_compute_type == "default":
+            ct2_compute_type = "int8_float16" if device_kind == "cuda" else "int8"
+
+        resolved_id = self._normalize_model_id(self.model_id)
+        self._resolved_model_id = resolved_id
+
+        init_kwargs = {
+            "device": device_kind,
+            "compute_type": ct2_compute_type,
+            "download_root": cache_dir or None,
+            **kwargs,
+        }
+        if device_index is not None:
+            init_kwargs["device_index"] = device_index
+
+        logging.info(
+            "Inicializando WhisperModel (requested_id=%s, resolved_id=%s, device=%s, device_index=%s, compute_type=%s)",
+            self.model_id,
+            resolved_id,
+            device_kind,
+            device_index,
+            ct2_compute_type,
+        )
 
         self.model = WhisperModel(
-            model_id,
-            device=device,
-            compute_type=ct2_compute_type,
-            download_root=cache_dir or None,
-            **kwargs,
+            resolved_id,
+            **init_kwargs,
         )
+        self.device = self._compose_device(device_kind, device_index)
 
     def warmup(self) -> None:
         """Run a dummy inference to initialize the model."""
@@ -52,6 +88,45 @@ class FasterWhisperBackend:
     def unload(self) -> None:
         """Release model resources."""
         self.model = None
+
+    def _normalize_model_id(self, raw_id: str | None) -> str:
+        candidate = (raw_id or "").strip()
+        if not candidate:
+            candidate = DEFAULT_MODEL_ID
+
+        path_candidate = Path(candidate).expanduser()
+        if path_candidate.exists():
+            return str(path_candidate)
+
+        normalized = candidate.replace("\\", "/")
+        if "/" in normalized:
+            normalized = normalized.split("/")[-1]
+        lowered = normalized.lower()
+
+        if lowered == "auto":
+            return DEFAULT_MODEL_ID
+
+        if lowered.startswith("whisper-"):
+            normalized = normalized[len("whisper-") :]
+            lowered = normalized.lower()
+
+        return normalized
+
+    @staticmethod
+    def _parse_device(device: str) -> tuple[str, int | None]:
+        value = (device or "auto").strip()
+        if value.startswith("cuda:"):
+            try:
+                return "cuda", int(value.split(":", 1)[1])
+            except ValueError:
+                return "cuda", None
+        return value or "auto", None
+
+    @staticmethod
+    def _compose_device(device: str, index: int | None) -> str:
+        if index is None or device in {"cpu", "auto"}:
+            return device
+        return f"{device}:{index}"
 
 
 def _has_cuda() -> bool:

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -164,6 +164,8 @@ class TranscriptionHandler:
         asr_ct2_compute_type,
         asr_cache_dir,
         transformers_device,
+        model_id,
+        effective_device,
     ) -> dict:
         """Constroi os parâmetros de ``load`` para o backend escolhido."""
         if backend_name in {"transformers", "whisper"}:
@@ -185,6 +187,8 @@ class TranscriptionHandler:
             return {
                 "ct2_compute_type": asr_ct2_compute_type,
                 "cache_dir": asr_cache_dir,
+                "model_id": model_id,
+                "device": effective_device,
             }
         return {"cache_dir": asr_cache_dir}
 
@@ -1053,6 +1057,8 @@ class TranscriptionHandler:
                     asr_ct2_compute_type=self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY),
                     asr_cache_dir=self.config_manager.get(ASR_CACHE_DIR_CONFIG_KEY),
                     transformers_device=transformers_device,
+                    model_id=req_model_id,
+                    effective_device=effective_device,
                 )
                 load_kwargs = {k: v for k, v in load_kwargs.items() if v is not None}
                 if "cache_dir" in load_kwargs and load_kwargs["cache_dir"]:


### PR DESCRIPTION
## Summary
- normalize configured faster-whisper model identifiers and device values before loading the CTranslate2 backend
- propagate the requested model id and device from the transcription handler when initializing the faster-whisper backend

## Testing
- python -m compileall src
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68df2bfe30a4833085188d605f2cb87e