### PR TITLE
Fix ASR model storage detection and cleanup

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -190,23 +190,21 @@ class AppCore:
             ct2_type = self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY)
 
             cache_root = Path(cache_dir)
-            storage_backend = model_manager_module.backend_storage_name(backend)
-            model_path = cache_root / storage_backend / model_id
 
             start_loading = True
-            if not (model_path.is_dir() and any(model_path.iterdir())):
-                legacy_path = cache_root / str(backend) / model_id if backend else None
-                if legacy_path and legacy_path.is_dir() and any(legacy_path.iterdir()):
-                    MODEL_LOGGER.info(
-                        "Found legacy model directory at %s; using it for backend %s.",
-                        legacy_path,
-                        backend or storage_backend,
-                    )
-                else:
-                    MODEL_LOGGER.warning("ASR model not found locally; waiting for user confirmation before downloading.")
-                    self.state_manager.set_state(sm.STATE_ERROR_MODEL)
-                    self._prompt_model_install(model_id, backend, cache_dir, ct2_type)
-                    start_loading = False
+            ready_path = model_manager_module.ensure_local_installation(
+                cache_root,
+                backend,
+                model_id,
+            )
+
+            if ready_path is None:
+                MODEL_LOGGER.warning(
+                    "ASR model not found locally; waiting for user confirmation before downloading.",
+                )
+                self.state_manager.set_state(sm.STATE_ERROR_MODEL)
+                self._prompt_model_install(model_id, backend, cache_dir, ct2_type)
+                start_loading = False
 
             if start_loading:
                 self._start_model_loading_with_synced_config()


### PR DESCRIPTION
## Summary
- ensure backend storage folders map to canonical locations and enumerate legacy candidates
- add reusable helpers to relocate or clean incomplete ASR installations before download
- simplify download preparation logic and reuse it from the core initialization path, plus harden snapshot kwarg detection

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e411f74edc8330ac2f85634a689177