### PR TITLE
Fix autostart registry creation on Windows

### DIFF
--- a/src/utils/autostart.py
+++ b/src/utils/autostart.py
@@ -1,6 +1,7 @@
+import logging
 import os
 import sys
-import logging
+from contextlib import suppress
 
 if os.name == "nt":
     import winreg
@@ -8,23 +9,36 @@ if os.name == "nt":
 RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
 APP_NAME = "WhisperTranscriber"
 
-def set_launch_at_startup(enable: bool, target: str | None = None, name: str = APP_NAME) -> None:
+def set_launch_at_startup(
+    enable: bool, target: str | None = None, name: str = APP_NAME
+) -> None:
     """Enable or disable launching the app at Windows startup."""
     if os.name != "nt":
         return
     if target is None:
         target = os.path.abspath(sys.argv[0])
+    access_rights = winreg.KEY_SET_VALUE | winreg.KEY_CREATE_SUB_KEY
+    key_handle = None
     try:
-        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY, 0, winreg.KEY_ALL_ACCESS) as key:
-            if enable:
-                winreg.SetValueEx(key, name, 0, winreg.REG_SZ, f'"{target}"')
-            else:
-                try:
-                    winreg.DeleteValue(key, name)
-                except FileNotFoundError:
-                    pass
-    except OSError as e:
-        logging.error(f"Failed to update autostart registry key: {e}")
+        try:
+            key_handle = winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER, RUN_KEY, 0, access_rights
+            )
+        except FileNotFoundError:
+            key_handle = winreg.CreateKeyEx(
+                winreg.HKEY_CURRENT_USER, RUN_KEY, 0, access_rights
+            )
+
+        if enable:
+            winreg.SetValueEx(key_handle, name, 0, winreg.REG_SZ, f'"{target}"')
+        else:
+            with suppress(FileNotFoundError):
+                winreg.DeleteValue(key_handle, name)
+    except OSError:
+        logging.exception("Failed to update autostart registry key.")
+    finally:
+        if key_handle is not None:
+            winreg.CloseKey(key_handle)
 
 
 def is_launch_at_startup_enabled(name: str = APP_NAME) -> bool:


### PR DESCRIPTION
## Summary
- ensure the Windows Run registry key is created when enabling autostart
- close registry handles safely and narrow permissions to the values we need

## Testing
- python -m compileall src
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68e4377f5e3c8330871df2a3d3b57504