### PR TITLE
Align dependency directory defaults in config schema

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -24,6 +24,11 @@ LOGGER = get_logger(__name__, component='ConfigSchema')
 
 _DEFAULT_STORAGE_ROOT = (Path.home() / ".cache" / "whisper_flash_transcriber").expanduser()
 _DEFAULT_MODELS_STORAGE_DIR = str((_DEFAULT_STORAGE_ROOT / "models").expanduser())
+_DEFAULT_DEPS_INSTALL_DIR = str((_DEFAULT_STORAGE_ROOT / "deps").expanduser())
+_DEFAULT_HF_HOME_DIR = str((Path(_DEFAULT_DEPS_INSTALL_DIR) / "huggingface").expanduser())
+_DEFAULT_TRANSFORMERS_CACHE_DIR = str(
+    (Path(_DEFAULT_DEPS_INSTALL_DIR) / "transformers").expanduser()
+)
 _SUPPORTED_UI_LANGUAGE_MAP = {
     "en": "en-US",
     "en-us": "en-US",
@@ -136,9 +141,9 @@ class AppConfig(BaseModel):
     launch_at_startup: bool = False
     clear_gpu_cache: bool = True
     models_storage_dir: str = _DEFAULT_MODELS_STORAGE_DIR
-    deps_install_dir: str = _DEFAULT_DEPS_STORAGE_DIR
-    hf_home_dir: str = str((Path(_DEFAULT_DEPS_STORAGE_DIR) / "huggingface").expanduser())
-    transformers_cache_dir: str = str((Path(_DEFAULT_DEPS_STORAGE_DIR) / "transformers").expanduser())
+    deps_install_dir: str = _DEFAULT_DEPS_INSTALL_DIR
+    hf_home_dir: str = _DEFAULT_HF_HOME_DIR
+    transformers_cache_dir: str = _DEFAULT_TRANSFORMERS_CACHE_DIR
     storage_root_dir: str = str(_DEFAULT_STORAGE_ROOT)
     recordings_dir: str = str((_DEFAULT_STORAGE_ROOT / "recordings").expanduser())
     asr_model_id: str = "distil-whisper/distil-large-v3"


### PR DESCRIPTION
## Summary
- declare dependency installation and cache directories in `config_schema` mirroring `ConfigManager`
- update `AppConfig` defaults to reference the new constants for dependency, Hugging Face, and transformers cache paths

## Testing
- python -m compileall src/config_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68e50470089883308a3158d53e52d9dd