### PR TITLE
Fix missing Mapping import in audio handler

### DIFF
--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 import threading
 import time
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable, Iterable
 


### PR DESCRIPTION
## Summary
- import `Mapping` from `collections.abc` in the audio handler so the logger adapter can safely detect mapping-like detail payloads

## Testing
- python -m compileall src
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e4274491288330b47867b9ee89f1a0