### PR TITLE
Fix VAD inference input handling

### DIFF
--- a/src/vad_manager.py
+++ b/src/vad_manager.py
@@ -136,6 +136,7 @@ class VADManager:
             return detected
 
         self._state = self._coerce_state_tensor(self._state)
+        vad_input = np.ascontiguousarray(prepared, dtype=np.float32)
         ort_inputs = {
             "input": vad_input,
             "state": self._state,


### PR DESCRIPTION
## Summary
- ensure the Silero VAD inference path passes the prepared audio tensor into ONNX Runtime
- keep the tensor contiguous before execution to avoid unexpected dtype or layout issues

## Testing
- python -m compileall src/vad_manager.py
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e407750f68833094e580ec185872ef