### PR TITLE
Fix hotkey registration for non-admin users

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ During the initial startup the application will create `config.json` and `hotkey
 - Press again (or release, depending on the chosen mode) to stop.
 - The application transcribes the captured audio and, if enabled, copies the final result to the clipboard and pastes it into the active window.
 
+### Windows permissions and global hotkeys
+
+The application registers global shortcuts using the [`keyboard`](https://github.com/boppreh/keyboard) library. Key suppression is intentionally disabled so that hotkeys work without elevated privileges on Windows. If you customize the code to block the underlying key events system-wide, make sure to run the application as an administrator to satisfy the library requirements.
+
 ## Architecture Overview
 
 - **`main.py`:** Application entry point that initializes `AppCore` and the user interface.

--- a/src/keyboard_hotkey_manager.py
+++ b/src/keyboard_hotkey_manager.py
@@ -201,7 +201,7 @@ class KeyboardHotkeyManager:
                         keyboard.on_release_key(
                             self.record_key,
                             lambda _: self._on_release_key(),
-                            suppress=True,
+                            suppress=False,
                         )
                     except OSError as e:
                         logging.error(
@@ -217,7 +217,11 @@ class KeyboardHotkeyManager:
 
             # Usar on_press_key em vez de add_hotkey para maior confiabilidade
             try:
-                keyboard.on_press_key(self.record_key, lambda _: handler(), suppress=True)
+                keyboard.on_press_key(
+                    self.record_key,
+                    lambda _: handler(),
+                    suppress=False,
+                )
             except OSError as e:
                 logging.error(
                     f"Falha específica ao registrar hotkey de gravação: {e}"
@@ -240,7 +244,7 @@ class KeyboardHotkeyManager:
                 keyboard.on_press_key(
                     self.agent_key,
                     lambda _: self._on_agent_key(),
-                    suppress=True,
+                    suppress=False,
                 )
             except OSError as e:
                 logging.error(


### PR DESCRIPTION
## Summary
- disable key suppression when registering hotkeys so the app runs without administrator rights
- document Windows-specific guidance around optional key suppression in the README

## Testing
- python -m compileall src
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfd5dd490c8330b78811d5b8b82edc