### PR TITLE
Fix ANSI escape filtering

### DIFF
--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -6,7 +6,7 @@ import os
 import re
 from typing import Iterable
 
-ANSI_ESCAPE_RE = re.compile(r"[@-_][0-?]*[ -/]*[@-~]")
+ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 
 class _StripAnsiFilter(logging.Filter):


### PR DESCRIPTION
## Summary
- restore the ANSI escape sequence regular expression so colored log codes are stripped correctly

## Testing
- pytest *(fails: missing numpy dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd57e51e88330ace10d1d69c7f397