### PR TITLE
Fix platform-aware auto paste hotkey

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -37,6 +37,7 @@ DEFAULT_CONFIG = {
     "record_mode": "toggle",
     "auto_paste": True,
     "agent_auto_paste": True,
+    "auto_paste_modifier": "auto",
     "min_record_duration": 0.5,
     "sound_enabled": True,
     "sound_frequency": 400,
@@ -161,6 +162,7 @@ KEYBOARD_LIB_WIN32 = "win32"
 TEXT_CORRECTION_ENABLED_CONFIG_KEY = "text_correction_enabled"
 TEXT_CORRECTION_SERVICE_CONFIG_KEY = "text_correction_service"
 ENABLE_AI_CORRECTION_CONFIG_KEY = TEXT_CORRECTION_ENABLED_CONFIG_KEY
+AUTO_PASTE_MODIFIER_CONFIG_KEY = "auto_paste_modifier"
 SERVICE_NONE = "none"
 SERVICE_OPENROUTER = "openrouter"
 SERVICE_GEMINI = "gemini"

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -43,6 +43,7 @@ class AppConfig(BaseModel):
     record_key: str = "F3"
     record_mode: str = "toggle"
     auto_paste: bool = True
+    auto_paste_modifier: str = "auto"
     agent_auto_paste: bool | None = None
     min_record_duration: float = Field(default=0.5, ge=0.0)
     sound_enabled: bool = True
@@ -114,6 +115,27 @@ class AppConfig(BaseModel):
     def _coerce_key(cls, value: Any) -> str:
         if isinstance(value, str):
             return value.strip()
+        return str(value)
+
+    @field_validator("auto_paste_modifier", mode="before")
+    @classmethod
+    def _normalize_auto_paste_modifier(cls, value: Any) -> str:
+        if value is None:
+            return "auto"
+        if isinstance(value, str):
+            normalized = value.strip()
+            return normalized or "auto"
+        if isinstance(value, (list, tuple, set)):
+            normalized_parts: list[str] = []
+            for item in value:
+                if item is None:
+                    continue
+                item_str = str(item).strip()
+                if item_str:
+                    normalized_parts.append(item_str)
+            if not normalized_parts:
+                return "auto"
+            return "+".join(normalized_parts)
         return str(value)
 
     @field_validator("record_mode", mode="before")


### PR DESCRIPTION
## Summary
- add a configurable auto paste modifier with validation defaults
- resolve the paste hotkey dynamically so macOS uses Command and other OSes stay on Control

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dfd58a17988330b3b112f21443cc77