### PR TITLE
Fix backend sync after model selection

### DIFF
--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -2247,6 +2247,7 @@ class UIManager:
                 runtime_catalog.append(baseline)
         runtime_by_id = {entry["id"]: entry for entry in runtime_catalog}
         ui_elements["catalog"] = runtime_catalog
+        self._set_settings_meta("catalog", runtime_catalog)
 
         try:
             installed_models = model_manager.list_installed(asr_cache_dir_var.get())
@@ -2370,6 +2371,7 @@ class UIManager:
             except Exception:
                 pass
             self._on_model_change(display_value)
+            self._update_install_button_state()
 
         recommended_entries = [
             entry for entry in runtime_catalog if entry.get("ui_group") == "recommended"


### PR DESCRIPTION
## Summary
- persist the runtime model catalog metadata so backend lookups succeed for non-installed models
- refresh the install button state immediately after selecting a model to mirror backend changes

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e5021e67348330895c5b8f6ebb2467