### PR TITLE
Fix legacy ASR backend adapter imports

### DIFF
--- a/src/asr_backends.py
+++ b/src/asr_backends.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Protocol
+from typing import Any, Callable, Protocol
 
-from .asr.backends import make_backend as _make_asr_backend
+from .asr import make_backend as _make_asr_backend
 
 
 class ASRBackend(Protocol):
@@ -52,7 +52,7 @@ class DummyBackend:
         return {"text": ""}
 
 
-backend_registry: Dict[str, Callable[[Any], ASRBackend]] = {
+backend_registry: dict[str, Callable[[Any], ASRBackend]] = {
     "whisper": WhisperBackend,
     "dummy": DummyBackend,
 }


### PR DESCRIPTION
## Summary
- ensure the legacy ASR backend adapter imports the shared backend factory from the modern module
- tighten typing imports so the adapter module can be imported without runtime NameError

## Testing
- python -m compileall src
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e4274491288330b47867b9ee89f1a0