### PR TITLE
Fix indentation bug in audio handler RAM fallback

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -218,14 +218,14 @@ class AudioHandler:
                                     thr_percent = 10
                                 percent_free = (avail_mb / total_mb * 100.0) if total_mb else 0.0
                                 if total_mb and percent_free < thr_percent:
-                                self._audio_log.info(
-                                    "Free RAM below configured threshold; moving buffers to disk.",
-                                    extra={
-                                        "event": "ram_to_disk_low_memory",
-                                        "stage": "storage_selection",
-                                        "details": f"percent_free={percent_free:.1f} threshold={thr_percent}",
-                                    },
-                                )
+                                    self._audio_log.info(
+                                        "Free RAM below configured threshold; moving buffers to disk.",
+                                        extra={
+                                            "event": "ram_to_disk_low_memory",
+                                            "stage": "storage_selection",
+                                            "details": f"percent_free={percent_free:.1f} threshold={thr_percent}",
+                                        },
+                                    )
                                     try:
                                         self._audio_log.info(
                                             "In-memory storage migration due to low available RAM.",


### PR DESCRIPTION
## Summary
- fix the mis-indented low-RAM migration log in the audio handler
- ensure the fallback migration to disk executes when RAM drops below the configured threshold

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e418e565b08330a47b1b29df968dd3