### PR TITLE
Fix missing imports in model_manager

### DIFF
--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -10,10 +10,11 @@ import os
 import shutil
 import time
 from dataclasses import dataclass
+from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path, PurePosixPath
 from threading import Event, RLock
-from typing import Any, Dict, List, NamedTuple
+from typing import Any, Dict, List, NamedTuple, Optional
 
 from huggingface_hub import HfApi, scan_cache_dir, snapshot_download
 


### PR DESCRIPTION
## Summary
- add the missing `contextmanager` import used by the temporary environment helper
- expand the typing import list to include `Optional`

## Testing
- python -m compileall src/model_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e504730af08330bb9b55cd746da3e5