### PR TITLE
Fix faster-whisper backend download selection

### DIFF
--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -756,7 +756,7 @@ def ensure_download(
         _check_abort()
         if storage_backend == "transformers":
             snapshot_download(**download_kwargs)
-        elif storage_backend == "ct2":
+        elif storage_backend in {"ct2", "faster-whisper"}:
             snapshot_download(**download_kwargs)
         else:
             raise ValueError(f"Unknown backend: {backend_label}")


### PR DESCRIPTION
## Summary
- ensure the faster-whisper backend uses the same snapshot_download path as ctranslate2 so downloads are not rejected

## Testing
- python -m compileall src
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68e412fa7bb48330bb451c4ba5c025e7