### PR TITLE
Fix missing requests import in OpenRouter API client

### DIFF
--- a/src/openrouter_api.py
+++ b/src/openrouter_api.py
@@ -5,6 +5,8 @@ import logging
 import time
 from typing import Optional
 
+import requests
+
 from .logging_utils import get_logger, log_context
 
 LOGGER = get_logger('whisper_flash_transcriber.openrouter', component='OpenRouterAPI')


### PR DESCRIPTION
## Summary
- import the `requests` dependency in `OpenRouterAPI` so HTTP calls no longer raise `NameError`

## Testing
- python -m compileall src/openrouter_api.py
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e4272a77e083308ac95776831d5332