### PR TITLE
Fix agent mode readiness for unified ASR backends

### DIFF
--- a/src/action_orchestrator.py
+++ b/src/action_orchestrator.py
@@ -106,10 +106,25 @@ class ActionOrchestrator:
             )
             return
 
+        if not self._transcription_handler.is_model_ready():
+            LOGGER.error(
+                "Transcription backend is not ready to receive audio (agent_mode=%s).",
+                agent_mode,
+            )
+            if self._log_status_callback:
+                self._log_status_callback("Modelo indisponível para transcrição.", True)
+            return
+
         LOGGER.info(
             "Dispatching audio segment for transcription (duration=%.2fs, agent=%s).",
             duration_seconds,
             agent_mode,
+        )
+        details = "Transcrição iniciada no modo agente." if agent_mode else "Transcrição iniciada."
+        self._state_manager.set_state(
+            sm.StateEvent.TRANSCRIPTION_STARTED,
+            details=details,
+            source="action_orchestrator",
         )
         self._transcription_handler.transcribe_audio_segment(audio_source, agent_mode)
 

--- a/src/core.py
+++ b/src/core.py
@@ -1025,7 +1025,7 @@ class AppCore:
             if current_state == sm.STATE_TRANSCRIBING:
                 self._log_status("Cannot record: Transcription running.", error=True)
                 return
-            if self.transcription_handler.pipe is None or current_state == sm.STATE_LOADING_MODEL:
+            if (not self.transcription_handler.is_model_ready()) or current_state == sm.STATE_LOADING_MODEL:
                 self._log_status("Cannot record: Model not loaded.", error=True)
                 return
             if current_state.startswith("ERROR"):
@@ -1085,7 +1085,7 @@ class AppCore:
         if current_state == sm.STATE_TRANSCRIBING:
             self._log_status("Cannot start command: transcription in progress.", error=True)
             return
-        if self.transcription_handler.pipe is None or current_state == sm.STATE_LOADING_MODEL:
+        if (not self.transcription_handler.is_model_ready()) or current_state == sm.STATE_LOADING_MODEL:
             self._log_status("Model not loaded.", error=True)
             return
         if current_state.startswith("ERROR"):

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -963,6 +963,15 @@ class TranscriptionHandler:
         """Indica se há correção de texto em andamento."""
         return self.correction_in_progress
 
+    def is_model_ready(self) -> bool:
+        """Indica se há um backend de ASR pronto para receber áudio."""
+        if self._asr_backend is not None:
+            backend_model = getattr(self._asr_backend, "model", None)
+            if backend_model is None:
+                return False
+            return True
+        return self.pipe is not None
+
     def stop_transcription(self) -> None:
         """Sinaliza que a transcrição em andamento deve ser cancelada."""
         self.transcription_cancel_event.set()
@@ -1355,7 +1364,7 @@ class TranscriptionHandler:
 
     def transcribe_audio_segment(self, audio_source: str | np.ndarray, agent_mode: bool = False):
         """Envia o áudio (arquivo ou array) para transcrição assíncrona."""
-        if self.pipe is None:
+        if not self.is_model_ready():
             logging.error("Transcription pipeline is not available. Model not loaded or failed to load.")
             self.on_model_error_callback("Pipeline de transcrição indisponível. O modelo não foi carregado ou falhou.")
             return


### PR DESCRIPTION
## Summary
- add a readiness helper in the transcription handler so AppCore can validate model availability for unified backends
- update agent command flow to emit the transcribing state and avoid dispatch when the backend is unavailable
- reuse the readiness helper across recording entry points to prevent false "Model not loaded" errors

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dfd5d8e2a483308b620613feca90c7