### PR TITLE
Handle absent parent window when showing toast notification

### DIFF
--- a/src/utils/toast.py
+++ b/src/utils/toast.py
@@ -28,11 +28,19 @@ class ToastNotification(BaseToplevel):
         self.duration = duration
 
         # Position the toast notification
-        self.master.update_idletasks()
-        master_width = self.master.winfo_width()
-        master_height = self.master.winfo_height()
-        master_x = self.master.winfo_x()
-        master_y = self.master.winfo_y()
+        parent = getattr(self, "master", None)
+        master_width = master_height = master_x = master_y = 0
+
+        if parent is not None:
+            try:
+                parent.update_idletasks()
+                master_width = parent.winfo_width()
+                master_height = parent.winfo_height()
+                master_x = parent.winfo_x()
+                master_y = parent.winfo_y()
+            except tk.TclError:
+                # Parent window might be destroyed or withdrawn; fall back
+                parent = None
 
         self.update_idletasks()
         width = self.winfo_width()
@@ -46,7 +54,7 @@ class ToastNotification(BaseToplevel):
 
         # If the master window has a meaningful geometry, anchor the toast
         # relative to it while clamping inside the visible screen area.
-        if master_width > 1 and master_height > 1:
+        if parent is not None and master_width > 1 and master_height > 1:
             x = master_x + master_width - width - 20
             y = master_y + master_height - height - 20
             x = max(0, min(x, screen_width - width))


### PR DESCRIPTION
## Summary
- guard toast notification positioning when no parent window is available so it falls back to screen coordinates instead of crashing

## Testing
- python -m compileall src/utils/toast.py
- pytest *(fails: missing optional dependency numpy in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4377f5e3c8330871df2a3d3b57504