### PR TITLE
Fix duration estimation for multi-dimensional audio chunks

### DIFF
--- a/src/action_orchestrator.py
+++ b/src/action_orchestrator.py
@@ -265,8 +265,17 @@ class ActionOrchestrator:
         array = np.asarray(audio_source)
         if array.size == 0:
             return 0.0
-        samples = array.shape[0]
-        return float(samples) / AUDIO_SAMPLE_RATE
+
+        if array.ndim <= 1:
+            samples = array.shape[0]
+        else:
+            meaningful_dims = [dim for dim in array.shape if dim > 1]
+            if meaningful_dims:
+                samples = max(meaningful_dims)
+            else:
+                samples = array.size
+
+        return float(samples) / float(AUDIO_SAMPLE_RATE)
 
     def _copy_to_clipboard(self, text: str) -> None:
         if not self._clipboard_module:


### PR DESCRIPTION
## Summary
- ensure ActionOrchestrator correctly infers sample counts for multidimensional numpy audio chunks
- guard against silent failures by falling back to the largest meaningful dimension when computing durations

## Testing
- python -m compileall src
- pytest *(fails: missing numpy dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4377f5e3c8330871df2a3d3b57504