### PR TITLE
Fix missing UI language config import

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -58,6 +58,7 @@ from .config_manager import (
     VAD_PRE_SPEECH_PADDING_MS_CONFIG_KEY,
     VAD_POST_SPEECH_PADDING_MS_CONFIG_KEY,
     AUTO_PASTE_MODIFIER_CONFIG_KEY,
+    UI_LANGUAGE_CONFIG_KEY,
     HOTKEY_CONFIG_FILE,
 )
 from .audio_handler import AudioHandler


### PR DESCRIPTION
## Summary
- import `UI_LANGUAGE_CONFIG_KEY` in `AppCore` to keep settings synchronization from raising a NameError

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e502051ca4833090ada1047c12224e