### PR TITLE
Fix ASR cache directory handling in settings UI

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -968,10 +968,27 @@ class UIManager:
             return
         models_storage_dir_to_apply = str(models_storage_dir_path)
 
+        asr_cache_dir_raw = asr_cache_dir_var.get().strip() if asr_cache_dir_var else ""
+        if not asr_cache_dir_raw:
+            asr_cache_path = storage_root_path / "asr"
+        else:
+            try:
+                asr_cache_path = Path(asr_cache_dir_raw).expanduser()
+            except Exception as exc:
+                messagebox.showerror(
+                    "Invalid Path",
+                    f"ASR cache directory is invalid:\n{exc}",
+                    parent=settings_win,
+                )
+                return
         try:
-            Path(asr_cache_dir_to_apply).mkdir(parents=True, exist_ok=True)
+            asr_cache_path.mkdir(parents=True, exist_ok=True)
         except Exception as exc:
-            messagebox.showerror("Invalid Path", f"ASR cache directory is invalid:\n{exc}", parent=settings_win)
+            messagebox.showerror(
+                "Invalid Path",
+                f"ASR cache directory is invalid:\n{exc}",
+                parent=settings_win,
+            )
             return
         asr_cache_dir_to_apply = str(asr_cache_path)
 


### PR DESCRIPTION
## Summary
- ensure the settings dialog normalizes and validates the ASR cache directory before use so the Apply action no longer crashes when the field is empty or invalid

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4377f5e3c8330871df2a3d3b57504