### PR TITLE
Add configurable directories for ASR models and recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ During the initial startup the application will create `config.json` and `hotkey
 - From the settings window you can:
   - Configure the recording hotkey.
   - Select the ASR model. If a model is missing, the application offers to download it.
+  - Choose where Whisper models are cached and where on-disk recordings are stored.
   - Configure AI services, audio feedback sounds, and additional quality-of-life options.
 
 ### Recording and Transcribing

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -94,6 +94,7 @@ DEFAULT_CONFIG = {
         "gemini-2.5-pro"
     ],
     "save_temp_recordings": False,
+    "recordings_dir": str((Path.home() / "WhisperFlashTranscriber" / "recordings").expanduser()),
     "record_storage_mode": "auto",
     "record_storage_limit": 0,
     "max_memory_seconds_mode": "manual",
@@ -148,6 +149,7 @@ GPU_INDEX_CONFIG_KEY = "gpu_index"
 SAVE_TEMP_RECORDINGS_CONFIG_KEY = "save_temp_recordings"
 RECORD_STORAGE_MODE_CONFIG_KEY = "record_storage_mode"
 RECORD_STORAGE_LIMIT_CONFIG_KEY = "record_storage_limit"
+RECORDINGS_DIR_CONFIG_KEY = "recordings_dir"
 MAX_MEMORY_SECONDS_MODE_CONFIG_KEY = "max_memory_seconds_mode"
 DISPLAY_TRANSCRIPTS_KEY = "display_transcripts_in_terminal"
 USE_VAD_CONFIG_KEY = "use_vad"
@@ -356,6 +358,13 @@ class ConfigManager:
         cfg[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = bool(
             cfg.get(SAVE_TEMP_RECORDINGS_CONFIG_KEY, self.default_config[SAVE_TEMP_RECORDINGS_CONFIG_KEY])
         )
+        recordings_dir_value = cfg.get(RECORDINGS_DIR_CONFIG_KEY, self.default_config[RECORDINGS_DIR_CONFIG_KEY])
+        recordings_path = Path(str(recordings_dir_value)).expanduser()
+        try:
+            recordings_path.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:  # pragma: no cover - defensive path
+            logging.warning("Failed to create recordings directory '%s': %s", recordings_path, exc)
+        cfg[RECORDINGS_DIR_CONFIG_KEY] = str(recordings_path)
         cfg[LAUNCH_AT_STARTUP_CONFIG_KEY] = bool(
             cfg.get(LAUNCH_AT_STARTUP_CONFIG_KEY, self.default_config[LAUNCH_AT_STARTUP_CONFIG_KEY])
         )
@@ -1138,6 +1147,15 @@ class ConfigManager:
 
     def set_save_temp_recordings(self, value: bool):
         self.config[SAVE_TEMP_RECORDINGS_CONFIG_KEY] = bool(value)
+
+    def get_recordings_dir(self) -> str:
+        return self.config.get(
+            RECORDINGS_DIR_CONFIG_KEY,
+            self.default_config[RECORDINGS_DIR_CONFIG_KEY],
+        )
+
+    def set_recordings_dir(self, value: str) -> None:
+        self.config[RECORDINGS_DIR_CONFIG_KEY] = os.path.expanduser(str(value))
 
 
     def get_record_storage_mode(self):

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -98,6 +98,7 @@ class AppConfig(BaseModel):
     asr_dtype: str = "float16"
     asr_ct2_compute_type: str = "int8_float16"
     asr_ct2_cpu_threads: int | None = None
+    recordings_dir: str = str((Path.home() / "WhisperFlashTranscriber" / "recordings").expanduser())
     asr_cache_dir: str = str((Path.home() / ".cache" / "whisper_flash_transcriber" / "asr").expanduser())
     asr_installed_models: list[str] = Field(default_factory=list)
     asr_curated_catalog: list[str] = Field(default_factory=list)
@@ -221,14 +222,14 @@ class AppConfig(BaseModel):
             return coerced
         return [str(value)]
 
-    @field_validator("asr_cache_dir", mode="before")
+    @field_validator("recordings_dir", "asr_cache_dir", mode="before")
     @classmethod
     def _expand_cache_dir(cls, value: Any) -> str:
         if isinstance(value, str):
             return str(Path(value).expanduser())
         if isinstance(value, Path):
             return str(value.expanduser())
-        raise ValueError("asr_cache_dir must be a string or Path")
+        raise ValueError("Directory paths must be provided as string or Path objects")
 
     @field_validator("asr_installed_models", "asr_curated_catalog", mode="before")
     @classmethod

--- a/src/core.py
+++ b/src/core.py
@@ -44,6 +44,7 @@ from .config_manager import (
     TEXT_CORRECTION_ENABLED_CONFIG_KEY,
     TEXT_CORRECTION_SERVICE_CONFIG_KEY,
     OPENROUTER_TIMEOUT_CONFIG_KEY,
+    RECORDINGS_DIR_CONFIG_KEY,
     VAD_PRE_SPEECH_PADDING_MS_CONFIG_KEY,
     VAD_POST_SPEECH_PADDING_MS_CONFIG_KEY,
     AUTO_PASTE_MODIFIER_CONFIG_KEY,
@@ -1359,6 +1360,7 @@ class AppCore:
             "new_display_transcripts_in_terminal": "display_transcripts_in_terminal",
             "new_record_storage_mode": RECORD_STORAGE_MODE_CONFIG_KEY,
             "new_record_storage_limit": RECORD_STORAGE_LIMIT_CONFIG_KEY,
+            "new_recordings_dir": RECORDINGS_DIR_CONFIG_KEY,
             "new_launch_at_startup": LAUNCH_AT_STARTUP_CONFIG_KEY,
             "new_chunk_length_mode": "chunk_length_mode",
             "new_chunk_length_sec": "chunk_length_sec",
@@ -1456,6 +1458,7 @@ class AppCore:
             VAD_POST_SPEECH_PADDING_MS_CONFIG_KEY,
             RECORD_STORAGE_MODE_CONFIG_KEY,
             RECORD_STORAGE_LIMIT_CONFIG_KEY,
+            RECORDINGS_DIR_CONFIG_KEY,
             MIN_RECORDING_DURATION_CONFIG_KEY,
         }
         if audio_related_keys & changed_mapped_keys:


### PR DESCRIPTION
## Summary
- add a dedicated recordings directory setting to the configuration schema and manager
- wire audio handling to respect the configurable recordings folder for temporary and saved files
- expose folder pickers for ASR cache and recording storage in the settings UI and document the option

## Testing
- python -m compileall src
- pytest *(fails: missing optional dependency numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68e420ebeabc8330b1d6d90219ecf7e6