### PR TITLE
Improve startup preflight to guarantee first run success

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -66,7 +66,13 @@ StateUpdateCallback = Callable[[sm.StateNotification], None]
 
 
 class AppCore:
-    def __init__(self, main_tk_root):
+    def __init__(
+        self,
+        main_tk_root,
+        *,
+        config_manager: ConfigManager | None = None,
+        hotkey_config_path: str = "hotkey_config.json",
+    ):
         self.main_tk_root = main_tk_root # Referência para a raiz Tkinter
 
         # --- Locks ---
@@ -86,7 +92,7 @@ class AppCore:
         self.on_segment_transcribed = None # Callback para UI ao vivo
 
         # --- Módulos ---
-        self.config_manager = ConfigManager()
+        self.config_manager = config_manager or ConfigManager()
         self.state_manager = sm.StateManager(sm.STATE_LOADING_MODEL, main_tk_root)
         self._ui_manager = None  # Será setado externamente pelo main.py
         self._pending_tray_tooltips: list[str] = []
@@ -167,7 +173,7 @@ class AppCore:
             self.state_manager.subscribe(ui_manager_instance.update_tray_icon)
 
         # --- Hotkey Manager ---
-        self.ahk_manager = KeyboardHotkeyManager(config_file="hotkey_config.json")
+        self.ahk_manager = KeyboardHotkeyManager(config_file=hotkey_config_path)
         self.ahk_running = False
         self.last_key_press_time = 0.0
         self.reregister_timer_thread = None


### PR DESCRIPTION
## Summary
- add startup preflight checks that validate configuration, secrets, and hotkey artifacts before the UI starts and emit structured logs
- wrap the bootstrap flow in an exception handler to surface fatal errors while reusing a pre-created ConfigManager instance
- allow AppCore to accept injected configuration and hotkey paths so the preflight artifacts are the same ones used at runtime

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e4226e044483308a38378c32f2da29