### PR TITLE
Add Gemini agent model selector to settings UI

### DIFF
--- a/docs/ui_vars.md
+++ b/docs/ui_vars.md
@@ -8,7 +8,7 @@ Este documento consolida todas as instâncias de `ctk.*Var` usadas na janela de 
 | Geral | `mode_var` | `StringVar` | `CTkRadioButton` (`toggle_rb`, `hold_rb`) | `"record_mode"` | Seleciona entre os modos *toggle* e *hold* de gravação. |
 | Geral | `detected_key_var` | `StringVar` | `CTkLabel` (`key_display`) | `"record_key"` | Exibe a tecla atual e recebe o valor detectado pelo listener de hotkeys. |
 | Geral | `agent_key_var` | `StringVar` | `CTkLabel` (`agent_key_display`) | `"agent_key"` | Espelha a tecla do modo agente; atualizado pelo detector dedicado. |
-| Geral | `agent_model_var` | `StringVar` | — | `"gemini_agent_model"` | Mantém o valor configurado mas não há widget para alterá-lo; apenas reaplicado no `apply_settings` e em *restore defaults*. |
+| Correção de texto | `agent_model_var` | `StringVar` | `CTkOptionMenu` (`agent_model_menu`) | `"gemini_agent_model"` | Seleciona o modelo Gemini específico para o modo agente. |
 | Geral | `hotkey_stability_service_enabled_var` | `BooleanVar` | `CTkSwitch` (`stability_switch`) | `"hotkey_stability_service_enabled"` | Liga/desliga o serviço de estabilização dos hotkeys. |
 | Geral | `launch_at_startup_var` | `BooleanVar` | `CTkSwitch` (`startup_switch`) | `"launch_at_startup"` | Habilita a inicialização automática no Windows. |
 | Som | `sound_enabled_var` | `BooleanVar` | `CTkSwitch` (`sound_switch`) | `"sound_enabled"` | Ativa os bipes de início/fim de gravação. |
@@ -46,7 +46,6 @@ Este documento consolida todas as instâncias de `ctk.*Var` usadas na janela de 
 
 ## Duplicatas ou variáveis potencialmente obsoletas
 
-- `agent_model_var`: inicializada com `"gemini_agent_model"`, aplicada e restaurada, porém nenhum widget atual permite modificar esse valor. Sugere-se incluir um seletor explícito ou remover a variável se o parâmetro for fixo. 
 - `asr_model_display_var`: é instanciada inicialmente sem valor e, alguns blocos adiante, recebe nova instância preenchida com os rótulos do catálogo. Não há efeito funcional, mas a criação anterior é redundante.
 
 Nenhuma outra `ctk.*Var` aparece duplicada ou sem uso na interface atual.

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -491,6 +491,7 @@ class UIManager:
             "openrouter_model_entry",
             "gemini_key_entry",
             "gemini_model_menu",
+            "agent_model_menu",
             "gemini_prompt_correction_textbox",
             "agentico_prompt_textbox",
             "gemini_models_textbox",
@@ -2494,6 +2495,7 @@ class UIManager:
                     openrouter_model_var.set(DEFAULT_CONFIG[OPENROUTER_MODEL_CONFIG_KEY])
                     gemini_api_key_var.set(DEFAULT_CONFIG[GEMINI_API_KEY_CONFIG_KEY])
                     gemini_model_var.set(DEFAULT_CONFIG[GEMINI_MODEL_CONFIG_KEY])
+                    agent_model_var.set(DEFAULT_CONFIG[GEMINI_AGENT_MODEL_CONFIG_KEY])
                     try:
                         gemini_model_menu
                     except NameError:
@@ -2501,6 +2503,13 @@ class UIManager:
                     else:
                         gemini_model_menu.configure(values=DEFAULT_CONFIG[GEMINI_MODEL_OPTIONS_CONFIG_KEY])
                         gemini_model_menu.set(DEFAULT_CONFIG[GEMINI_MODEL_CONFIG_KEY])
+                    try:
+                        agent_model_menu
+                    except NameError:
+                        pass
+                    else:
+                        agent_model_menu.configure(values=DEFAULT_CONFIG[GEMINI_MODEL_OPTIONS_CONFIG_KEY])
+                        agent_model_menu.set(DEFAULT_CONFIG[GEMINI_AGENT_MODEL_CONFIG_KEY])
                     gemini_model_options[:] = list(DEFAULT_CONFIG[GEMINI_MODEL_OPTIONS_CONFIG_KEY])
                     asr_model_id_var.set(DEFAULT_CONFIG[ASR_MODEL_ID_CONFIG_KEY])
                     asr_model_display_var = self._get_settings_var("asr_model_display_var")
@@ -2722,6 +2731,16 @@ class UIManager:
                 gemini_model_menu.pack(side="left", padx=5)
                 self._set_settings_var("gemini_model_menu", gemini_model_menu)
                 Tooltip(gemini_model_menu, "Modelo utilizado nas requisições Gemini.")
+
+                ctk.CTkLabel(gemini_frame, text="Modelo do Agente:").pack(side="left", padx=(5, 10))
+                agent_model_menu = ctk.CTkOptionMenu(
+                    gemini_frame,
+                    variable=agent_model_var,
+                    values=gemini_model_options,
+                )
+                agent_model_menu.pack(side="left", padx=5)
+                self._set_settings_var("agent_model_menu", agent_model_menu)
+                Tooltip(agent_model_menu, "Modelo dedicado às ações do modo agente.")
 
                 # --- Gemini Prompt ---
                 gemini_prompt_frame = ctk.CTkFrame(ai_frame)


### PR DESCRIPTION
## Summary
- add a dedicated option menu in the Gemini section to let users choose the agent-mode model
- ensure the new control participates in enable/disable logic and default resets for AI settings
- document the new widget in the UI variable inventory

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dfd59046188330be8b9c7a814e5425