### PR TITLE
Fix logging utils missing initialization

### DIFF
--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -10,10 +10,12 @@ import threading
 import time
 import uuid
 from contextlib import contextmanager
+from datetime import datetime, timezone
 import contextvars
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Mapping
+from uuid import uuid4
 
 ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
@@ -445,6 +447,7 @@ def _build_rotating_file_handler(filters: Iterable[logging.Filter]) -> logging.H
 def setup_logging(*, extra_filters: Iterable[logging.Filter] | None = None) -> None:
     """Configure root logging with a structured, copy-friendly format."""
 
+    level = _determine_level()
     filters: list[logging.Filter] = [
         _StripAnsiFilter(),
         _RuntimeContextFilter(),


### PR DESCRIPTION
## Summary
- import the datetime helpers used to seed the logging session identifiers
- reuse the UUID helper instead of relying on an undefined symbol
- initialize the logging level inside `setup_logging` before configuring handlers

## Testing
- `python -m compileall src`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e43724672c8330a4bcbdc274da62a1