### PR TITLE
Handle chunk_length_s in faster-whisper backend

### DIFF
--- a/src/asr/backend_faster_whisper.py
+++ b/src/asr/backend_faster_whisper.py
@@ -106,6 +106,9 @@ class FasterWhisperBackend:
         """Transcribe the provided audio and return just the text."""
         if not self.model:
             raise RuntimeError("Backend not loaded")
+        chunk_length_s = kwargs.pop("chunk_length_s", None)
+        if chunk_length_s is not None:
+            kwargs.setdefault("chunk_length", chunk_length_s)
         segments, _ = self.model.transcribe(audio, **kwargs)
         text = " ".join(segment.text for segment in segments)
         return {"text": text}


### PR DESCRIPTION
## Summary
- map the chunk_length_s argument to faster-whisper's chunk_length parameter so the backend accepts the setting

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dfcb14bedc83309d822ea8bb7b8957