### PR TITLE
Ensure first-run profile artifacts are created safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,12 @@ Launch the application for the first time with:
 ```bash
 python src/main.py
 ```
-During the initial startup the application will create `config.json` and `hotkey_config.json` in the project root.
+During the initial startup the application will create the persistent profile under
+`~/.cache/whisper_flash_transcriber/` (or the directory pointed to by the
+`WHISPER_FLASH_PROFILE_DIR` environment variable). The preflight stage ensures that
+`config.json`, `secrets.json`, and `hotkey_config.json` exist inside that profile
+folder before continuing, so the bootstrap completes successfully even when the
+installation directory is read-only.
 
 ### Configuration
 

--- a/src/core.py
+++ b/src/core.py
@@ -53,6 +53,7 @@ from .config_manager import (
     VAD_PRE_SPEECH_PADDING_MS_CONFIG_KEY,
     VAD_POST_SPEECH_PADDING_MS_CONFIG_KEY,
     AUTO_PASTE_MODIFIER_CONFIG_KEY,
+    HOTKEY_CONFIG_FILE,
 )
 from .audio_handler import AudioHandler
 from .action_orchestrator import ActionOrchestrator
@@ -77,7 +78,7 @@ class AppCore:
         main_tk_root,
         *,
         config_manager: ConfigManager | None = None,
-        hotkey_config_path: str = "hotkey_config.json",
+        hotkey_config_path: str = HOTKEY_CONFIG_FILE,
     ):
         self.main_tk_root = main_tk_root # Referência para a raiz Tkinter
         self.hotkey_config_path = hotkey_config_path
@@ -180,7 +181,7 @@ class AppCore:
             self.state_manager.subscribe(ui_manager_instance.update_tray_icon)
 
         # --- Hotkey Manager ---
-        config_path = getattr(self, "hotkey_config_path", "hotkey_config.json")
+        config_path = getattr(self, "hotkey_config_path", HOTKEY_CONFIG_FILE)
         self.ahk_manager = KeyboardHotkeyManager(config_file=config_path)
         self.ahk_running = False
         self.last_key_press_time = 0.0
@@ -1132,7 +1133,7 @@ class AppCore:
                         self.ahk_manager.stop()
                         self.ahk_running = False
                         time.sleep(0.2)
-                    self.ahk_manager = KeyboardHotkeyManager(config_file="hotkey_config.json")
+                    self.ahk_manager = KeyboardHotkeyManager(config_file=HOTKEY_CONFIG_FILE)
                     LOGGER.info("KeyboardHotkeyManager reload completed successfully.")
                     break
                 except Exception as e:

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@ import atexit
 import importlib.util
 import json
 import os
+import shutil
 import sys
 import threading
 import tkinter as tk
@@ -14,11 +15,14 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 
-ICON_PATH = os.path.join(PROJECT_ROOT, "icon.ico")
-HOTKEY_CONFIG_PATH = Path(PROJECT_ROOT, "hotkey_config.json")
-
-
 import src.config_manager as config_module
+
+
+ICON_PATH = os.path.join(PROJECT_ROOT, "icon.ico")
+HOTKEY_CONFIG_PATH = Path(config_module.HOTKEY_CONFIG_FILE).expanduser()
+LEGACY_HOTKEY_CONFIG_PATHS = tuple(
+    Path(path).expanduser() for path in config_module.LEGACY_HOTKEY_LOCATIONS
+)
 
 from src.logging_utils import (
     StructuredMessage,
@@ -206,6 +210,54 @@ def _ensure_hotkey_payload(data: dict[str, object]) -> dict[str, object]:
     return updated
 
 
+def _maybe_migrate_hotkey_config(target: Path, candidates: tuple[Path, ...]) -> None:
+    if target.exists():
+        return
+    for candidate in candidates:
+        try:
+            if candidate.resolve() == target.resolve():
+                return
+        except Exception:
+            if str(candidate) == str(target):
+                return
+        if not candidate.exists():
+            continue
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            LOGGER.warning(
+                StructuredMessage(
+                    "Unable to prepare destination for hotkey configuration.",
+                    event="startup.hotkey_config_migration_failed",
+                    destination=str(target),
+                    error=str(exc),
+                )
+            )
+            return
+        try:
+            shutil.move(str(candidate), str(target))
+        except Exception as exc:
+            LOGGER.warning(
+                StructuredMessage(
+                    "Failed to migrate legacy hotkey configuration.",
+                    event="startup.hotkey_config_migration_failed",
+                    source=str(candidate),
+                    destination=str(target),
+                    error=str(exc),
+                )
+            )
+            return
+        LOGGER.info(
+            StructuredMessage(
+                "Hotkey configuration migrated to profile directory.",
+                event="startup.hotkey_config_migrated",
+                source=str(candidate),
+                destination=str(target),
+            )
+        )
+        return
+
+
 def _ensure_json_file(
     path: Path,
     payload: dict[str, object],
@@ -217,6 +269,7 @@ def _ensure_json_file(
 
     created = False
     try:
+        path.parent.mkdir(parents=True, exist_ok=True)
         if not path.exists():
             path.write_text(json.dumps(payload, indent=4), encoding="utf-8")
             created = True
@@ -264,6 +317,7 @@ def _ensure_hotkey_config(path: Path) -> bool:
 
     defaults: dict[str, object] = {"record_key": "f3", "agent_key": "f4", "record_mode": "toggle"}
     try:
+        path.parent.mkdir(parents=True, exist_ok=True)
         if not path.exists():
             path.write_text(json.dumps(defaults, indent=4), encoding="utf-8")
             return True
@@ -342,11 +396,20 @@ def run_startup_preflight(config_manager, *, hotkey_config_path: Path) -> None:
         raise RuntimeError(f"Configuration file missing after preflight: {config_path}")
 
     secrets_path = Path(config_module.SECRETS_FILE).resolve()
-    secrets_created = _ensure_json_file(secrets_path, {}, description="secrets")
+    secrets_payload = {
+        config_module.GEMINI_API_KEY_CONFIG_KEY: "",
+        config_module.OPENROUTER_API_KEY_CONFIG_KEY: "",
+    }
+    secrets_created = _ensure_json_file(
+        secrets_path,
+        secrets_payload,
+        description="secrets",
+    )
     _log_artifact_ready("Secrets", secrets_path, created=secrets_created)
     if not secrets_path.exists():
         raise RuntimeError(f"Secrets file missing after preflight: {secrets_path}")
 
+    _maybe_migrate_hotkey_config(hotkey_config_path, LEGACY_HOTKEY_CONFIG_PATHS)
     hotkey_created = _ensure_hotkey_config(hotkey_config_path)
     _log_artifact_ready("Hotkey configuration", hotkey_config_path, created=hotkey_created)
     if not hotkey_config_path.exists():


### PR DESCRIPTION
## Summary
- relocate configuration, secrets, and hotkey artifacts into the per-user profile directory with migration of legacy files
- harden startup preflight and hotkey manager to create parent directories and adopt existing configurations automatically
- document the new persistence location so first-run succeeds even from read-only installs

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e43755a8508330a45eb2f53440e25f