### PR TITLE
Handle legacy hold record mode

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -362,9 +362,21 @@ def coerce_with_defaults(payload: dict[str, Any], defaults: dict[str, Any]) -> t
     Returns the sanitized configuration dictionary and a list of warning
     messages produced while coercing invalid fields back to their defaults.
     """
-
-    merged = {**defaults, **payload}
+    normalized_payload = dict(payload)
     warnings: list[str] = []
+
+    record_mode_value = normalized_payload.get("record_mode")
+    if isinstance(record_mode_value, str) and record_mode_value.strip().lower() == "hold":
+        warnings.append("Legacy record_mode 'hold' mapped to 'press'.")
+        LOGGER.info(
+            log_context(
+                "Mapping legacy record_mode 'hold' to 'press'.",
+                event="config.legacy_record_mode_mapped",
+            )
+        )
+        normalized_payload["record_mode"] = "press"
+
+    merged = {**defaults, **normalized_payload}
 
     while True:
         try:


### PR DESCRIPTION
## Summary
- map legacy `record_mode` value "hold" to "press" during schema coercion
- log the migration so existing configurations keep press semantics without resetting to toggle

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e5002588a88330aa0fd54fbd24ae36