### PR TITLE
Align ASR model installation paths with backend expectations

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -189,24 +189,24 @@ class AppCore:
             backend = self.asr_backend
             ct2_type = self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY)
 
-            cache_root = Path(cache_dir)
-            storage_backend = model_manager_module.backend_storage_name(backend)
-            model_path = cache_root / storage_backend / model_id
-
             start_loading = True
-            if not (model_path.is_dir() and any(model_path.iterdir())):
-                legacy_path = cache_root / str(backend) / model_id if backend else None
-                if legacy_path and legacy_path.is_dir() and any(legacy_path.iterdir()):
+            canonical_path = model_manager_module.get_installation_dir(cache_dir, backend, model_id)
+            existing_path = model_manager_module.find_existing_installation(cache_dir, backend, model_id)
+
+            if existing_path is None:
+                MODEL_LOGGER.warning(
+                    "ASR model not found locally; waiting for user confirmation before downloading.",
+                )
+                self.state_manager.set_state(sm.STATE_ERROR_MODEL)
+                self._prompt_model_install(model_id, backend, cache_dir, ct2_type)
+                start_loading = False
+            else:
+                if existing_path != canonical_path:
                     MODEL_LOGGER.info(
-                        "Found legacy model directory at %s; using it for backend %s.",
-                        legacy_path,
-                        backend or storage_backend,
+                        "Using legacy ASR model directory at %s for backend %s.",
+                        existing_path,
+                        backend or "unknown",
                     )
-                else:
-                    MODEL_LOGGER.warning("ASR model not found locally; waiting for user confirmation before downloading.")
-                    self.state_manager.set_state(sm.STATE_ERROR_MODEL)
-                    self._prompt_model_install(model_id, backend, cache_dir, ct2_type)
-                    start_loading = False
 
             if start_loading:
                 self._start_model_loading_with_synced_config()


### PR DESCRIPTION
## Summary
- centralize ASR model installation path resolution, migrating legacy layouts and ensuring downloads land in the curated directory tree
- update the core bootstrapper and transcription fallback logic to rely on the shared path helpers
- load ctranslate2 weights directly from the curated cache in the faster-whisper backend, avoiding redundant downloads

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e411f74edc8330ac2f85634a689177