### PR TITLE
Add streaming segment support for CT2 backend

### DIFF
--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -1691,11 +1691,58 @@ class TranscriptionHandler:
                 agent_mode=agent_mode,
             )
             try:
-                result = self._asr_backend.transcribe(
-                    audio_source,
-                    chunk_length_s=float(self.chunk_length_sec),
-                    batch_size=dynamic_batch_size,
-                )
+                if (
+                    (self.backend_resolved or "").lower() == "ctranslate2"
+                    and hasattr(self._asr_backend, "stream_transcribe")
+                ):
+                    streamed_segments: list[dict[str, Any]] = []
+
+                    def _handle_stream_segment(
+                        text: str,
+                        *,
+                        metadata: dict[str, Any] | None = None,
+                        is_final: bool = False,
+                    ) -> None:
+                        record = dict(metadata or {})
+                        if "text" not in record:
+                            record["text"] = text
+                        record["is_final"] = bool(is_final)
+                        streamed_segments.append(record)
+                        self._log_model_event(
+                            "transcription_segment",
+                            segment_index=len(streamed_segments) - 1,
+                            start=record.get("start"),
+                            end=record.get("end"),
+                            text_chars=len((record.get("text") or "")),
+                            is_final=record.get("is_final", False),
+                            agent_mode=agent_mode,
+                        )
+                        if self.on_segment_transcribed_callback:
+                            try:
+                                self.on_segment_transcribed_callback(
+                                    text,
+                                    metadata=metadata,
+                                    is_final=is_final,
+                                )
+                            except TypeError:
+                                self.on_segment_transcribed_callback(text)
+
+                    aggregated_text, metadata_list = self._asr_backend.stream_transcribe(
+                        audio_source,
+                        chunk_length_s=float(self.chunk_length_sec),
+                        batch_size=dynamic_batch_size,
+                        on_segment=_handle_stream_segment,
+                        cancel_event=self.transcription_cancel_event,
+                    )
+                    if metadata_list:
+                        streamed_segments = metadata_list
+                    result = {"text": aggregated_text, "segments": streamed_segments}
+                else:
+                    result = self._asr_backend.transcribe(
+                        audio_source,
+                        chunk_length_s=float(self.chunk_length_sec),
+                        batch_size=dynamic_batch_size,
+                    )
             except Exception as transcribe_error:
                 duration_ms = (time.perf_counter() - start_ts) * 1000.0
                 self._log_model_event(
@@ -2013,7 +2060,13 @@ class TranscriptionHandler:
         ):
             logging.warning(f"Segment processed without meaningful text or with error: {text_result}")
             if text_result and self.on_segment_transcribed_callback:
-                self.on_segment_transcribed_callback(text_result or "")
+                try:
+                    self.on_segment_transcribed_callback(
+                        text_result or "",
+                        is_final=True,
+                    )
+                except TypeError:
+                    self.on_segment_transcribed_callback(text_result or "")
             if (
                 not agent_mode
                 and text_result
@@ -2117,6 +2170,8 @@ class TranscriptionHandler:
 
         if self.on_segment_transcribed_callback:
             try:
+                self.on_segment_transcribed_callback(error_message, is_final=True)
+            except TypeError:
                 self.on_segment_transcribed_callback(error_message)
             except Exception:  # pragma: no cover - callback externo
                 logging.debug(

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -1591,7 +1591,15 @@ class UIManager:
             self.update_live_transcription_threadsafe = self.update_live_transcription_threadsafe
 
     # Thread-safe method to update live transcription
-    def update_live_transcription_threadsafe(self, text):
+    def update_live_transcription_threadsafe(
+        self,
+        text,
+        *,
+        metadata=None,
+        is_final: bool = False,
+        **_: object,
+    ):
+        del metadata, is_final
         self.main_tk_root.after(0, lambda: self._update_live_transcription(text))
 
     def create_image(self, width, height, color1, color2=None):


### PR DESCRIPTION
## Summary
- add a stream_transcribe helper to the faster-whisper backend so callers can consume cancellable segment callbacks while preserving legacy behaviour
- update the transcription handler to use the streaming path for CT2 backends, logging each segment and propagating metadata to the UI callbacks
- track the final-segment marker in AppCore/UI to keep live transcripts consistent and avoid duplicate fallback pastes

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e50348db2483309fbe5efd5e1759c5