### PR TITLE
Align models storage default in AppConfig

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -14,6 +14,7 @@ LOGGER = get_logger(__name__, component='ConfigSchema')
 
 
 _DEFAULT_STORAGE_ROOT = (Path.home() / ".cache" / "whisper_flash_transcriber").expanduser()
+_DEFAULT_MODELS_STORAGE_DIR = str((_DEFAULT_STORAGE_ROOT / "models").expanduser())
 
 
 class ASRDownloadStatus(BaseModel):
@@ -95,9 +96,8 @@ class AppConfig(BaseModel):
     enable_torch_compile: bool = False
     launch_at_startup: bool = False
     clear_gpu_cache: bool = True
-    models_storage_dir: str = str(_DEFAULT_STORAGE_ROOT)
+    models_storage_dir: str = _DEFAULT_MODELS_STORAGE_DIR
     storage_root_dir: str = str(_DEFAULT_STORAGE_ROOT)
-    models_storage_dir: str = str(_DEFAULT_STORAGE_ROOT)
     recordings_dir: str = str((_DEFAULT_STORAGE_ROOT / "recordings").expanduser())
     asr_model_id: str = "openai/whisper-large-v3-turbo"
     asr_backend: str = "ctranslate2"


### PR DESCRIPTION
## Summary
- ensure AppConfig uses the models storage subdirectory by default
- remove duplicate models_storage_dir declaration and keep storage_root_dir separate

## Testing
- python - <<'PY'
from src.config_schema import AppConfig
cfg = AppConfig()
print("models_storage_dir:", cfg.models_storage_dir)
print("storage_root_dir:", cfg.storage_root_dir)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e4468024988330bc0fbd3d1cd86496