### PR TITLE
Fix optional snapshot_download arguments for older hubs

### DIFF
--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -8,6 +8,7 @@ import logging
 import os
 import shutil
 import time
+from functools import lru_cache
 from pathlib import Path
 from threading import Event, RLock
 from typing import Dict, List
@@ -74,6 +75,36 @@ _download_size_lock = RLock()
 
 _list_installed_cache: dict[str, tuple[float, List[Dict[str, str]]]] = {}
 _list_installed_lock = RLock()
+
+
+@lru_cache(maxsize=None)
+def _snapshot_download_supports(parameter: str) -> bool:
+    """Return ``True`` when ``snapshot_download`` accepts ``parameter``.
+
+    Some optional arguments (``local_dir_use_symlinks``,
+    ``local_dir_use_hardlinks`` and ``resume_download``) were introduced in
+    recent versions of ``huggingface_hub``. Older releases raised ``TypeError``
+    if those keyword arguments were provided, which previously resulted in the
+    entire download process crashing before it even started. This helper checks
+    the exported function signature (and any ``**kwargs`` catch-all) so that we
+    can conditionally pass the arguments only when they are actually supported.
+    """
+
+    if not parameter:
+        return False
+
+    try:
+        signature = inspect.signature(snapshot_download)
+    except Exception:  # pragma: no cover - defensive best effort
+        return False
+
+    parameters = signature.parameters
+    if parameter in parameters:
+        return True
+
+    return any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in parameters.values()
+    )
 
 _MODEL_WEIGHT_FILE_HINTS = {
     "model.bin",
@@ -488,14 +519,12 @@ def ensure_download(
         "local_dir": str(local_dir),
         "allow_patterns": None,
         "tqdm_class": progress_class,
-        "resume_download": True,
-        "local_dir_use_symlinks": False,
     }
     if _snapshot_download_supports("local_dir_use_symlinks"):
         download_kwargs["local_dir_use_symlinks"] = False
     if _snapshot_download_supports("local_dir_use_hardlinks"):
         download_kwargs["local_dir_use_hardlinks"] = False
-    if _snapshot_download_supports("resume_download") and "resume_download" not in download_kwargs:
+    if _snapshot_download_supports("resume_download"):
         download_kwargs["resume_download"] = True
     if revision is not None:
         download_kwargs["revision"] = revision


### PR DESCRIPTION
## Summary
- add a compatibility helper that inspects huggingface_hub.snapshot_download to check which optional keyword arguments are available
- pass optional download arguments only when the installed huggingface_hub version supports them to prevent TypeErrors during model downloads

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e40c38a4cc8330846bf9f8d92469eb