### PR TITLE
Import ModelDownloadController into core

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -65,6 +65,7 @@ from .action_orchestrator import ActionOrchestrator
 from .transcription_handler import TranscriptionHandler
 from .keyboard_hotkey_manager import KeyboardHotkeyManager # Assumindo que está na raiz
 from .gemini_api import GeminiAPI # Adicionado para correção de texto
+from .model_download_controller import ModelDownloadController
 from . import model_manager as model_manager_module
 from .onboarding.first_run_wizard import (
     DownloadProgressPanel,


### PR DESCRIPTION
## Summary
- add the missing `ModelDownloadController` import to `src/core.py`
- keep the local import grouping consistent with other core dependencies

## Testing
- python -m compileall src/core.py

------
https://chatgpt.com/codex/tasks/task_e_68e5047571f48330b79e709f238be638