### PR TITLE
Fix ASR settings directory handling and quantization metadata

### DIFF
--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -22,6 +22,32 @@ from .logging_utils import get_logger, log_context
 MODEL_LOGGER = get_logger("whisper_recorder.model", component="ModelManager")
 
 
+_CT2_KNOWN_QUANTIZATIONS: set[str] = {
+    "default",
+    "int8",
+    "int8_float16",
+    "int8_float32",
+    "int8_bfloat16",
+    "int16",
+    "float16",
+    "float32",
+}
+
+_CT2_QUANTIZATION_ALIASES: dict[str, str] = {
+    "auto": "default",
+    "fp16": "float16",
+    "half": "float16",
+    "fp32": "float32",
+    "full": "float32",
+    "int8float16": "int8_float16",
+    "int8_float_16": "int8_float16",
+    "int8float32": "int8_float32",
+    "int8_float_32": "int8_float32",
+    "int8bf16": "int8_bfloat16",
+    "int8_bf16": "int8_bfloat16",
+}
+
+
 @dataclass(frozen=True)
 class ModelDownloadResult:
     """Structured result for :func:`ensure_download`."""

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -938,11 +938,20 @@ class UIManager:
         recordings_dir_to_apply = str(recordings_path)
         asr_cache_dir_to_apply = asr_cache_dir_var.get() if asr_cache_dir_var else self.config_manager.get_asr_cache_dir()
 
+        models_storage_dir_raw = models_storage_dir_var.get().strip() if models_storage_dir_var else ""
+        if not models_storage_dir_raw:
+            models_storage_dir_raw = self.config_manager.get_models_storage_dir()
         try:
-            Path(models_storage_dir_to_apply).mkdir(parents=True, exist_ok=True)
+            models_storage_dir_path = Path(models_storage_dir_raw).expanduser()
         except Exception as exc:
             messagebox.showerror("Invalid Path", f"Models storage directory is invalid:\n{exc}", parent=settings_win)
             return
+        try:
+            models_storage_dir_path.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            messagebox.showerror("Invalid Path", f"Models storage directory is invalid:\n{exc}", parent=settings_win)
+            return
+        models_storage_dir_to_apply = str(models_storage_dir_path)
 
         try:
             Path(asr_cache_dir_to_apply).mkdir(parents=True, exist_ok=True)
@@ -1230,6 +1239,9 @@ class UIManager:
         asr_compute_device_var,
         asr_dtype_var,
         asr_ct2_compute_type_var,
+        models_storage_dir_var,
+        storage_root_dir_var,
+        recordings_dir_var,
         asr_cache_dir_var,
         ui_elements,
     ):
@@ -3038,6 +3050,9 @@ class UIManager:
             asr_compute_device_var=asr_compute_device_var,
             asr_dtype_var=asr_dtype_var,
             asr_ct2_compute_type_var=asr_ct2_compute_type_var,
+            models_storage_dir_var=models_storage_dir_var,
+            storage_root_dir_var=storage_root_dir_var,
+            recordings_dir_var=recordings_dir_var,
             asr_cache_dir_var=asr_cache_dir_var,
             ui_elements={},
         )


### PR DESCRIPTION
## Summary
- define the set of supported CTranslate2 quantizations and their aliases to avoid NameError when normalizing labels
- resolve and validate the models storage directory in the settings UI before use, and pass the related variables into the ASR builder helpers

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e42885fbe883309a3939e1c7925e89