### PR TITLE
feat: allow configuring model storage directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ During the initial startup the application will create `config.json` and `hotkey
 - From the settings window you can:
   - Configure the recording hotkey.
   - Select the ASR model. If a model is missing, the application offers to download it.
-  - Choose where large assets such as downloaded models and persisted recordings are stored.
+  - Fine-tune where the application stores heavyweight assets:
+    - Set a base storage root for cached data.
+    - Override the dedicated models directory and its derived ASR cache path.
+    - Choose a separate recordings folder for WAV artifacts.
   - Configure AI services, audio feedback sounds, and additional quality-of-life options.
 
 ### Recording and Transcribing

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -114,6 +114,7 @@ DEFAULT_CONFIG = {
     "enable_torch_compile": False,
     "launch_at_startup": False,
     "clear_gpu_cache": True,
+    "models_storage_dir": _DEFAULT_STORAGE_ROOT_DIR,
     "storage_root_dir": _DEFAULT_STORAGE_ROOT_DIR,
     "recordings_dir": _DEFAULT_RECORDINGS_DIR,
     "asr_model_id": "openai/whisper-large-v3-turbo",
@@ -570,7 +571,62 @@ class ConfigManager:
         )
         cfg[STORAGE_ROOT_DIR_CONFIG_KEY] = str(storage_root_path)
 
-        derived_asr_path = storage_root_path / "asr"
+        default_models_path = Path(
+            self.default_config.get(
+                MODELS_STORAGE_DIR_CONFIG_KEY,
+                self.default_config[STORAGE_ROOT_DIR_CONFIG_KEY],
+            )
+        ).expanduser()
+        derived_models_path = storage_root_path
+        models_defaults = {
+            _normalized_str(default_models_path),
+            _normalized_str(derived_models_path),
+        }
+        if previous_storage_root_path is not None:
+            models_defaults.add(_normalized_str(previous_storage_root_path))
+
+        models_override = False
+        if applied_updates and MODELS_STORAGE_DIR_CONFIG_KEY in applied_updates:
+            models_override = True
+        elif loaded_config and MODELS_STORAGE_DIR_CONFIG_KEY in loaded_config:
+            loaded_models_path = _normalized_str(
+                _coerce_path(
+                    loaded_config[MODELS_STORAGE_DIR_CONFIG_KEY],
+                    default=derived_models_path,
+                )
+            )
+            if loaded_models_path not in models_defaults:
+                models_override = True
+
+        models_raw = _source_value(
+            MODELS_STORAGE_DIR_CONFIG_KEY,
+            default=cfg.get(
+                MODELS_STORAGE_DIR_CONFIG_KEY,
+                self.default_config.get(
+                    MODELS_STORAGE_DIR_CONFIG_KEY,
+                    self.default_config[STORAGE_ROOT_DIR_CONFIG_KEY],
+                ),
+            ),
+        )
+        if models_override:
+            requested_models_path = _coerce_path(
+                models_raw,
+                default=derived_models_path,
+            )
+            models_storage_path = _ensure_directory(
+                requested_models_path,
+                fallback=derived_models_path,
+                description="models storage",
+            )
+        else:
+            models_storage_path = _ensure_directory(
+                derived_models_path,
+                fallback=default_models_path,
+                description="models storage",
+            )
+        cfg[MODELS_STORAGE_DIR_CONFIG_KEY] = str(models_storage_path)
+
+        derived_asr_path = models_storage_path / "asr"
         default_asr_path = Path(self.default_config[ASR_CACHE_DIR_CONFIG_KEY]).expanduser()
         asr_defaults = {
             _normalized_str(derived_asr_path),
@@ -1416,6 +1472,18 @@ class ConfigManager:
 
     def set_asr_ct2_compute_type(self, value: str):
         self.config[ASR_CT2_COMPUTE_TYPE_CONFIG_KEY] = str(value)
+
+    def get_models_storage_dir(self) -> str:
+        return self.config.get(
+            MODELS_STORAGE_DIR_CONFIG_KEY,
+            self.default_config.get(
+                MODELS_STORAGE_DIR_CONFIG_KEY,
+                self.default_config[STORAGE_ROOT_DIR_CONFIG_KEY],
+            ),
+        )
+
+    def set_models_storage_dir(self, value: str):
+        self.config[MODELS_STORAGE_DIR_CONFIG_KEY] = os.path.expanduser(str(value))
 
     def get_storage_root_dir(self) -> str:
         return self.config.get(

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -95,6 +95,7 @@ class AppConfig(BaseModel):
     enable_torch_compile: bool = False
     launch_at_startup: bool = False
     clear_gpu_cache: bool = True
+    models_storage_dir: str = str(_DEFAULT_STORAGE_ROOT)
     storage_root_dir: str = str(_DEFAULT_STORAGE_ROOT)
     recordings_dir: str = str((_DEFAULT_STORAGE_ROOT / "recordings").expanduser())
     asr_model_id: str = "openai/whisper-large-v3-turbo"
@@ -226,7 +227,13 @@ class AppConfig(BaseModel):
             return coerced
         return [str(value)]
 
-    @field_validator("storage_root_dir", "recordings_dir", "asr_cache_dir", mode="before")
+    @field_validator(
+        "storage_root_dir",
+        "models_storage_dir",
+        "recordings_dir",
+        "asr_cache_dir",
+        mode="before",
+    )
     @classmethod
     def _expand_cache_dir(cls, value: Any) -> str:
         if isinstance(value, str):

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -921,6 +921,22 @@ class UIManager:
             return
         storage_root_dir_to_apply = str(storage_root_path)
 
+        models_storage_dir_raw = models_storage_dir_var.get().strip() if models_storage_dir_var else ""
+        if not models_storage_dir_raw:
+            models_storage_path = storage_root_path
+        else:
+            try:
+                models_storage_path = Path(models_storage_dir_raw).expanduser()
+            except Exception as exc:
+                messagebox.showerror("Invalid Path", f"Models storage directory is invalid:\n{exc}", parent=settings_win)
+                return
+        try:
+            models_storage_path.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            messagebox.showerror("Invalid Path", f"Models storage directory is invalid:\n{exc}", parent=settings_win)
+            return
+        models_storage_dir_to_apply = str(models_storage_path)
+
         recordings_dir_raw = recordings_dir_var.get().strip() if recordings_dir_var else ""
         if not recordings_dir_raw:
             recordings_path = storage_root_path / "recordings"
@@ -936,34 +952,22 @@ class UIManager:
             messagebox.showerror("Invalid Path", f"Recordings directory is invalid:\n{exc}", parent=settings_win)
             return
         recordings_dir_to_apply = str(recordings_path)
-        asr_cache_dir_to_apply = asr_cache_dir_var.get() if asr_cache_dir_var else self.config_manager.get_asr_cache_dir()
 
+        asr_cache_dir_raw = asr_cache_dir_var.get().strip() if asr_cache_dir_var else ""
+        if not asr_cache_dir_raw:
+            asr_cache_path = models_storage_path / "asr"
+        else:
+            try:
+                asr_cache_path = Path(asr_cache_dir_raw).expanduser()
+            except Exception as exc:
+                messagebox.showerror("Invalid Path", f"ASR cache directory is invalid:\n{exc}", parent=settings_win)
+                return
         try:
-            Path(models_storage_dir_to_apply).mkdir(parents=True, exist_ok=True)
-        except Exception as exc:
-            messagebox.showerror("Invalid Path", f"Models storage directory is invalid:\n{exc}", parent=settings_win)
-            return
-
-        try:
-            Path(asr_cache_dir_to_apply).mkdir(parents=True, exist_ok=True)
+            asr_cache_path.mkdir(parents=True, exist_ok=True)
         except Exception as exc:
             messagebox.showerror("Invalid Path", f"ASR cache directory is invalid:\n{exc}", parent=settings_win)
             return
-
-        recordings_dir_to_apply = (
-            recordings_dir_var.get()
-            if recordings_dir_var
-            else self.config_manager.get_recordings_dir()
-        )
-        try:
-            Path(recordings_dir_to_apply).mkdir(parents=True, exist_ok=True)
-        except Exception as exc:
-            messagebox.showerror(
-                "Invalid Path",
-                f"Recording directory is invalid:\n{exc}",
-                parent=settings_win,
-            )
-            return
+        asr_cache_dir_to_apply = str(asr_cache_path)
 
         selected_device_str = asr_compute_device_var.get() if asr_compute_device_var else "Auto-select (Recommended)"
         gpu_index_to_apply = -1


### PR DESCRIPTION
## Summary
- add a dedicated models storage directory setting with schema validation and runtime normalization
- update the settings workflow and UI to derive the ASR cache from the configured models directory
- refresh the README to describe the new storage customization options

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e4271d91408330bb409b4f8ee1ee2e