### PR TITLE
Refine logging format and translate terminal messages

### DIFF
--- a/src/action_orchestrator.py
+++ b/src/action_orchestrator.py
@@ -101,7 +101,7 @@ class ActionOrchestrator:
             LOGGER.error("Transcription handler is not available to receive audio.")
             if agent_mode:
                 self._log_status(
-                    "Modo agente indisponível: aguarde o carregamento do modelo e tente novamente.",
+                    "Agent mode is unavailable while the model is loading. Please wait and try again.",
                     error=True,
                 )
             self._state_manager.set_state(
@@ -119,7 +119,7 @@ class ActionOrchestrator:
             if agent_mode:
                 self._agent_mode_active = True
                 self._log_status(
-                    "Falha ao engajar o modo agente. Verifique o carregamento do modelo e tente novamente.",
+                    "Agent mode activation failed. Ensure the model is loaded and try again.",
                     error=True,
                 )
             else:
@@ -135,7 +135,7 @@ class ActionOrchestrator:
                     "Agent mode request preserved: transcription handler rejected audio segment (model likely unavailable)."
                 )
                 self._log_status(
-                    "Modo agente indisponível: o modelo ainda não está pronto para receber comandos.",
+                    "Agent mode is unavailable: the model is not ready to receive commands.",
                     error=True,
                 )
             else:
@@ -190,16 +190,16 @@ class ActionOrchestrator:
 
         response = (agent_response_text or "").strip()
         if not response:
-            self._log_status("Comando do agente sem resposta.", error=True)
+            self._log_status("Agent command returned an empty response.", error=True)
             LOGGER.warning("Agent command returned an empty response.")
             return
 
         self._copy_to_clipboard(response)
 
         if self._config_manager.get("agent_auto_paste", True):
-            self._paste_and_log(success_message="Comando do agente executado e colado.")
+            self._paste_and_log(success_message="Agent command executed and pasted.")
         else:
-            self._log_status("Comando do agente executado (colagem automática desativada).")
+            self._log_status("Agent command executed (auto-paste disabled).")
 
         self._state_manager.set_state(
             sm.StateEvent.AGENT_COMMAND_COMPLETED,

--- a/src/keyboard_hotkey_manager.py
+++ b/src/keyboard_hotkey_manager.py
@@ -34,7 +34,7 @@ class KeyboardHotkeyManager:
         self._load_config()
 
     def _load_config(self):
-        """Carrega a configuração do arquivo, criando-o com valores padrão se não existir."""
+        """Load configuration from disk, creating the file with defaults when it is missing."""
         try:
             if not os.path.exists(self.config_file):
                 logging.warning(f"'{self.config_file}' not found. Creating it with default values.")
@@ -57,7 +57,7 @@ class KeyboardHotkeyManager:
             logging.error(f"An unexpected error occurred while loading hotkey config: {e}", exc_info=True)
 
     def _save_config(self):
-        """Salva a configuração no arquivo."""
+        """Persist the current hotkey configuration to disk."""
         try:
             config = {
                 'record_key': self.record_key,
@@ -69,19 +69,19 @@ class KeyboardHotkeyManager:
             logging.info("Configuration saved: record_key=%s, agent_key=%s, record_mode=%s",
                          self.record_key, self.agent_key, self.record_mode)
         except Exception as e:
-            logging.error(f"Erro ao salvar configuração: {e}")
+            logging.error(f"Failed to save hotkey configuration: {e}")
 
     def start(self):
         """Inicia o gerenciador de hotkeys."""
         if self.is_running:
-            logging.warning("KeyboardHotkeyManager já está em execução.")
+            logging.warning("KeyboardHotkeyManager is already running.")
             return True
 
         try:
             # Registrar as hotkeys e verificar o resultado
             success = self._register_hotkeys()
             if not success:
-                logging.error("Falha ao registrar hotkeys.")
+                logging.error("Failed to register hotkeys.")
                 self.stop()
                 return False
 
@@ -89,7 +89,7 @@ class KeyboardHotkeyManager:
             logging.info("KeyboardHotkeyManager started successfully.")
             return True
         except Exception as e:
-            logging.error(f"Erro ao iniciar KeyboardHotkeyManager: {e}", exc_info=True)
+            logging.error(f"Error starting KeyboardHotkeyManager: {e}", exc_info=True)
             self.stop()
             return False
 
@@ -132,17 +132,17 @@ class KeyboardHotkeyManager:
             if was_running:
                 result = self._register_hotkeys()
                 if not result:
-                    logging.error("Falha ao registrar hotkeys após atualização.")
+                    logging.error("Failed to register hotkeys after applying the update.")
                     self.is_running = False
                     return False
                 # Retomar o estado de execução se o registro foi bem-sucedido
                 self.is_running = True
 
-            logging.info(f"Configuração atualizada: record_key={self.record_key}, agent_key={self.agent_key}, record_mode={self.record_mode}")
+            logging.info(f"Configuration saved: record_key={self.record_key}, agent_key={self.agent_key}, record_mode={self.record_mode}")
             return True
 
         except Exception as e:
-            logging.error(f"Erro ao atualizar configuração: {e}")
+            logging.error(f"Failed to update hotkey configuration: {e}")
             return False
 
     def set_callbacks(self, toggle=None, start=None, stop=None, agent=None):
@@ -208,12 +208,12 @@ class KeyboardHotkeyManager:
                         )
                     except OSError as e:
                         logging.error(
-                            f"Falha específica ao registrar hotkey release: {e}"
+                            f"Specific failure while registering release hotkey: {e}"
                         )
                         return False
                     except Exception as e:
                         logging.error(
-                            f"Erro ao registrar hotkey release: {e}", exc_info=True
+                            f"Error while registering release hotkey: {e}", exc_info=True
                         )
                         return False
                     logging.info("Release handler registered for: %s", self.record_key)
@@ -231,12 +231,12 @@ class KeyboardHotkeyManager:
                 )
             except OSError as e:
                 logging.error(
-                    f"Falha específica ao registrar hotkey de gravação: {e}"
+                    f"Specific failure while registering record hotkey: {e}"
                 )
                 return False
             except Exception as e:
                 logging.error(
-                    f"Erro ao registrar hotkey de gravação: {e}", exc_info=True
+                    f"Failed to register record hotkey: {e}", exc_info=True
                 )
                 return False
             logging.info(
@@ -258,12 +258,12 @@ class KeyboardHotkeyManager:
                 )
             except OSError as e:
                 logging.error(
-                    f"Falha específica ao registrar hotkey de comando: {e}"
+                    f"Specific failure while registering agent hotkey: {e}"
                 )
                 return False
             except Exception as e:
                 logging.error(
-                    f"Erro ao registrar hotkey de comando: {e}", exc_info=True
+                    f"Error while registering agent hotkey: {e}", exc_info=True
                 )
                 return False
             logging.info(
@@ -275,7 +275,7 @@ class KeyboardHotkeyManager:
             return True
 
         except Exception as e:
-            logging.error(f"Erro ao registrar hotkeys: {e}", exc_info=True)
+            logging.error(f"Error registering hotkeys: {e}", exc_info=True)
             return False
 
     def _unregister_hotkeys(self):
@@ -293,7 +293,7 @@ class KeyboardHotkeyManager:
                         )
                     except Exception as e:
                         logging.error(
-                            "Erro ao remover hook '%s': %s",
+                            "Error while removing hook '%s': %s",
                             handle_id,
                             e,
                             exc_info=True,
@@ -309,43 +309,43 @@ class KeyboardHotkeyManager:
             self.is_running = False
 
         except Exception as e:
-            logging.error(f"Erro ao desregistrar hotkeys: {e}", exc_info=True)
+            logging.error(f"Error unregistering hotkeys: {e}", exc_info=True)
 
     def _on_toggle_key(self):
         """Handler para a tecla de toggle."""
         try:
             if self.callback_toggle:
                 threading.Thread(target=self.callback_toggle, daemon=True, name="ToggleCallback").start()
-                logging.info("Callback de toggle chamado.")
+                logging.info("Toggle callback invoked.")
         except Exception as e:
-            logging.error(f"Erro ao chamar callback de toggle: {e}", exc_info=True)
+            logging.error(f"Error while invoking toggle callback: {e}", exc_info=True)
 
     def _on_press_key(self):
         """Handler para a tecla de press."""
         try:
             if self.callback_start:
                 threading.Thread(target=self.callback_start, daemon=True, name="StartCallback").start()
-                logging.info("Callback de start chamado.")
+                logging.info("Start callback invoked.")
         except Exception as e:
-            logging.error(f"Erro ao chamar callback de start: {e}", exc_info=True)
+            logging.error(f"Error while invoking start callback: {e}", exc_info=True)
 
     def _on_agent_key(self):
-        """Handler para a tecla de comando agêntico."""
+        """Handler for the agent command hotkey."""
         try:
             if self.callback_agent:
                 threading.Thread(target=self.callback_agent, daemon=True, name="AgentCallback").start()
-                logging.info("Callback de comando chamado.")
+                logging.info("Agent callback invoked.")
         except Exception as e:
-            logging.error(f"Erro ao chamar callback de comando: {e}", exc_info=True)
+            logging.error(f"Error while invoking agent callback: {e}", exc_info=True)
 
     def _on_release_key(self):
         """Handler para o evento de soltar a tecla no modo press."""
         try:
             if self.callback_stop:
                 threading.Thread(target=self.callback_stop, daemon=True, name="StopCallback").start()
-                logging.info("Callback de stop chamado (release key).")
+                logging.info("Stop callback invoked (release key).")
         except Exception as e:
-            logging.error(f"Erro ao chamar callback de stop (release): {e}", exc_info=True)
+            logging.error(f"Error while invoking stop callback (release): {e}", exc_info=True)
 
     def restart(self):
         """Reinicia o gerenciador de hotkeys."""
@@ -360,7 +360,7 @@ class KeyboardHotkeyManager:
         if result:
             logging.info("KeyboardHotkeyManager restarted successfully.")
         else:
-            logging.error("Falha ao reiniciar KeyboardHotkeyManager.")
+            logging.error("Failed to restart KeyboardHotkeyManager.")
 
         return result
 
@@ -375,7 +375,7 @@ class KeyboardHotkeyManager:
             str: A tecla detectada ou None se nenhuma tecla for detectada
         """
         try:
-            logging.info(f"Iniciando detecção de tecla com timeout de {timeout} segundos...")
+            logging.info(f"Starting key detection with a timeout of {timeout} seconds...")
 
             # Variáveis para armazenar a tecla detectada
             detected_key = [None]
@@ -414,7 +414,7 @@ class KeyboardHotkeyManager:
                 keyboard.unhook(hook)
 
         except Exception as e:
-            logging.error(f"Erro ao detectar tecla: {e}", exc_info=True)
+            logging.error(f"Error while detecting key: {e}", exc_info=True)
             return None
 
     def detect_single_key(self, timeout=5.0):

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -26,16 +26,41 @@ def _determine_level() -> int:
     return getattr(logging, env_level, logging.INFO)
 
 
+class _StructuredLogFormatter(logging.Formatter):
+    """Formatter that produces explicit, copy-friendly log lines."""
+
+    default_time_format = "%Y-%m-%dT%H:%M:%S"
+    default_msec_format = "%s.%03d"
+
+    def format(self, record: logging.LogRecord) -> str:
+        timestamp = self.formatTime(record, self.datefmt)
+        level = record.levelname.upper()
+        name = record.name
+        message = super().format(record)
+
+        extras: list[str] = []
+        if record.processName:
+            extras.append(f"process={record.processName}")
+        if record.threadName and record.threadName != "MainThread":
+            extras.append(f"thread={record.threadName}")
+        if record.funcName:
+            extras.append(f"func={record.funcName}")
+
+        context = f" [{', '.join(extras)}]" if extras else ""
+
+        if "\n" in message:
+            head, *rest = message.splitlines()
+            body = "\n".join(f"    {line}" for line in rest)
+            message = head + ("\n" + body if body else "")
+
+        return f"{timestamp} | {level:<8} | {name}{context} | {message}"
+
+
 def setup_logging(*, extra_filters: Iterable[logging.Filter] | None = None) -> None:
-    """Configure root logging with a compact, copy-friendly format."""
+    """Configure root logging for deterministic, information-rich output."""
 
     handler = logging.StreamHandler()
-    handler.setFormatter(
-        logging.Formatter(
-            fmt="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-    )
+    handler.setFormatter(_StructuredLogFormatter())
 
     filters: list[logging.Filter] = [_StripAnsiFilter()]
     if extra_filters:
@@ -44,6 +69,7 @@ def setup_logging(*, extra_filters: Iterable[logging.Filter] | None = None) -> N
         handler.addFilter(filt)
 
     logging.basicConfig(level=_determine_level(), handlers=[handler], force=True)
+    logging.captureWarnings(True)
 
     for noisy_logger in ("google", "httpx", "urllib3", "asyncio"):
         logging.getLogger(noisy_logger).setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary
- replace the root logger configuration with a structured formatter that emits richer timestamped context while keeping ANSI stripping intact
- translate AppCore and KeyboardHotkeyManager runtime logs to English and expand the messaging to better describe error and recovery paths
- align agent orchestrator status updates with the English logging strategy for clearer operator feedback

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e411ebf1708330a3d8e8225f9d3295