### PR TITLE
Fix tray icon path resolution

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,9 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 
+ICON_PATH = os.path.join(PROJECT_ROOT, "icon.ico")
+
+
 ENV_DEFAULTS = {
     "HF_HUB_DISABLE_PROGRESS_BARS": "1",
     "HF_HUB_DISABLE_TELEMETRY": "1",
@@ -135,11 +138,18 @@ def main() -> None:
 
     main_tk_root = tk.Tk()
     main_tk_root.withdraw()
-    try:
-        # Define o ícone da aplicação, que aparecerá na barra de tarefas
-        main_tk_root.iconbitmap("icon.ico")
-    except Exception:
-        logging.warning("Failed to set main window icon. icon.ico may be missing or invalid.")
+    icon_path = ICON_PATH
+    if not os.path.exists(icon_path):
+        logging.warning("Failed to set main window icon. File not found: %s", icon_path)
+    else:
+        try:
+            # Define o ícone da aplicação, que aparecerá na barra de tarefas
+            main_tk_root.iconbitmap(icon_path)
+        except Exception:
+            logging.warning(
+                "Failed to set main window icon. icon.ico may be missing or invalid at %s.",
+                icon_path,
+            )
 
     app_core_instance = AppCore(main_tk_root)
     ui_manager_instance = UIManager(


### PR DESCRIPTION
## Summary
- resolve the main window icon path using an absolute location relative to the project root
- improve logging when the icon file is missing or cannot be loaded

## Testing
- python -m compileall src
- pytest *(fails: missing numpy dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e407750f68833094e580ec185872ef