### PR TITLE
feat: add configurable logging output format

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -47,6 +47,7 @@ from .config_manager import (
 
 from .utils.form_validation import safe_get_float, safe_get_int
 from .utils.tooltip import Tooltip
+from .logging_utils import get_log_directory
 
 # Importar get_available_devices_for_ui (pode ser movido para um utils ou ficar aqui)
 # Por enquanto, vamos assumir que está disponível globalmente ou será movido para cá.
@@ -381,7 +382,10 @@ class UIManager:
             logging.error("UIManager: falha ao abrir %s: %s", target, exc, exc_info=True)
 
     def open_logs_directory(self) -> None:
-        self._open_directory_from_tray(Path("logs"))
+        target = get_log_directory()
+        if target is None:
+            target = Path(os.getenv("WHISPER_LOG_DIR", "logs")).expanduser()
+        self._open_directory_from_tray(target)
 
     def open_docs_directory(self) -> None:
         self._open_directory_from_tray(Path("docs"))


### PR DESCRIPTION
## Summary
- add a JSON log formatter option selected via `WHISPER_LOG_FORMAT` alongside accessors for the active log destination
- expose the resolved log directory in the tray action so it follows custom log locations

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e437357e4483309ff21af3cd43ca9b