### PR TITLE
Improve model download visibility and scheduling safety

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -28,6 +28,17 @@ class ASRDownloadStatus(BaseModel):
     backend: str = ""
     message: str = ""
     details: str = ""
+    target_dir: str = ""
+    bytes_downloaded: int | None = None
+    throughput_bps: float | None = None
+    duration_seconds: float | None = None
+    task_id: str | None = None
+
+
+class ASRDownloadHistoryEntry(ASRDownloadStatus):
+    """Historical record capturing metadata of a download attempt."""
+
+    pass
 
 
 class ASRPromptDecision(BaseModel):
@@ -90,6 +101,7 @@ class AppConfig(BaseModel):
     max_memory_seconds: float = Field(default=30.0, ge=0.0)
     min_free_ram_mb: int = Field(default=1000, ge=0)
     auto_ram_threshold_percent: int = Field(default=10, ge=1, le=50)
+    max_parallel_downloads: int = Field(default=1, ge=1, le=8)
     min_transcription_duration: float = Field(default=1.0, ge=0.0)
     chunk_length_sec: float = Field(default=30.0, ge=0.0)
     chunk_length_mode: str = "manual"
@@ -110,6 +122,7 @@ class AppConfig(BaseModel):
     asr_curated_catalog: list[str] = Field(default_factory=list)
     asr_curated_catalog_url: str = ""
     asr_last_download_status: ASRDownloadStatus = Field(default_factory=ASRDownloadStatus)
+    asr_download_history: list[ASRDownloadHistoryEntry] = Field(default_factory=list)
     asr_last_prompt_decision: ASRPromptDecision = Field(default_factory=ASRPromptDecision)
 
     @staticmethod

--- a/src/core.py
+++ b/src/core.py
@@ -61,6 +61,7 @@ from .transcription_handler import TranscriptionHandler
 from .keyboard_hotkey_manager import KeyboardHotkeyManager # Assumindo que está na raiz
 from .gemini_api import GeminiAPI # Adicionado para correção de texto
 from . import model_manager as model_manager_module
+from .model_download_controller import ModelDownloadController, DownloadTask
 from .logging_utils import (
     StructuredMessage,
     get_logger,
@@ -134,6 +135,15 @@ class AppCore:
             "DownloadCancelledError",
             Exception,
         )
+        max_parallel_downloads = self.config_manager.get_max_parallel_downloads()
+        self.model_download_controller = ModelDownloadController(
+            state_manager=self.state_manager,
+            config_manager=self.config_manager,
+            max_parallel_downloads=max_parallel_downloads,
+            on_task_finished=self._on_download_task_finished,
+        )
+        self._tracked_download_tasks: set[str] = set()
+        self._auto_reload_tasks: set[str] = set()
 
         # Sincronizar modelos ASR já presentes no disco no início da aplicação
         try:
@@ -203,7 +213,6 @@ class AppCore:
         # Carregar configurações iniciais
         self._apply_initial_config_to_core_attributes()
 
-        self._active_model_download_event: threading.Event | None = None
         self.model_download_timeout = self._resolve_model_download_timeout()
 
     def build_bootstrap_report(self) -> dict[str, Any]:
@@ -301,15 +310,12 @@ class AppCore:
                 )
                 if messagebox.askyesno("Model Download", prompt_text):
                     self.config_manager.record_model_prompt_decision("accept", model_id, backend)
-                    cancel_event = threading.Event()
-                    self._active_model_download_event = cancel_event
                     self._start_model_download(
                         model_id,
                         backend,
                         cache_dir,
                         ct2_type,
                         timeout=self.model_download_timeout,
-                        cancel_event=cancel_event,
                     )
                 else:
                     self.config_manager.record_model_prompt_decision("defer", model_id, backend)
@@ -331,109 +337,122 @@ class AppCore:
 
         self.main_tk_root.after(0, _ask_user)
 
-    def _record_download_status(
+    def schedule_model_download(
         self,
-        status: str,
         model_id: str,
         backend: str,
+        cache_dir: str,
+        quant: str | None,
         *,
-        message: str = "",
-        details: str = "",
-    ) -> None:
-        """Persist structured information about download attempts."""
+        auto_reload: bool = False,
+        timeout: float | None = None,
+    ) -> DownloadTask:
+        normalized_backend = model_manager_module.normalize_backend_label(backend)
+        task = self.model_download_controller.schedule_download(
+            model_id,
+            normalized_backend or backend,
+            cache_dir,
+            quant,
+            timeout=timeout if timeout is not None else self.model_download_timeout,
+        )
+        self._tracked_download_tasks.add(task.task_id)
+        if auto_reload:
+            self._auto_reload_tasks.add(task.task_id)
+        self.state_manager.set_state(
+            sm.StateEvent.MODEL_DOWNLOAD_STARTED,
+            details={
+                "message": f"Download scheduled for {model_id}",
+                "task_id": task.task_id,
+                "model_id": model_id,
+                "backend": normalized_backend,
+            },
+            source="model_download",
+        )
+        return task
 
-        config_manager = getattr(self, "config_manager", None)
-        if not config_manager:
-            return
-        try:
-            config_manager.record_model_download_status(
-                status=status,
-                model_id=model_id,
-                backend=backend,
-                message=message,
-                details=details,
+    def get_model_downloads_snapshot(self) -> dict:
+        return self.model_download_controller.snapshot()
+
+    def cancel_download_task(self, task_id: str) -> bool:
+        return self.model_download_controller.cancel(task_id)
+
+    def pause_download_task(self, task_id: str) -> bool:
+        return self.model_download_controller.pause(task_id)
+
+    def resume_download_task(self, task_id: str) -> DownloadTask | None:
+        task = self.model_download_controller.resume(task_id)
+        if task is not None:
+            self._tracked_download_tasks.add(task.task_id)
+        return task
+
+    def _on_download_task_finished(self, task: DownloadTask) -> None:
+        task_id = getattr(task, "task_id", None)
+        if task_id in self._tracked_download_tasks and task.status not in {"queued", "running"}:
+            self._tracked_download_tasks.discard(task_id)
+
+        if task_id in self._auto_reload_tasks:
+            should_reload = task.status in {"completed", "skipped"}
+            should_remove = task.status not in {"paused"}
+            if should_reload:
+                def _do_reload() -> None:
+                    try:
+                        self._refresh_installed_models("post_download", raise_errors=False)
+                    except Exception:
+                        LOGGER.warning("Failed to refresh models after download.", exc_info=True)
+                    try:
+                        self.transcription_handler.reload_asr()
+                    except Exception:
+                        LOGGER.error("Failed to reload ASR after download.", exc_info=True)
+
+                if self.main_tk_root is not None:
+                    self.main_tk_root.after(0, _do_reload)
+                else:
+                    _do_reload()
+            if should_remove:
+                self._auto_reload_tasks.discard(task_id)
+
+        message_details = {
+            "message": task.message,
+            "task_id": task.task_id,
+            "model_id": task.model_id,
+            "backend": task.backend,
+            "status": task.status,
+        }
+
+        if task.status == "error":
+            self.state_manager.set_state(
+                sm.StateEvent.MODEL_DOWNLOAD_FAILED,
+                details=message_details,
+                source="model_download",
             )
-        except Exception:  # pragma: no cover - persistence best effort
-            LOGGER.debug(
-                "Failed to persist download status for model %s (status=%s).",
-                model_id,
-                status,
-                exc_info=True,
+            if self.main_tk_root is not None:
+                self.main_tk_root.after(
+                    0,
+                    lambda msg=task.message: messagebox.showerror("Model", msg or "Model download failed."),
+                )
+        elif task.status in {"cancelled", "timed_out"}:
+            self.state_manager.set_state(
+                sm.StateEvent.MODEL_DOWNLOAD_CANCELLED,
+                details=message_details,
+                source="model_download",
             )
+            if self.main_tk_root is not None:
+                self.main_tk_root.after(
+                    0,
+                    lambda msg=task.message: messagebox.showinfo("Model", msg or "Model download cancelled."),
+                )
 
     def download_model_and_reload(self, model_id, backend, cache_dir, quant):
-        """
-        Handles the full model download and subsequent reload process.
-        This method is designed to be called from a background thread started by the UI.
-        It raises exceptions back to the caller thread.
-        """
-        cancel_event = threading.Event()
-        self._active_model_download_event = cancel_event
-        
-        try:
-            self.state_manager.set_state(sm.STATE_LOADING_MODEL)
-            self._record_download_status(
-                "in_progress",
-                model_id,
-                backend,
-                message="Model download started.",
-            )
+        """Compat wrapper that schedules a download and reload sequence."""
 
-            ensure_kwargs = {
-                "quant": quant,
-                "timeout": self.model_download_timeout,
-                "cancel_event": cancel_event,
-            }
-
-            result = self.model_manager.ensure_download(
-                model_id,
-                backend,
-                cache_dir,
-                **ensure_kwargs,
-            )
-
-            downloaded = bool(getattr(result, "downloaded", True))
-            result_path = getattr(result, "path", "")
-            status = "success" if downloaded else "skipped"
-            message = (
-                "Model download completed."
-                if downloaded
-                else "Model already present; download skipped."
-            )
-            self._record_download_status(
-                status,
-                model_id,
-                backend,
-                message=message,
-                details=result_path,
-            )
-
-            # If download was not cancelled and did not raise an error, reload
-            self._refresh_installed_models("post_download", raise_errors=False)
-            self.transcription_handler.reload_asr()
-
-        except self._download_cancelled_error as e:
-            LOGGER.info(f"Download was cancelled for model {model_id}: {e}")
-            self._record_download_status(
-                "cancelled",
-                model_id,
-                backend,
-                message=str(e) or "Model download cancelled.",
-            )
-            raise # Re-raise for the UI thread to handle
-        except Exception as e:
-            LOGGER.error(f"An error occurred during model download/reload for {model_id}: {e}", exc_info=True)
-            self.state_manager.set_state(sm.STATE_ERROR_MODEL)
-            self._record_download_status(
-                "error",
-                model_id,
-                backend,
-                message="Model download failed.",
-                details=str(e),
-            )
-            raise # Re-raise for the UI thread to handle
-        finally:
-            self._active_model_download_event = None
+        self.schedule_model_download(
+            model_id,
+            backend,
+            cache_dir,
+            quant,
+            auto_reload=True,
+            timeout=self.model_download_timeout,
+        )
 
     def _start_model_download(
         self,
@@ -445,115 +464,20 @@ class AppCore:
         timeout: float | None = None,
         cancel_event: threading.Event | None = None,
     ):
-        """Inicia o download do modelo em uma thread separada."""
+        """Agenda o download do modelo respeitando o controlador unificado."""
 
+        task = self.schedule_model_download(
+            model_id,
+            backend,
+            cache_dir,
+            ct2_type,
+            auto_reload=True,
+            timeout=timeout,
+        )
         if cancel_event is not None:
+            # Mantém compatibilidade com fluxos que esperam um Event.
             cancel_event.clear()
-
-        def _download():
-            try:
-                self.state_manager.set_state(sm.STATE_LOADING_MODEL)
-                self._record_download_status(
-                    "in_progress",
-                    model_id,
-                    backend,
-                    message="Model download started.",
-                )
-                ensure_kwargs = {
-                    "quant": ct2_type,
-                    "timeout": timeout,
-                    "cancel_event": cancel_event,
-                }
-                result = self.model_manager.ensure_download(
-                    model_id,
-                    backend,
-                    cache_dir,
-                    **ensure_kwargs,
-                )
-                downloaded = bool(getattr(result, "downloaded", True))
-                result_path = getattr(result, "path", "")
-                status = "success" if downloaded else "skipped"
-                message = (
-                    "Model download completed."
-                    if downloaded
-                    else "Model already present; download skipped."
-                )
-                self._record_download_status(
-                    status,
-                    model_id,
-                    backend,
-                    message=message,
-                    details=result_path,
-                )
-            except self._download_cancelled_error as cancel_exc:
-                by_user = bool(getattr(cancel_exc, "by_user", False))
-                timed_out = bool(getattr(cancel_exc, "timed_out", False))
-                reason = str(cancel_exc).strip()
-                if not reason:
-                    if timed_out:
-                        reason = "Model download timed out."
-                    elif by_user:
-                        reason = "Model download cancelled by user."
-                    else:
-                        reason = "Model download cancelled."
-                self._record_download_status(
-                    "cancelled",
-                    model_id,
-                    backend,
-                    message=reason,
-                )
-                context_flags = []
-                if by_user:
-                    context_flags.append("by_user=True")
-                if timed_out:
-                    context_flags.append("timed_out=True")
-                context_suffix = f" ({', '.join(context_flags)})" if context_flags else ""
-                MODEL_LOGGER.info(
-                    "Model download cancelled%s: backend=%s model_id=%s reason=%s",
-                    context_suffix,
-                    backend,
-                    model_id,
-                    reason,
-                )
-                self.state_manager.set_state(
-                    sm.StateEvent.MODEL_DOWNLOAD_CANCELLED,
-                    details=f"Download for '{model_id}' cancelled: {reason}",
-                    source="model_download",
-                )
-                self.main_tk_root.after(
-                    0,
-                    lambda msg=reason: messagebox.showinfo("Model", msg),
-                )
-                return
-            except OSError:
-                MODEL_LOGGER.error("Invalid cache directory during model download.", exc_info=True)
-                self._record_download_status(
-                    "error",
-                    model_id,
-                    backend,
-                    message="Invalid cache directory during model download.",
-                )
-                self.state_manager.set_state(sm.STATE_ERROR_MODEL)
-                self.main_tk_root.after(0, lambda: messagebox.showerror("Model", "Invalid cache directory. Check your settings."))
-            except Exception as exc:
-                MODEL_LOGGER.error(f"Model download failed: {exc}", exc_info=True)
-                self._record_download_status(
-                    "error",
-                    model_id,
-                    backend,
-                    message="Model download failed.",
-                    details=str(exc),
-                )
-                self.state_manager.set_state(sm.STATE_ERROR_MODEL)
-                self.main_tk_root.after(0, lambda exc=exc: messagebox.showerror("Model", f"Download failed: {exc}"))  # noqa: F821
-            else:
-                MODEL_LOGGER.info("Model download completed successfully.")
-                self.main_tk_root.after(0, self.transcription_handler.start_model_loading)
-            finally:
-                active_event = getattr(self, "_active_model_download_event", None)
-                if active_event is cancel_event:
-                    self._active_model_download_event = None
-        threading.Thread(target=_download, daemon=True, name="ModelDownloadThread").start()
+            self._tracked_download_tasks.add(task.task_id)
 
     def _start_model_loading_with_synced_config(self):
         """Start model loading after asserting the ConfigManager linkage.
@@ -588,10 +512,9 @@ class AppCore:
         handler.start_model_loading()
 
     def cancel_model_download(self) -> None:
-        """Solicita o cancelamento do download de modelo em andamento."""
-        event = getattr(self, "_active_model_download_event", None)
-        if event is not None:
-            event.set()
+        """Solicita o cancelamento de todos os downloads de modelo ativos."""
+        for task_id in list(self._tracked_download_tasks):
+            self.model_download_controller.cancel(task_id)
 
     def _apply_initial_config_to_core_attributes(self):
         # Mover a atribuição de self.record_key, self.record_mode, etc.
@@ -1533,6 +1456,7 @@ class AppCore:
             "new_chunk_length_mode": "chunk_length_mode",
             "new_chunk_length_sec": "chunk_length_sec",
             "new_enable_torch_compile": "enable_torch_compile",
+            "new_max_parallel_downloads": "max_parallel_downloads",
         }
 
         legacy_key_aliases = {
@@ -1613,6 +1537,17 @@ class AppCore:
         }
         reload_required = bool(changed_mapped_keys & reload_keys)
         launch_changed = LAUNCH_AT_STARTUP_CONFIG_KEY in changed_mapped_keys
+
+        if "max_parallel_downloads" in changed_mapped_keys:
+            try:
+                new_limit = self.config_manager.get_max_parallel_downloads()
+                self.model_download_controller.update_parallel_limit(new_limit)
+                LOGGER.info("Updated model download concurrency to %d", new_limit)
+            except Exception:
+                LOGGER.warning(
+                    "Failed to propagate max_parallel_downloads change to controller.",
+                    exc_info=True,
+                )
 
         self._apply_initial_config_to_core_attributes()
 
@@ -1742,6 +1677,17 @@ class AppCore:
 
         # Re-aplicar configurações aos atributos do AppCore
         self._apply_initial_config_to_core_attributes()
+
+        if key == "max_parallel_downloads":
+            try:
+                new_limit = self.config_manager.get_max_parallel_downloads()
+                self.model_download_controller.update_parallel_limit(new_limit)
+                LOGGER.info("Updated model download concurrency to %d", new_limit)
+            except Exception:
+                LOGGER.warning(
+                    "Failed to propagate max_parallel_downloads update via update_setting.",
+                    exc_info=True,
+                )
 
         if key == "launch_at_startup":
             from .utils.autostart import set_launch_at_startup

--- a/src/model_download_controller.py
+++ b/src/model_download_controller.py
@@ -1,0 +1,378 @@
+"""Download controller for orchestrating ASR model downloads."""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Optional
+
+from . import model_manager
+from . import state_manager as sm
+from .logging_utils import get_logger, log_context
+
+LOGGER = get_logger("whisper_flash_transcriber.model_download_controller", component="ModelDownloadController")
+
+
+@dataclass
+class DownloadTask:
+    """In-memory representation of a scheduled download."""
+
+    task_id: str
+    model_id: str
+    backend: str
+    cache_dir: str
+    quant: Optional[str]
+    timeout: Optional[float]
+    created_at: float = field(default_factory=time.time)
+    status: str = "queued"
+    stage: str = "queued"
+    message: str = ""
+    bytes_done: int = 0
+    bytes_total: int = 0
+    eta_seconds: Optional[float] = None
+    throughput_bps: Optional[float] = None
+    target_dir: Optional[str] = None
+    started_at: Optional[float] = None
+    finished_at: Optional[float] = None
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+    pause_requested: bool = False
+    metadata: Dict[str, object] = field(default_factory=dict)
+    result: Optional[model_manager.ModelDownloadResult] = None
+    error: Optional[BaseException] = None
+
+    def snapshot(self) -> dict:
+        percent = None
+        if self.bytes_total:
+            percent = min(100.0, (self.bytes_done / self.bytes_total) * 100.0)
+        return {
+            "task_id": self.task_id,
+            "model_id": self.model_id,
+            "backend": self.backend,
+            "status": self.status,
+            "stage": self.stage,
+            "message": self.message,
+            "bytes_done": self.bytes_done,
+            "bytes_total": self.bytes_total,
+            "percent": percent,
+            "eta_seconds": self.eta_seconds,
+            "throughput_bps": self.throughput_bps,
+            "target_dir": self.target_dir,
+            "created_at": self.created_at,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "metadata": dict(self.metadata),
+        }
+
+
+class ModelDownloadController:
+    """Coordinates model downloads with bounded concurrency and observability."""
+
+    def __init__(
+        self,
+        *,
+        state_manager: sm.StateManager,
+        config_manager,
+        max_parallel_downloads: int = 1,
+        on_task_finished: Optional[Callable[[DownloadTask], None]] = None,
+    ) -> None:
+        self._state_manager = state_manager
+        self._config_manager = config_manager
+        self._on_task_finished = on_task_finished
+        self._lock = threading.RLock()
+        self._tasks: Dict[str, DownloadTask] = {}
+        self._task_order: list[str] = []
+        self._futures: Dict[str, Future] = {}
+        self._max_parallel = max(1, int(max_parallel_downloads))
+        # Allow bursting up to schema limits while constraining via semaphore.
+        self._executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="ModelDownload")
+        self._semaphore = threading.Semaphore(self._max_parallel)
+
+    def shutdown(self) -> None:
+        with self._lock:
+            for task in self._tasks.values():
+                task.cancel_event.set()
+            self._executor.shutdown(wait=False, cancel_futures=True)
+
+    def update_parallel_limit(self, new_limit: int) -> None:
+        normalized = max(1, int(new_limit))
+        with self._lock:
+            if normalized == self._max_parallel:
+                return
+            delta = normalized - self._max_parallel
+            if delta > 0:
+                for _ in range(delta):
+                    self._semaphore.release()
+            else:
+                for _ in range(-delta):
+                    try:
+                        self._semaphore.acquire(blocking=False)
+                    except Exception:
+                        # Semaphore already at zero available permits; rely on
+                        # running tasks to release naturally.
+                        break
+            self._max_parallel = normalized
+
+    def schedule_download(
+        self,
+        model_id: str,
+        backend: str,
+        cache_dir: str,
+        quant: Optional[str],
+        *,
+        timeout: Optional[float] = None,
+    ) -> DownloadTask:
+        task = DownloadTask(
+            task_id=uuid.uuid4().hex,
+            model_id=model_id,
+            backend=backend,
+            cache_dir=cache_dir,
+            quant=quant,
+            timeout=timeout,
+        )
+        with self._lock:
+            self._tasks[task.task_id] = task
+            self._task_order.append(task.task_id)
+            self._publish(task, message="Queued")
+            future = self._executor.submit(self._task_wrapper, task.task_id)
+            self._futures[task.task_id] = future
+        return task
+
+    def cancel(self, task_id: str, *, by_user: bool = True) -> bool:
+        with self._lock:
+            task = self._tasks.get(task_id)
+        if not task:
+            return False
+        task.pause_requested = False
+        task.cancel_event.set()
+        task.message = "Cancellation requested by user" if by_user else "Cancellation requested"
+        task.status = "cancelling"
+        self._publish(task)
+        return True
+
+    def pause(self, task_id: str) -> bool:
+        with self._lock:
+            task = self._tasks.get(task_id)
+        if not task:
+            return False
+        task.pause_requested = True
+        task.cancel_event.set()
+        task.message = "Pause requested"
+        task.status = "pausing"
+        self._publish(task)
+        return True
+
+    def resume(self, task_id: str) -> Optional[DownloadTask]:
+        with self._lock:
+            task = self._tasks.get(task_id)
+        if not task:
+            return None
+        if task.status not in {"paused", "cancelled"}:
+            return task
+        task.pause_requested = False
+        task.cancel_event = threading.Event()
+        task.status = "queued"
+        task.stage = "queued"
+        task.bytes_done = 0
+        task.bytes_total = 0
+        task.started_at = None
+        task.finished_at = None
+        task.message = "Rescheduled"
+        self._publish(task)
+        future = self._executor.submit(self._task_wrapper, task.task_id)
+        with self._lock:
+            self._futures[task.task_id] = future
+        return task
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            ordered = [self._tasks[tid].snapshot() for tid in self._task_order if tid in self._tasks]
+        return {"tasks": ordered, "max_parallel_downloads": self._max_parallel}
+
+    def _task_wrapper(self, task_id: str) -> None:
+        acquired = False
+        try:
+            acquired = self._semaphore.acquire(timeout=None)
+            if not acquired:
+                return
+            self._run_task(task_id)
+        finally:
+            if acquired:
+                self._semaphore.release()
+
+    def _run_task(self, task_id: str) -> None:
+        with self._lock:
+            task = self._tasks.get(task_id)
+        if task is None:
+            return
+        task.status = "running"
+        task.stage = "starting"
+        task.started_at = time.time()
+        task.cancel_event.clear()
+        self._publish(task, message="Starting download")
+
+        def _on_progress(bytes_done: int, bytes_total: int) -> None:
+            if bytes_total > 0:
+                task.bytes_total = max(task.bytes_total, bytes_total)
+            task.bytes_done = max(task.bytes_done, bytes_done)
+            now = time.time()
+            if task.started_at and task.bytes_done:
+                elapsed = now - task.started_at
+                if elapsed > 0:
+                    task.throughput_bps = task.bytes_done / elapsed
+                    remaining = max(task.bytes_total - task.bytes_done, 0)
+                    task.eta_seconds = remaining / task.throughput_bps if task.throughput_bps else None
+            self._publish(task)
+
+        def _on_stage(stage_id: str, metadata: dict) -> None:
+            task.stage = stage_id
+            task.metadata.update(metadata or {})
+            message = metadata.get("message") if isinstance(metadata, dict) else None
+            if stage_id == "size_estimated" and isinstance(metadata, dict):
+                estimated_bytes = int(metadata.get("estimated_bytes") or 0)
+                if estimated_bytes:
+                    task.bytes_total = estimated_bytes
+            if stage_id == "download_start":
+                task.target_dir = metadata.get("path")
+            if stage_id == "success":
+                if metadata.get("bytes_downloaded"):
+                    task.bytes_done = int(metadata.get("bytes_downloaded"))
+                    task.bytes_total = max(task.bytes_total, task.bytes_done)
+                throughput = metadata.get("throughput_bps")
+                if isinstance(throughput, (float, int)):
+                    task.throughput_bps = float(throughput)
+            if message:
+                task.message = str(message)
+            self._publish(task)
+
+        try:
+            result = model_manager.ensure_download(
+                task.model_id,
+                task.backend,
+                task.cache_dir,
+                task.quant,
+                timeout=task.timeout,
+                cancel_event=task.cancel_event,
+                on_progress=_on_progress,
+                on_stage_change=_on_stage,
+            )
+        except model_manager.DownloadCancelledError as exc:
+            task.finished_at = time.time()
+            task.error = exc
+            by_user = getattr(exc, "by_user", False)
+            timed_out = getattr(exc, "timed_out", False)
+            if task.pause_requested and not timed_out:
+                task.status = "paused"
+                task.message = "Download paused"
+            else:
+                task.status = "cancelled" if by_user or not timed_out else "timed_out"
+                task.message = str(exc) or ("Timed out" if timed_out else "Cancelled")
+            self._publish(task)
+            self._finalize(task)
+            return
+        except Exception as exc:  # pragma: no cover - defensive
+            task.finished_at = time.time()
+            task.status = "error"
+            task.error = exc
+            task.message = str(exc)
+            self._publish(task)
+            self._finalize(task)
+            return
+
+        task.finished_at = time.time()
+        task.result = result
+        task.status = "skipped" if not result.downloaded else "completed"
+        task.message = "Model already present" if task.status == "skipped" else "Download finished"
+        if result.target_dir:
+            task.target_dir = result.target_dir
+        if result.bytes_downloaded:
+            task.bytes_done = int(result.bytes_downloaded)
+            task.bytes_total = max(task.bytes_total, task.bytes_done)
+        if result.duration_seconds and result.bytes_downloaded:
+            duration = max(result.duration_seconds, 1e-6)
+            task.throughput_bps = result.bytes_downloaded / duration
+        self._publish(task)
+        self._finalize(task)
+
+    def _publish(self, task: DownloadTask, message: Optional[str] = None) -> None:
+        if message:
+            task.message = message
+        with self._lock:
+            details = task.snapshot()
+            try:
+                queue_position = self._task_order.index(task.task_id)
+            except ValueError:
+                queue_position = None
+            details["queue_position"] = queue_position
+            tasks_snapshot = [
+                self._tasks[tid].snapshot()
+                for tid in self._task_order
+                if tid in self._tasks
+            ]
+        self._state_manager.set_state(
+            sm.StateEvent.MODEL_DOWNLOAD_PROGRESS,
+            details={
+                **details,
+                "message": task.message,
+                "tasks": tasks_snapshot,
+            },
+            source="model_download",
+        )
+
+    def _finalize(self, task: DownloadTask) -> None:
+        if self._on_task_finished:
+            try:
+                self._on_task_finished(task)
+            except Exception:  # pragma: no cover - observer safety
+                LOGGER.debug("Task finished callback failed for %s", task.task_id, exc_info=True)
+
+        bytes_downloaded = None
+        throughput = None
+        target_dir = task.target_dir
+        duration_seconds = None
+        if task.result and task.result.bytes_downloaded is not None:
+            bytes_downloaded = int(task.result.bytes_downloaded)
+            target_dir = task.result.target_dir or target_dir
+            if task.result.duration_seconds:
+                duration = max(task.result.duration_seconds, 1e-6)
+                throughput = bytes_downloaded / duration
+                duration_seconds = float(task.result.duration_seconds)
+        elif task.bytes_done:
+            bytes_downloaded = task.bytes_done
+            throughput = task.throughput_bps
+        if duration_seconds is None and task.started_at and task.finished_at:
+            duration_seconds = max(task.finished_at - task.started_at, 0.0)
+        status_value = task.status
+        if status_value == "completed":
+            status_value = "success"
+        elif status_value == "timed_out":
+            status_value = "timeout"
+        try:
+            self._config_manager.record_model_download_status(
+                status=status_value,
+                model_id=task.model_id,
+                backend=task.backend,
+                message=task.message,
+                details=target_dir or "",
+                target_dir=target_dir,
+                bytes_downloaded=bytes_downloaded,
+                throughput_bytes_per_sec=throughput,
+                duration_seconds=duration_seconds,
+                task_id=task.task_id,
+            )
+        except Exception:  # pragma: no cover - persistence best effort
+            LOGGER.debug(
+                "Failed to persist download status for task %s", task.task_id, exc_info=True
+            )
+        LOGGER.info(
+            log_context(
+                "Model download task finalized.",
+                event="model.download_controller.task_finalized",
+                task_id=task.task_id,
+                status=task.status,
+                model=task.model_id,
+                backend=task.backend,
+            )
+        )


### PR DESCRIPTION
## Summary
- persist detailed model download history alongside the existing last-status metadata
- propagate max_parallel_downloads updates through AppCore and enrich controller metrics with duration and task identifiers
- extend the downloads UI with a history panel and duplicate scheduling safeguards for curated model queues

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e4ef87c5448330bafa0109e58add23