### PR TITLE
Enforce recording storage limit for disk mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,7 @@ pytest
 | Item | Location |
 | --- | --- |
 | Rotating log files | `logs/` directory (configuration is in the logger setup). |
-| Temporary audio files | Project root (`temp_recording_*.wav`, `recording_*.wav`). |
+| Temporary audio files | Project root (`temp_recording_*.wav`, `recording_*.wav`). | Auto-pruned when `record_storage_limit` > 0 (limit in MiB, oldest files removed first). |
 | Agent action plans | `plans/` directory. |
 
 ---

--- a/docs/ui_vars.md
+++ b/docs/ui_vars.md
@@ -44,6 +44,10 @@ Este documento consolida todas as instâncias de `ctk.*Var` usadas na janela de 
 | ASR | `asr_ct2_compute_type_var` | `StringVar` | `CTkOptionMenu` (`asr_ct2_menu`) | `"asr_ct2_compute_type"` | Ajusta o compute type quando o backend é CTranslate2. |
 | ASR | `asr_cache_dir_var` | `StringVar` | `CTkEntry` (`asr_cache_entry`) | `"asr_cache_dir"` | Diretório raiz usado para armazenar modelos baixados. |
 
+## Notas adicionais
+
+- A configuração `record_storage_limit` ainda não possui `ctk.*Var` associada. Quando definida manualmente em `config.json`, o `AudioHandler` limita o total combinado de `temp_recording_*.wav` e `recording_*.wav` no diretório raiz, removendo os arquivos mais antigos assim que o teto (em MiB) é excedido.
+
 ## Duplicatas ou variáveis potencialmente obsoletas
 
 - `agent_model_var`: inicializada com `"gemini_agent_model"`, aplicada e restaurada, porém nenhum widget atual permite modificar esse valor. Sugere-se incluir um seletor explícito ou remover a variável se o parâmetro for fixo. 


### PR DESCRIPTION
## Summary
- enforce the configured record storage limit before starting new captures and after saving disk-based recordings
- add a helper that prunes old `recording_*.wav`/`temp_recording_*.wav` files to stay within the MiB budget and guard active files
- document the automatic pruning behaviour in the agent reference and UI variable inventory

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dfd5a549b083309a50f65d1b804422