### PR TITLE
Fix missing OpenRouter API dependency import

### DIFF
--- a/src/openrouter_api.py
+++ b/src/openrouter_api.py
@@ -5,6 +5,8 @@ import logging
 import time
 from typing import Optional
 
+import requests
+
 from .logging_utils import get_logger, log_context
 
 LOGGER = get_logger('whisper_flash_transcriber.openrouter', component='OpenRouterAPI')


### PR DESCRIPTION
## Summary
- ensure the OpenRouter API client imports the `requests` package before making HTTP calls to avoid runtime failures

## Testing
- python -m compileall src
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e4274491288330b47867b9ee89f1a0