### PR TITLE
Fix faster-whisper batch size kwarg handling

### DIFF
--- a/src/asr/backend_faster_whisper.py
+++ b/src/asr/backend_faster_whisper.py
@@ -52,8 +52,12 @@ class FasterWhisperBackend:
         """Transcribe the provided audio and return just the text."""
         if not self.model:
             raise RuntimeError("Backend not loaded")
-        if 'chunk_length_s' in kwargs:
-            kwargs['chunk_length'] = kwargs.pop('chunk_length_s')
+        if "chunk_length_s" in kwargs:
+            kwargs["chunk_length"] = kwargs.pop("chunk_length_s")
+        # ``WhisperModel.transcribe`` does not accept ``batch_size``. The unified
+        # transcription handler still provides the value for backends that use it,
+        # so we discard it here to avoid ``TypeError``.
+        kwargs.pop("batch_size", None)
         segments, _ = self.model.transcribe(audio, **kwargs)
         text = " ".join(segment.text for segment in segments)
         return {"text": text}


### PR DESCRIPTION
## Summary
- discard the unified transcription batch_size kwarg before calling WhisperModel.transcribe to avoid TypeError
- keep chunk_length remapping while ensuring unsupported kwargs are sanitized

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dfd5d08e4883309ec906e393be6765