### PR TITLE
Fix missing Mapping import in audio handler

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 import threading
 import time
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable, Iterable
 


### PR DESCRIPTION
## Summary
- import the Mapping ABC in the audio handler to avoid runtime NameError when processing audio logging context

## Testing
- python -m compileall src/audio_handler.py
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e4272a77e083308ac95776831d5332