### PR TITLE
refactor: enforce ctranslate2 backend only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ This section outlines the fundamental rules and user-mandated instructions that 
 - **Primary Language**: Python 3.11+ (tested up to 3.13.2).
 - **UI Framework**: `tkinter` (for the settings window) + `pystray` (for the system tray icon).
 - **Input/Output**: Audio capture via `sounddevice`; automatic text pasting using `pyautogui` and `pyperclip`.
-- **Primary ASR Engine**: Hugging Face Whisper models, accessed through `transformers`, `faster-whisper`, or `ctranslate2` backends.
+- **Primary ASR Engine**: Hugging Face Whisper models executed exclusively via the CTranslate2 runtime (faster-whisper backend).
 - **Optional External Services**: Google Gemini (for text correction/agent mode) and OpenRouter (for text correction).
 - **Execution Model**: System tray application driven by global hotkeys, managed by the `keyboard` library.
 
@@ -33,7 +33,7 @@ This section outlines the fundamental rules and user-mandated instructions that 
 | Path | Contents | Notes |
 | --- | --- | --- |
 | `src/` | Main application source code. | See component map in the architecture section. |
-| `src/asr/` | Specific ASR backend adapters (e.g., faster-whisper, transformers). | Contains the pipeline adapters for different ASR libraries. |
+| `src/asr/` | CTranslate2 backend adapter (faster-whisper runtime). | Contains the unified runtime adapter for ASR. |
 | `src/utils/` | Shared utilities for memory, autostart, UI helpers, etc. | Reused by core components and the UI. |
 | `plans/` | Tactical plans and agent-generated artifacts. | Any agent must register new plans and strategies here. |
 | `docs/` | Supplementary documentation (workflows, UI variables, changelog). | Use as a reference for deeper understanding. |

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ installation estimates.
   - Configure AI services, audio feedback sounds, and additional quality-of-life options.
   - Calibrate VAD behaviour with pre/post speech padding, minimum durations, and silence thresholds.
 
+### ASR backend policy
+
+Whisper Flash Transcriber now distributes only the faster-whisper/CTranslate2 backend. The legacy Transformers
+pipeline has been removed from the packaged application. If you depend on the Transformers stack (for example,
+to experiment with custom attention implementations or torch-native quantization), fork the project and re-enable
+`src/asr/backend_transformers.py` together with the required dependencies.
+
 ### Custom installation directories
 
 The application allows you to relocate heavyweight assets so that ephemeral or slow system drives do not become bottlenecks. The
@@ -117,7 +124,7 @@ virtual environment, ensure that `PYTHONPATH` includes the path before launching
 directory to `sys.path`, but external scripts or shells may require explicit exports.
 - **`vad_models_dir`** — Dedicated folder for the Silero VAD model. If empty, the packaged copy is copied into the directory on
   first use. Keep this path on a fast local drive to avoid I/O stalls during VAD activation.
-- **`hf_cache_dir`** — Shared Hugging Face cache that backs `snapshot_download` calls and any Transformers pipelines. The
+- **`hf_cache_dir`** — Shared Hugging Face cache that backs `snapshot_download` calls used by the CTranslate2 runtime. The
   bootstrap sequence creates the directory and sets `HF_HOME`/`HUGGINGFACE_HUB_CACHE` accordingly.
 
 Because all these directories default to the storage root, you can move the entire cache tree by changing `storage_root_dir` or

--- a/plans/2025-10-03-bug-audit.md
+++ b/plans/2025-10-03-bug-audit.md
@@ -75,37 +75,14 @@ Auditoria focada em estabilidade, fluxo de agente e ajustes de backend revelou p
   - [ ] Sanitizar kwargs em `FasterWhisperBackend.transcribe`.
   - [ ] Verificar transcrição completa após o ajuste.
 
-### 7. Backend transformers ignora o modelo solicitado
-- **Arquivo**: `src/asr/backend_transformers.py:23`
-- **Impacto**: `TransformersBackend.load` usa sempre `self.model_id` local e ignora o `model_id` passado pelo `TranscriptionHandler`. Trocas de modelo na UI não surtem efeito.
-- **Reprodução**: Alterar o modelo na UI para outro id, reiniciar o backend e observar que o log continua carregando o modelo padrão.
-- **Correção sugerida**:
-  1. Atualizar `self.model_id` com `kwargs.get("model_id")` antes de carregar processor/model.
-  2. Registrar nos logs qual modelo foi realmente inicializado.
-- **Checklist**:
-  - [ ] Ajustar `TransformersBackend.load` para respeitar o modelo solicitado.
-  - [ ] Validar com dois modelos distintos.
+### 7. Backend transformers ignora o modelo solicitado (OBSOLETO)
+- **Status**: Resolvido indiretamente. O backend Transformers foi removido na migração para distribuição CT2-only, portanto o problema não se aplica mais.
 
-### 8. Backend transformers força execução na GPU 0
-- **Arquivo**: `src/asr/backend_transformers.py:38`
-- **Impacto**: O cálculo do dispositivo converte qualquer valor diferente de -1 para `0`, ignorando seleções como `cuda:1` ou `cpu`. Usuários não conseguem direcionar a execução para outra GPU nem forçar CPU.
-- **Reprodução**: Configure `asr_compute_device` como `cuda:1`; os logs mostram uso da GPU 0.
-- **Correção sugerida**:
-  1. Aceitar strings do tipo `cuda:N` e repassar o índice correto ao pipeline.
-  2. Manter `-1` para CPU e ajustar o cálculo de `torch_dtype` para não forçar Float16 quando o dispositivo for CPU.
-- **Checklist**:
-  - [ ] Revisar cálculo de `device`/`torch_dtype`.
-  - [ ] Testar em CPU e múltiplas GPUs.
+### 8. Backend transformers força execução na GPU 0 (OBSOLETO)
+- **Status**: Resolvido indiretamente. O backend Transformers foi removido na migração para distribuição CT2-only.
 
-### 9. Identificador incorreto de FlashAttention
-- **Arquivo**: `src/transcription_handler.py:1208`
-- **Impacto**: `_build_backend_load_kwargs` retorna `flash_attn2`, enquanto `transformers` espera `flash_attention_2`. Quando a extensão está instalada, o carregamento falha.
-- **Reprodução**: Instale `flash-attn`, carregue o backend transformers e observe a exceção `ValueError` relacionada ao nome do backend de atenção.
-- **Correção sugerida**:
-  1. Padronizar para `flash_attention_2`, alinhando com o restante do código.
-  2. Adicionar teste ou validação manual com FlashAttention disponível.
-- **Checklist**:
-  - [ ] Ajustar a string e validar o carregamento.
+### 9. Identificador incorreto de FlashAttention (OBSOLETO)
+- **Status**: Resolvido indiretamente. Com a remoção do backend Transformers, o carregamento de pipelines Torch não faz mais parte do escopo oficial.
 
 ### 10. Limite de armazenamento nunca é aplicado
 - **Arquivo**: `src/audio_handler.py:619`

--- a/plans/2025-10-05-operational-playbook.md
+++ b/plans/2025-10-05-operational-playbook.md
@@ -46,7 +46,7 @@
 
 ## Checklist C — Auditoria de dependências
 1. [ ] Executar `pip list --outdated` dentro do ambiente virtual.
-2. [ ] Priorizar bibliotecas críticas (`torch`, `transformers`, `ctranslate2`, `faster-whisper`, `sounddevice`).
+2. [ ] Priorizar bibliotecas críticas (`torch`, `ctranslate2`, `faster-whisper`, `sounddevice`).
 3. [ ] Para cada pacote alvo, consultar changelog oficial e riscos de regressão.
 4. [ ] Registrar na tabela abaixo a decisão (atualizar agora, adiar, requer teste adicional) e o racional técnico.
 5. [ ] Se decidir atualizar, criar *branch* dedicado, aplicar `pip install --upgrade <pacote>` e reexecutar `pytest` + testes manuais das checklists A/B.
@@ -55,7 +55,6 @@
 | Pacote | Versão atual | Versão alvo | Decisão | Notas |
 | --- | --- | --- | --- | --- |
 | `torch` | _(preencher)_ | _(preencher)_ | _( ) Atualizar _( ) Adiar_( ) Investigar | Impacto em CUDA e `torch.compile`. |
-| `transformers` | _(preencher)_ | _(preencher)_ | _( ) Atualizar _( ) Adiar_( ) Investigar | Verificar breaking changes na API de `WhisperModel`. |
 | `ctranslate2` | _(preencher)_ | _(preencher)_ | _( ) Atualizar _( ) Adiar_( ) Investigar | Confirmar compatibilidade do compute type. |
 | `faster-whisper` | _(preencher)_ | _(preencher)_ | _( ) Atualizar _( ) Adiar_( ) Investigar | Validar parâmetros aceitos em `transcribe`. |
 | `sounddevice` | _(preencher)_ | _(preencher)_ | _( ) Atualizar _( ) Adiar_( ) Investigar | Testar captura em Windows e WSL. |

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,6 @@ pytest
 flake8==7.2.0
 
 # Dependências da Aplicação usadas nos Testes
-transformers
 sounddevice
 numpy>=2.3.0
 pyautogui

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 torch==2.5.1
-transformers>=4.44,<5
 sounddevice==0.5.2
 numpy==2.3.0
 pyautogui==0.9.54

--- a/src/asr/backends.py
+++ b/src/asr/backends.py
@@ -25,8 +25,11 @@ def make_backend(name: str) -> ASRBackend:
     """Factory that returns an ASR backend by name."""
     normalized = name.strip().lower()
     if normalized == "transformers":
-        from .backend_transformers import TransformersBackend
-        return TransformersBackend()
+        raise ValueError(
+            "The legacy Transformers backend is no longer bundled. Configure the "
+            "application to use the CTranslate2 runtime or reinstall a fork that "
+            "ships the Transformers pipeline."
+        )
     if normalized in {"faster-whisper", "faster_whisper", "ct2", "ctranslate2"}:
         from .backend_faster_whisper import FasterWhisperBackend
         return FasterWhisperBackend()

--- a/src/asr_backends.py
+++ b/src/asr_backends.py
@@ -74,18 +74,14 @@ class _AdapterBackend:
         cache = cfg.get("asr_cache_dir") or None
         ct2_type = cfg.get("asr_ct2_compute_type") or "default"
 
-        backend = _make_asr_backend(self._name)
+        backend_name = "ctranslate2" if self._name in {"faster-whisper", "ct2"} else self._name
+        backend = _make_asr_backend(backend_name)
         if hasattr(backend, "model_id"):
             backend.model_id = model_id
         if hasattr(backend, "device"):
             backend.device = device
 
-        if self._name == "transformers":
-            backend.load(device=device, dtype=dtype, cache_dir=cache)
-        elif self._name == "faster-whisper":
-            backend.load(cache_dir=cache, ct2_compute_type=ct2_type)
-        else:
-            backend.load()
+        backend.load(cache_dir=cache, ct2_compute_type=ct2_type)
         self._backend = backend
 
     def unload(self) -> None:
@@ -103,9 +99,8 @@ class _AdapterBackend:
 
 backend_registry.update(
     {
-        "transformers": lambda h: _AdapterBackend(h, "transformers"),
-        "ct2": lambda h: _AdapterBackend(h, "faster-whisper"),
-        "ctranslate2": lambda h: _AdapterBackend(h, "faster-whisper"),
-        "faster-whisper": lambda h: _AdapterBackend(h, "faster-whisper"),
+        "ct2": lambda h: _AdapterBackend(h, "ct2"),
+        "ctranslate2": lambda h: _AdapterBackend(h, "ctranslate2"),
+        "faster-whisper": lambda h: _AdapterBackend(h, "ctranslate2"),
     }
 )

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -340,12 +340,16 @@ def _normalize_asr_backend(name: str | None) -> str | None:
     if not isinstance(name, str):
         return name
     normalized = name.strip().lower()
-    if normalized in {"faster whisper", "faster_whisper"}:
-        normalized = "faster-whisper"
-    if normalized in {"ct2", "ctranslate2"}:
+    if normalized in {
+        "ct2",
+        "ctranslate2",
+        "faster whisper",
+        "faster_whisper",
+        "faster-whisper",
+        "transformers",
+        "auto",
+    }:
         return "ctranslate2"
-    if normalized == "faster-whisper":
-        return "faster-whisper"
     return normalized
 
 

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -30,10 +30,7 @@ _SUPPORTED_UI_LANGUAGE_MAP = {
 _DEFAULT_UI_LANGUAGE = "en-US"
 
 _CURATED_MODEL_IDS = {entry["id"] for entry in CURATED}
-_ALLOWED_ASR_BACKENDS = {
-    normalize_backend_label(entry.get("backend"))
-    for entry in CURATED
-} | {"transformers"}
+_ALLOWED_ASR_BACKENDS = {"ctranslate2"}
 
 
 class ASRDownloadStatus(BaseModel):
@@ -334,6 +331,8 @@ class AppConfig(BaseModel):
         if not isinstance(value, str):
             raise ValueError("asr_backend must be a string")
         normalized = normalize_backend_label(value)
+        if normalized == "auto":
+            normalized = "ctranslate2"
         if normalized not in _ALLOWED_ASR_BACKENDS:
             raise ValueError(
                 f"asr_backend must be one of {sorted(_ALLOWED_ASR_BACKENDS)}"

--- a/src/onboarding/first_run_wizard.py
+++ b/src/onboarding/first_run_wizard.py
@@ -455,7 +455,7 @@ class FirstRunWizard(ctk.CTkToplevel):
         backend_menu = ctk.CTkOptionMenu(
             form,
             variable=self.backend_var,
-            values=["ctranslate2", "faster-whisper", "transformers"],
+            values=["ctranslate2"],
             command=lambda _: self._sync_quant_visibility(),
         )
         backend_menu.grid(row=1, column=1, sticky="w", pady=8)
@@ -651,10 +651,10 @@ class FirstRunWizard(ctk.CTkToplevel):
         if not model_id:
             messagebox.showerror("Modelo", "Informe o identificador do modelo.", parent=self)
             return False
-        if backend not in {"ctranslate2", "faster-whisper", "transformers"}:
+        if backend != "ctranslate2":
             messagebox.showerror(
                 "Modelo",
-                "Backend inválido. Escolha entre 'ctranslate2', 'faster-whisper' ou 'transformers'.",
+                "Backend inválido. Utilize 'ctranslate2'.",
                 parent=self,
             )
             return False

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -15,22 +15,6 @@ try:  # pragma: no cover - biblioteca opcional
 except Exception:  # pragma: no cover
     from .asr.backends import make_backend  # type: ignore
 
-try:  # pragma: no cover - transformers podem não estar instalados em testes
-    from transformers import (
-        pipeline,
-        AutoProcessor,
-        AutoModelForSpeechSeq2Seq,
-        BitsAndBytesConfig,
-    )
-except Exception:  # pragma: no cover
-    pipeline = None  # type: ignore
-    AutoProcessor = None  # type: ignore
-    AutoModelForSpeechSeq2Seq = None  # type: ignore
-
-    class BitsAndBytesConfig:  # type: ignore[py-class-var]
-        def __init__(self, *_, **__):
-            pass
-
 from .openrouter_api import OpenRouterAPI # Assumindo que está na raiz ou em path acessível
 from .audio_handler import AUDIO_SAMPLE_RATE
 from pathlib import Path
@@ -244,27 +228,11 @@ class TranscriptionHandler:
         asr_dtype,
         asr_ct2_compute_type,
         asr_cache_dir,
-        transformers_device,
         backend_device,
         backend_device_index,
         asr_ct2_cpu_threads,
     ) -> dict:
         """Constroi os parâmetros de ``load`` para o backend escolhido."""
-        if backend_name in {"transformers", "whisper"}:
-            attn_impl = "sdpa"
-            try:
-                import importlib.util
-
-                if importlib.util.find_spec("flash_attn") is not None:
-                    attn_impl = "flash_attention_2"
-            except Exception:
-                pass
-            return {
-                "device": transformers_device,
-                "dtype": asr_dtype,
-                "cache_dir": asr_cache_dir,
-                "attn_implementation": attn_impl,
-            }
         if backend_name in {"ct2", "faster-whisper", "ctranslate2"}:
             payload: dict[str, object] = {
                 "ct2_compute_type": asr_ct2_compute_type,
@@ -587,13 +555,10 @@ class TranscriptionHandler:
 
     def _resolve_asr_settings(self):
         """Determina backend, modelo e parâmetros de ASR conforme hardware."""
-        backend = (self.asr_backend or "auto").lower()
+        backend = model_manager_module.normalize_backend_label(self.asr_backend) or "ctranslate2"
         compute_device = (self.asr_compute_device or "auto").lower()
         model_id = self.asr_model_id or "auto"
         dtype = (self.asr_dtype or "auto").lower()
-
-        if backend == "auto":
-            backend = "transformers"
 
         if compute_device == "auto":
             compute_device = "cuda" if _torch_cuda_available() else "cpu"
@@ -741,115 +706,6 @@ class TranscriptionHandler:
                 if self.on_model_ready_callback:
                     self.on_model_ready_callback()
                 return model, processor
-
-            device = (
-                f"cuda:{self.gpu_index}"
-                if self.gpu_index is not None
-                and self.gpu_index >= 0
-                and _torch_cuda_available()
-                else "cpu"
-            )
-
-            try:
-                if hasattr(model, "eval"):
-                    model.eval()
-                    logging.info(
-                        "Model moved to eval mode.",
-                        extra={"event": "model_eval_applied", "duration_ms": 0},
-                    )
-                    training_flag = getattr(model, "training", None)
-                    if training_flag is not None:
-                        logging.debug("Model.training=%s (expected False)", training_flag)
-            except Exception as eval_error:
-                logging.warning("Unable to apply model.eval(): %s", eval_error)
-
-            if (
-                self.enable_torch_compile
-                and _torch_available()
-                and hasattr(torch, "compile")
-                and device.startswith("cuda")
-            ):
-                try:
-                    assert torch is not None
-                    model = torch.compile(model)  # type: ignore[attr-defined]
-                    logging.info(
-                        "torch.compile applied to the model (experimental).",
-                        extra={"event": "torch_compile", "status": "applied"},
-                    )
-                except Exception as compile_error:
-                    logging.warning(
-                        "Failed to apply torch.compile: %s. Continuing without compilation.",
-                        compile_error,
-                        exc_info=True,
-                    )
-            else:
-                logging.info(
-                    "torch.compile disabled or unavailable; continuing without compilation.",
-                    extra={"event": "torch_compile", "status": "skipped"},
-                )
-
-            if self.chunk_length_mode == "auto":
-                try:
-                    effective_chunk = float(self._effective_chunk_length())
-                    if effective_chunk != self.chunk_length_sec:
-                        logging.info(
-                            "Chunk length adjusted automatically: %.1fs -> %.1fs",
-                            self.chunk_length_sec,
-                            effective_chunk,
-                        )
-                    self.chunk_length_sec = effective_chunk
-                except Exception as chunk_error:
-                    logging.warning(
-                        "Failed to compute auto chunk_length: %s. Keeping current value %.1fs.",
-                        chunk_error,
-                        self.chunk_length_sec,
-                    )
-
-            generate_kwargs_init = {"task": "transcribe", "language": None}
-            torch_mod = _require_torch()
-            self.pipe = pipeline(
-                "automatic-speech-recognition",
-                model=model,
-                tokenizer=processor.tokenizer,
-                feature_extractor=processor.feature_extractor,
-                chunk_length_s=self.chunk_length_sec,
-                batch_size=self.batch_size,
-                torch_dtype=torch_mod.float16 if device.startswith("cuda") else torch_mod.float32,
-                generate_kwargs=generate_kwargs_init,
-            )
-            logging.info(
-                "Transcription pipeline initialized successfully.",
-                extra={"event": "transcription_pipeline", "status": "ready", "details": f"device={device}"},
-            )
-
-            try:
-                import numpy as _np
-
-                warmup_dur = max(0.1, min(0.25, float(self.chunk_length_sec) * 0.01))
-                sr = AUDIO_SAMPLE_RATE
-                n = int(sr * warmup_dur)
-                t = _np.linspace(0, warmup_dur, n, False, dtype=_np.float32)
-                tone = (_np.sin(2 * _np.pi * 440.0 * t)).astype(_np.float32)
-                t0 = time.perf_counter()
-                with _torch_no_grad():
-                    _ = self.pipe(
-                        tone,
-                        chunk_length_s=self.chunk_length_sec,
-                        batch_size=max(1, int(self.batch_size)),
-                        return_timestamps=False,
-                        generate_kwargs={"task": "transcribe", "language": None},
-                    )
-                t1 = time.perf_counter()
-                logging.info(
-                    "Warmup inference completed.",
-                    extra={
-                        "event": "warmup_infer",
-                        "duration_ms": (t1 - t0) * 1000,
-                        "details": f"device={device} chunk={self.chunk_length_sec:.2f}s batch={self.batch_size}",
-                    },
-                )
-            except Exception as warmup_error:
-                logging.warning("Pipeline warmup failed: %s", warmup_error)
 
             self._asr_loaded = True
             if self.on_model_ready_callback:
@@ -1143,1154 +999,259 @@ class TranscriptionHandler:
         self.transcription_cancel_event.set()
 
     def _load_model_task(self):
+        self._apply_environment_overrides()
+        self.device_in_use = "cpu"
+        core_ref = getattr(self, "core_instance_ref", None)
+        state_mgr = getattr(core_ref, "state_manager", None) if core_ref is not None else None
+        if make_backend is None:
+            if state_mgr is not None:
+                state_mgr.set_state(sm.STATE_ERROR_MODEL)
+            raise RuntimeError(
+                "The CTranslate2 backend factory is unavailable. Reinstall the application with CT2 support."
+            )
+
+        backend_preference = self.config_manager.get("asr_backend") or "ctranslate2"
+        requested_backend_display = (
+            backend_preference.strip()
+            if isinstance(backend_preference, str)
+            else "ctranslate2"
+        )
+        backend_candidate = (
+            model_manager_module.normalize_backend_label(requested_backend_display)
+            or "ctranslate2"
+        )
+
+        if backend_candidate not in {"ctranslate2"}:
+            message = (
+                f"Unsupported ASR backend '{requested_backend_display}'. Update the settings to use "
+                "the CTranslate2 runtime."
+            )
+            logging.error(message)
+            if state_mgr is not None:
+                state_mgr.set_state(sm.STATE_ERROR_MODEL)
+            raise RuntimeError(message)
+
         try:
-            self._apply_environment_overrides()
-            self.device_in_use = "cpu"
-            if make_backend is not None:
-                backend_preference = self.config_manager.get("asr_backend") or "transformers"
-                requested_backend_display = (
-                    backend_preference.strip()
-                    if isinstance(backend_preference, str)
-                    else "transformers"
-                )
-                backend_candidate = (
-                    requested_backend_display.lower()
-                    if requested_backend_display
-                    else "transformers"
-                )
-                if not backend_candidate:
-                    backend_candidate = "transformers"
+            self._asr_backend = make_backend(backend_candidate)
+        except Exception as backend_error:
+            message = (
+                "Unable to initialize the CTranslate2 backend. Reinstall the optional dependencies "
+                "or run the dependency remediation flow."
+            )
+            logging.error("%s: %s", message, backend_error)
+            if state_mgr is not None:
+                state_mgr.set_state(sm.STATE_ERROR_MODEL)
+            raise RuntimeError(message) from backend_error
 
-                backend_name = backend_candidate
-                try:
-                    self._asr_backend = make_backend(backend_name)
-                except Exception as backend_error:
-                    if backend_name != "transformers":
-                        logging.warning(
-                            "Failed to instantiate backend '%s': %s. Falling back to 'transformers'.",
-                            backend_name,
-                            backend_error,
-                        )
-                        backend_name = "transformers"
-                        self._asr_backend = make_backend(backend_name)
+        self.backend_resolved = backend_candidate
+
+        req_backend, req_model_id, req_device, req_dtype = self._resolve_asr_settings()
+        logging.info(
+            "Resolved ASR settings: backend=%s, model=%s, device=%s, dtype=%s",
+            req_backend,
+            req_model_id,
+            req_device,
+            req_dtype,
+        )
+
+        available_cuda = _torch_cuda_available()
+        gpu_count = _torch_cuda_device_count() if available_cuda else 0
+
+        requested_gpu_index: int | None = None
+        if isinstance(req_device, str):
+            lowered_device = req_device.strip().lower()
+            if lowered_device.startswith("cuda"):
+                _, _, suffix = lowered_device.partition(":")
+                if suffix:
+                    try:
+                        requested_gpu_index = int(suffix)
+                    except ValueError:
+                        requested_gpu_index = None
+
+        config_gpu_idx_raw = self.config_manager.get(GPU_INDEX_CONFIG_KEY, -1)
+        try:
+            config_gpu_idx = int(config_gpu_idx_raw)
+        except (TypeError, ValueError):
+            config_gpu_idx = -1
+
+        self.gpu_index_requested = (
+            requested_gpu_index
+            if requested_gpu_index is not None
+            else (config_gpu_idx if config_gpu_idx >= 0 else None)
+        )
+
+        effective_device = "cpu"
+        selected_gpu_index: int | None = None
+
+        if req_device == "cpu":
+            logging.info("ASR device explicitly set to CPU.")
+        elif isinstance(req_device, str) and req_device.startswith("cuda"):
+            if not available_cuda or gpu_count == 0:
+                reason = (
+                    "CUDA not available."
+                    if not available_cuda
+                    else "No GPUs detected."
+                )
+                self._emit_device_warning(req_device, "cpu", reason)
+            else:
+                target_idx = requested_gpu_index
+                if target_idx is None or target_idx < 0:
+                    if 0 <= config_gpu_idx < gpu_count:
+                        target_idx = config_gpu_idx
                     else:
-                        raise
-                self.backend_resolved = backend_name
-
-                req_backend, req_model_id, req_device, req_dtype = self._resolve_asr_settings()
-                logging.info(
-                    "Resolved ASR settings: backend=%s, model=%s, device=%s, dtype=%s",
-                    req_backend,
-                    req_model_id,
-                    req_device,
-                    req_dtype,
-                )
-
-                available_cuda = _torch_cuda_available()
-                gpu_count = _torch_cuda_device_count() if available_cuda else 0
-
-                requested_gpu_index: int | None = None
-                if isinstance(req_device, str):
-                    lowered_device = req_device.strip().lower()
-                    if lowered_device.startswith("cuda"):
-                        _, _, suffix = lowered_device.partition(":")
-                        if suffix:
-                            try:
-                                requested_gpu_index = int(suffix)
-                            except ValueError:
-                                requested_gpu_index = None
-
-                config_gpu_idx_raw = self.config_manager.get(GPU_INDEX_CONFIG_KEY, -1)
-                try:
-                    config_gpu_idx = int(config_gpu_idx_raw)
-                except (TypeError, ValueError):
-                    config_gpu_idx = -1
-
-                self.gpu_index_requested = (
-                    requested_gpu_index
-                    if requested_gpu_index is not None
-                    else (config_gpu_idx if config_gpu_idx >= 0 else None)
-                )
-
-                effective_device = "cpu"
-                transformers_device: int | str = -1
-                selected_gpu_index: int | None = None
-
-                if req_device == "cpu":
-                    logging.info("ASR device explicitly set to CPU.")
-                elif isinstance(req_device, str) and req_device.startswith("cuda"):
-                    if not available_cuda or gpu_count == 0:
-                        reason = (
-                            "CUDA not available."
-                            if not available_cuda
-                            else "No GPUs detected."
-                        )
-                        self._emit_device_warning(req_device, "cpu", reason)
-                    else:
-                        target_idx = requested_gpu_index
-                        if target_idx is None or target_idx < 0:
-                            if 0 <= config_gpu_idx < gpu_count:
-                                target_idx = config_gpu_idx
-                            else:
-                                if config_gpu_idx not in (-1, 0):
-                                    logging.warning(
-                                        "Invalid GPU index %s, falling back to GPU 0.",
-                                        config_gpu_idx,
-                                    )
-                                target_idx = 0
-                        if target_idx is not None and target_idx >= gpu_count:
-                            self._emit_device_warning(
-                                req_device,
-                                "cpu",
-                                (
-                                    f"Requested GPU index {target_idx} is out of range for "
-                                    f"{gpu_count} visible device(s)."
-                                ),
+                        if config_gpu_idx not in (-1, 0):
+                            logging.warning(
+                                "Invalid GPU index %s, falling back to GPU 0.",
+                                config_gpu_idx,
                             )
-                        else:
-                            selected_gpu_index = target_idx
-                            effective_device = f"cuda:{selected_gpu_index}" if selected_gpu_index is not None else "cpu"
-                            transformers_device = (
-                                f"cuda:{selected_gpu_index}" if selected_gpu_index is not None else -1
-                            )
-
-                self.device_in_use = effective_device
-                self.gpu_index = selected_gpu_index if selected_gpu_index is not None else -1
-
-                logging.info(
-                    "Effective ASR device: %s (transformers_device=%s, gpu_index=%s)",
-                    self.device_in_use,
-                    transformers_device,
-                    self.gpu_index,
-                )
-
-                effective_dtype = self._resolve_effective_dtype(req_dtype)
-                backend_device = effective_device
-                backend_device_index = selected_gpu_index if selected_gpu_index is not None else None
-                if not backend_device.startswith("cuda"):
-                    backend_device_index = None
-
-                load_kwargs = self._build_backend_load_kwargs(
-                    backend_name=backend_name,
-                    asr_dtype=effective_dtype,
-                    asr_ct2_compute_type=self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY),
-                    asr_cache_dir=self.config_manager.get(ASR_CACHE_DIR_CONFIG_KEY),
-                    transformers_device=transformers_device,
-                    backend_device=backend_device,
-                    backend_device_index=backend_device_index,
-                    asr_ct2_cpu_threads=self.config_manager.get(ASR_CT2_CPU_THREADS_CONFIG_KEY),
-                )
-                load_kwargs = {k: v for k, v in load_kwargs.items() if v is not None}
-                if "cache_dir" in load_kwargs and load_kwargs["cache_dir"]:
-                    load_kwargs["cache_dir"] = str(load_kwargs["cache_dir"])
-
-                if hasattr(self._asr_backend, "model_id"):
-                    try:
-                        self._asr_backend.model_id = req_model_id
-                    except Exception:
-                        logging.debug("Unable to propagate model_id to backend instance.", exc_info=True)
-                if hasattr(self._asr_backend, "device"):
-                    try:
-                        self._asr_backend.device = backend_device
-                    except Exception:
-                        logging.debug("Unable to propagate device to backend instance.", exc_info=True)
-                if hasattr(self._asr_backend, "device_index"):
-                    try:
-                        self._asr_backend.device_index = backend_device_index
-                    except Exception:
-                        logging.debug("Unable to propagate device_index to backend instance.", exc_info=True)
-
-                self._update_model_log_context(
-                    backend=backend_name,
-                    model=req_model_id,
-                    device=effective_device,
-                    dtype=load_kwargs.get("dtype", req_dtype),
-                    compute_type=load_kwargs.get(
-                        "ct2_compute_type",
-                        self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY),
-                    ),
-                    chunk_length_s=float(self.chunk_length_sec),
-                    batch_size=self.batch_size,
-                )
-                load_started_at = time.perf_counter()
-                self._model_load_started_at = load_started_at
-                self._log_model_event(
-                    "load_start",
-                    backend=backend_name,
-                    model_id=req_model_id,
-                    device=effective_device,
-                    dtype=load_kwargs.get("dtype", req_dtype),
-                    compute_type=load_kwargs.get(
-                        "ct2_compute_type",
-                        self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY),
-                    ),
-                    chunk_length_s=float(self.chunk_length_sec),
-                    batch_size=self.batch_size,
-                )
-                if backend_name in {"transformers", "whisper"} and not _torch_available():
-                    raise RuntimeError(
-                        "PyTorch is required for the Transformers backend but is not installed."
-                    )
-                load_kwargs["model_id"] = req_model_id
-                try:
-                    self._asr_backend.load(**load_kwargs)
-                except Exception as load_error:
-                    duration_ms = (time.perf_counter() - load_started_at) * 1000.0
-                    self._log_model_event(
-                        "load_failure",
-                        level=logging.ERROR,
-                        backend=backend_name,
-                        model_id=req_model_id,
-                        device=effective_device,
-                        dtype=load_kwargs.get("dtype", req_dtype),
-                        compute_type=load_kwargs.get(
-                            "ct2_compute_type",
-                            self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY),
+                        target_idx = 0
+                if target_idx is not None and target_idx >= gpu_count:
+                    self._emit_device_warning(
+                        req_device,
+                        "cpu",
+                        (
+                            f"Requested GPU index {target_idx} is out of range for "
+                            f"{gpu_count} visible device(s)."
                         ),
-                        chunk_length_s=float(self.chunk_length_sec),
-                        batch_size=self.batch_size,
-                        duration_ms=duration_ms,
-                        error=str(load_error),
                     )
-                    self._model_load_started_at = None
-                    raise
+                else:
+                    selected_gpu_index = target_idx
+                    effective_device = (
+                        f"cuda:{selected_gpu_index}" if selected_gpu_index is not None else "cpu"
+                    )
 
-                warmup_failed = None
-                try:
-                    self._asr_backend.warmup()
-                except Exception as warmup_error:
-                    warmup_failed = warmup_error
-                    logging.debug("ASR backend warmup failed: %s", warmup_error)
+        self.device_in_use = effective_device
+        self.gpu_index = selected_gpu_index if selected_gpu_index is not None else -1
 
-                duration_ms = (time.perf_counter() - load_started_at) * 1000.0
-                resolved_device = getattr(self._asr_backend, "device", effective_device)
-                resolved_model = getattr(self._asr_backend, "model_id", req_model_id)
-                resolved_dtype = load_kwargs.get("dtype", req_dtype)
-                resolved_compute = load_kwargs.get(
+        logging.info(
+            "Effective ASR device: %s (gpu_index=%s)",
+            self.device_in_use,
+            self.gpu_index,
+        )
+
+        effective_dtype = self._resolve_effective_dtype(req_dtype)
+        backend_device = effective_device
+        backend_device_index = selected_gpu_index if selected_gpu_index is not None else None
+        if not backend_device.startswith("cuda"):
+            backend_device_index = None
+
+        load_kwargs = self._build_backend_load_kwargs(
+            backend_name=backend_candidate,
+            asr_dtype=effective_dtype,
+            asr_ct2_compute_type=self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY),
+            asr_cache_dir=self.config_manager.get(ASR_CACHE_DIR_CONFIG_KEY),
+            backend_device=backend_device,
+            backend_device_index=backend_device_index,
+            asr_ct2_cpu_threads=self.config_manager.get(ASR_CT2_CPU_THREADS_CONFIG_KEY),
+        )
+        load_kwargs = {k: v for k, v in load_kwargs.items() if v is not None}
+        if "cache_dir" in load_kwargs and load_kwargs["cache_dir"]:
+            load_kwargs["cache_dir"] = str(load_kwargs["cache_dir"])
+
+        if hasattr(self._asr_backend, "model_id"):
+            try:
+                self._asr_backend.model_id = req_model_id
+            except Exception:
+                logging.debug("Unable to propagate model_id to backend instance.", exc_info=True)
+        if hasattr(self._asr_backend, "device"):
+            try:
+                self._asr_backend.device = backend_device
+            except Exception:
+                logging.debug("Unable to propagate device to backend instance.", exc_info=True)
+        if hasattr(self._asr_backend, "device_index"):
+            try:
+                self._asr_backend.device_index = backend_device_index
+            except Exception:
+                logging.debug("Unable to propagate device_index to backend instance.", exc_info=True)
+
+        self._update_model_log_context(
+            backend=backend_candidate,
+            model=req_model_id,
+            device=effective_device,
+            dtype=load_kwargs.get("dtype", req_dtype),
+            compute_type=load_kwargs.get(
+                "ct2_compute_type",
+                self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY),
+            ),
+            chunk_length_s=float(self.chunk_length_sec),
+            batch_size=self.batch_size,
+        )
+        load_started_at = time.perf_counter()
+        self._model_load_started_at = load_started_at
+        self._log_model_event(
+            "load_start",
+            backend=backend_candidate,
+            model_id=req_model_id,
+            device=effective_device,
+            dtype=load_kwargs.get("dtype", req_dtype),
+            compute_type=load_kwargs.get(
+                "ct2_compute_type",
+                self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY),
+            ),
+            chunk_length_s=float(self.chunk_length_sec),
+            batch_size=self.batch_size,
+        )
+        load_kwargs["model_id"] = req_model_id
+        try:
+            self._asr_backend.load(**load_kwargs)
+        except Exception as load_error:
+            duration_ms = (time.perf_counter() - load_started_at) * 1000.0
+            self._log_model_event(
+                "load_failure",
+                level=logging.ERROR,
+                backend=backend_candidate,
+                model_id=req_model_id,
+                device=effective_device,
+                dtype=load_kwargs.get("dtype", req_dtype),
+                compute_type=load_kwargs.get(
                     "ct2_compute_type",
                     self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY),
-                )
-                self._update_model_log_context(
-                    backend=backend_name,
-                    model=resolved_model,
-                    device=resolved_device,
-                    dtype=resolved_dtype,
-                    compute_type=resolved_compute,
-                    chunk_length_s=float(self.chunk_length_sec),
-                    batch_size=self.batch_size,
-                )
-                self._log_model_event(
-                    "load_success",
-                    backend=backend_name,
-                    device=resolved_device,
-                    dtype=resolved_dtype,
-                    compute_type=resolved_compute,
-                    duration_ms=duration_ms,
-                    status="warmup_failed" if warmup_failed else "ready",
-                )
-                self._model_load_started_at = None
-                logging.info(
-                    "Backend '%s' initialized on device %s.",
-                    self.backend_resolved,
-                    self.device_in_use,
-                )
-                return self._asr_backend, None
-
-            self._asr_backend = None
-            model_id = self.asr_model_id
-            backend = self.asr_backend
-            compute_device = self.asr_compute_device
-            model_dir = model_manager_module.find_existing_installation(
-                self.asr_cache_dir,
-                backend,
-                model_id,
-            )
-            if model_dir is None:
-                raise FileNotFoundError(
-                    f"Model '{model_id}' not found. Install it through the application settings."
-                )
-            canonical_dir = model_manager_module.get_installation_dir(
-                self.asr_cache_dir,
-                backend,
-                model_id,
-            )
-            if model_dir != canonical_dir:
-                logging.info(
-                    "Utilizando instalação legada do modelo em %s enquanto a migração é finalizada.",
-                    model_dir,
-                )
-            model_path = Path(model_dir)
-            self._update_model_log_context(
-                backend=backend,
-                model=model_id,
-                device=compute_device,
-                dtype=self.asr_dtype,
-                compute_type=self.asr_ct2_compute_type,
+                ),
                 chunk_length_s=float(self.chunk_length_sec),
                 batch_size=self.batch_size,
-            )
-            load_started_at = time.perf_counter()
-            self._model_load_started_at = load_started_at
-            self._log_model_event(
-                "load_start",
-                backend=backend,
-                model_id=model_id,
-                device=compute_device,
-                dtype=self.asr_dtype,
-                compute_type=self.asr_ct2_compute_type,
-                chunk_length_s=float(self.chunk_length_sec),
-                batch_size=self.batch_size,
-            )
-
-            if AutoProcessor is None or AutoModelForSpeechSeq2Seq is None:
-                raise RuntimeError("Transformers are not available in this environment.")
-
-            logging.info("Loading processor for %s...", model_id)
-            processor = AutoProcessor.from_pretrained(str(model_path))
-
-            torch_mod = _require_torch()
-
-            if _torch_cuda_available():
-                if self.gpu_index == -1:
-                    num_gpus = _torch_cuda_device_count()
-                    if num_gpus > 0:
-                        best_gpu_index = 0
-                        max_vram = 0
-                        for i in range(num_gpus):
-                            props = torch_mod.cuda.get_device_properties(i)
-                            if props.total_memory > max_vram:
-                                max_vram = props.total_memory
-                                best_gpu_index = i
-                        self.gpu_index = best_gpu_index
-                        logging.info(
-                            "Auto-selected GPU with highest total VRAM: %s (%s)",
-                            self.gpu_index,
-                            torch_mod.cuda.get_device_name(self.gpu_index),
-                        )
-                    else:
-                        logging.info("No GPU available; using CPU.")
-                        self.gpu_index = -1
-                        level = (
-                            "warning"
-                            if str(compute_device or "auto").lower() == "cuda"
-                            else "info"
-                        )
-                        self._emit_device_warning(
-                            str(compute_device or "auto"),
-                            "cpu",
-                            "No GPU available for loading.",
-                            level=level,
-                        )
-
-            device = (
-                f"cuda:{self.gpu_index}"
-                if self.gpu_index >= 0 and _torch_cuda_available()
-                else "cpu"
-            )
-            self.device_in_use = device
-            torch_dtype_local = torch_mod.float16 if device.startswith("cuda") else torch_mod.float32
-            resolved_device = device
-            resolved_dtype_label = str(torch_dtype_local).replace("torch.", "")
-            self._update_model_log_context(device=resolved_device, dtype=resolved_dtype_label)
-
-            logging.info("Model load device explicitly set to: %s", device)
-
-            try:
-                if (
-                    compute_device == "cuda"
-                    and _torch_cuda_available()
-                    and self.gpu_index == -1
-                ):
-                    best_idx = None
-                    best_free = -1
-                    for i in range(_torch_cuda_device_count()):
-                        try:
-                            free_b, _ = torch_mod.cuda.mem_get_info(torch_mod.device(f"cuda:{i}"))
-                            if free_b > best_free:
-                                best_free = free_b
-                                best_idx = i
-                        except Exception as _e:
-                            logging.debug(
-                                "Failed to query mem_get_info for GPU %s: %s",
-                                i,
-                                _e,
-                            )
-                    if best_idx is not None:
-                        self.gpu_index = best_idx
-                        free_gb = best_free / (1024 ** 3) if best_free > 0 else 0.0
-                        total_gb = (
-                            torch_mod.cuda.get_device_properties(self.gpu_index).total_memory
-                            / (1024 ** 3)
-                        )
-                        logging.info(
-                            "Automatic GPU selection completed.",
-                            extra={
-                                "event": "gpu_autoselect",
-                                "details": f"gpu={self.gpu_index} free_gb={free_gb:.2f} total_gb={total_gb:.2f}",
-                            },
-                        )
-            except Exception as _gpu_sel_e:
-                logging.warning("Failed to select GPU by free memory: %s", _gpu_sel_e)
-
-            quant_config = None
-            if compute_device == "cuda" and _torch_cuda_available() and self.gpu_index >= 0:
-                quant_config = BitsAndBytesConfig(load_in_8bit=True)
-
-            attn_impl = "sdpa"
-            try:
-                import importlib.util
-
-                if importlib.util.find_spec("flash_attn") is not None:
-                    attn_impl = "flash_attention_2"
-            except Exception:
-                pass
-
-            model_kwargs = {
-                "torch_dtype": torch_dtype_local,
-                "low_cpu_mem_usage": True,
-                "use_safetensors": True,
-                "device_map": {"": device},
-                "attn_implementation": attn_impl,
-            }
-            if quant_config is not None:
-                model_kwargs["quantization_config"] = quant_config
-
-            model = AutoModelForSpeechSeq2Seq.from_pretrained(
-                model_id,
-                cache_dir=str(model_path),
-                **model_kwargs,
-            )
-
-            duration_ms = (time.perf_counter() - load_started_at) * 1000.0
-            self._update_model_log_context(device=resolved_device, dtype=resolved_dtype_label)
-            self._log_model_event(
-                "load_success",
-                backend=backend,
-                device=resolved_device,
-                dtype=resolved_dtype_label,
-                compute_type=self.asr_ct2_compute_type,
                 duration_ms=duration_ms,
-                status="legacy_loaded",
+                error=str(load_error),
             )
             self._model_load_started_at = None
-            return model, processor
-        except OSError:
-            error_message = "Invalid cache directory. Check your configuration."
-            if self._model_load_started_at is not None:
-                duration_ms = (time.perf_counter() - self._model_load_started_at) * 1000.0
-                self._log_model_event(
-                    "load_failure",
-                    level=logging.ERROR,
-                    duration_ms=duration_ms,
-                    error=error_message,
-                )
-                self._model_load_started_at = None
-            logging.error(error_message, exc_info=True)
-            try:
-                if self.on_model_error_callback:
-                    self.on_model_error_callback(error_message)
-            except Exception:
-                logging.debug(
-                    "Failed to report invalid directory error.",
-                    exc_info=True,
-                )
-            return None, None
-        except Exception as e:
-            error_message = f"Failed to load the model: {e}"
-            if self._model_load_started_at is not None:
-                duration_ms = (time.perf_counter() - self._model_load_started_at) * 1000.0
-                self._log_model_event(
-                    "load_failure",
-                    level=logging.ERROR,
-                    duration_ms=duration_ms,
-                    error=str(e),
-                )
-                self._model_load_started_at = None
-            logging.error(error_message, exc_info=True)
-            try:
-                if self.on_model_error_callback:
-                    self.on_model_error_callback(error_message)
-            except Exception:
-                logging.debug("Failed to notify load error.", exc_info=True)
-            return None, None
+            raise
 
-    def transcribe_audio_segment(
-        self,
-        audio_source: str | np.ndarray,
-        agent_mode: bool = False,
-        *,
-        correlation_id: str | None = None,
-    ):
-        """Envia o áudio (arquivo ou array) para transcrição assíncrona."""
-        if not self.is_model_ready():
-            logging.error("Transcription pipeline is not available. Model not loaded or failed to load.")
-            self.on_model_error_callback(
-                "Transcription pipeline unavailable. The model is not loaded or failed to load."
-            )
-            return
-        if correlation_id is None:
-            correlation_id = current_correlation_id()
-
-        self.transcription_cancel_event.clear()
-
-        def _transcription_wrapper() -> None:
-            with scoped_correlation_id(correlation_id):
-                try:
-                    self._transcription_task(audio_source, agent_mode)
-                except Exception as exc:  # pragma: no cover - erro inesperado
-                    self._handle_unexpected_transcription_error(
-                        exc,
-                        audio_source=audio_source,
-                        agent_mode=agent_mode,
-                    )
-
-        self.transcription_future = self.transcription_executor.submit(_transcription_wrapper)
-
-    def _transcription_task(self, audio_source: str | np.ndarray, agent_mode: bool) -> None:
-        text_result: str | None = None
-
-        if self.transcription_cancel_event.is_set():
-            self._log_model_event(
-                "transcription_cancelled",
-                status="pre_start",
-                agent_mode=agent_mode,
-            )
-            logging.info(
-                "Transcription cancelled by stop signal before processing began.",
-                extra={"event": "transcription_cancel", "stage": "preprocess"},
-            )
-            return
-
-        dynamic_batch_size = None
-        size_descriptor = self._format_audio_source(audio_source)
-        if self._asr_backend is not None:
-            try:
-                dynamic_batch_size = self._get_dynamic_batch_size()
-            except Exception as batch_error:
-                self._log_model_event(
-                    "transcription_failure",
-                    level=logging.ERROR,
-                    batch_size=dynamic_batch_size,
-                    chunk_length_s=float(self.chunk_length_sec),
-                    size=size_descriptor,
-                    agent_mode=agent_mode,
-                    error=f"dynamic_batch:{batch_error}",
-                )
-                raise
-
-            self._update_model_log_context(
-                chunk_length_s=float(self.chunk_length_sec),
-                batch_size=dynamic_batch_size,
-            )
-            start_ts = time.perf_counter()
-            self._log_model_event(
-                "transcription_start",
-                batch_size=dynamic_batch_size,
-                chunk_length_s=float(self.chunk_length_sec),
-                size=size_descriptor,
-                agent_mode=agent_mode,
-            )
-            try:
-                result = self._asr_backend.transcribe(
-                    audio_source,
-                    chunk_length_s=float(self.chunk_length_sec),
-                    batch_size=dynamic_batch_size,
-                )
-            except Exception as transcribe_error:
-                duration_ms = (time.perf_counter() - start_ts) * 1000.0
-                self._log_model_event(
-                    "transcription_failure",
-                    level=logging.ERROR,
-                    batch_size=dynamic_batch_size,
-                    chunk_length_s=float(self.chunk_length_sec),
-                    size=size_descriptor,
-                    agent_mode=agent_mode,
-                    duration_ms=duration_ms,
-                    error=str(transcribe_error),
-                )
-                logging.error(
-                    f"Error during transcription via unified backend: {transcribe_error}",
-                    exc_info=True,
-                )
-                return
-            else:
-                duration_ms = (time.perf_counter() - start_ts) * 1000.0
-                text_result = result.get("text", "").strip() or "[No speech detected]"
-                self._log_model_event(
-                    "transcription_success",
-                    batch_size=dynamic_batch_size,
-                    chunk_length_s=float(self.chunk_length_sec),
-                    size=size_descriptor,
-                    agent_mode=agent_mode,
-                    duration_ms=duration_ms,
-                )
-        else:
-            # Legacy pipeline
-            # Garantir que dynamic_batch_size esteja definido mesmo quando o backend
-            # for CTranslate2, evitando UnboundLocalError no bloco de exceção.
-            dynamic_batch_size = None
-            legacy_started_at: float | None = None
-            logged_failure = False
-            try:
-                if self.backend_resolved == "ctranslate2":
-                    self._update_model_log_context(
-                        chunk_length_s=float(self.chunk_length_sec),
-                    )
-                    legacy_started_at = time.perf_counter()
-                    self._log_model_event(
-                        "transcription_start",
-                        chunk_length_s=float(self.chunk_length_sec),
-                        size=size_descriptor,
-                        agent_mode=agent_mode,
-                    )
-                    segments, _ = self.pipe.transcribe(audio_source, language=None)
-                    text_result = "".join(seg.text for seg in segments).strip()
-                    if not text_result:
-                        text_result = "[No speech detected]"
-                    duration_ms = (time.perf_counter() - legacy_started_at) * 1000.0
-                    self._log_model_event(
-                        "transcription_success",
-                        chunk_length_s=float(self.chunk_length_sec),
-                        size=size_descriptor,
-                        agent_mode=agent_mode,
-                        duration_ms=duration_ms,
-                    )
-                    logging.info(
-                        "CTranslate2 transcription pipeline finished.",
-                        extra={"event": "transcription_backend", "status": "complete", "details": "ctranslate2"},
-                    )
-                else:
-                    if self.pipe is None:
-                        error_message = "Pipeline de transcrição indisponível. Modelo não carregado ou falhou."
-                        self._log_model_event(
-                            "transcription_failure",
-                            level=logging.ERROR,
-                            chunk_length_s=float(self.chunk_length_sec),
-                            size=size_descriptor,
-                            agent_mode=agent_mode,
-                            error="pipeline_unavailable",
-                        )
-                        logging.error(error_message)
-                        self.on_model_error_callback(error_message)
-                        return
-
-                    try:
-                        dynamic_batch_size = self._get_dynamic_batch_size()
-                    except Exception as batch_error:
-                        logged_failure = True
-                        self._log_model_event(
-                            "transcription_failure",
-                            level=logging.ERROR,
-                            chunk_length_s=float(self.chunk_length_sec),
-                            size=size_descriptor,
-                            agent_mode=agent_mode,
-                            error=f"dynamic_batch:{batch_error}",
-                        )
-                        raise
-
-                    self._update_model_log_context(
-                        chunk_length_s=float(self.chunk_length_sec),
-                        batch_size=dynamic_batch_size,
-                    )
-                    legacy_started_at = time.perf_counter()
-                    self._log_model_event(
-                        "transcription_start",
-                        batch_size=dynamic_batch_size,
-                        chunk_length_s=float(self.chunk_length_sec),
-                        size=size_descriptor,
-                        agent_mode=agent_mode,
-                    )
-                    logging.info(
-                        f"Starting segment transcription with batch_size={dynamic_batch_size}..."
-                    )
-
-                    generate_kwargs = {
-                        "task": "transcribe",
-                        "language": None
-                    }
-                    if isinstance(audio_source, np.ndarray) and audio_source.ndim > 1:
-                        audio_source = audio_source.flatten()
-
-                    if self.chunk_length_mode == "auto":
-                        try:
-                            self.chunk_length_sec = float(self._effective_chunk_length())
-                        except Exception:
-                            pass
-
-                    try:
-                        device = (
-                            f"cuda:{self.gpu_index}"
-                            if _torch_cuda_available() and self.gpu_index >= 0
-                            else "cpu"
-                        )
-                    except Exception:
-                        device = "cpu"
-                    dtype = "fp16" if (_torch_cuda_available() and self.gpu_index >= 0) else "fp32"
-                    try:
-                        import importlib.util as _spec_util
-                        attn_impl = "flash_attn2" if _spec_util.find_spec("flash_attn") is not None else "sdpa"
-                    except Exception:
-                        attn_impl = "sdpa"
-
-                    t_total_start = legacy_started_at if legacy_started_at is not None else time.perf_counter()
-                    t_pre_start = time.perf_counter()
-                    t_pre_end = time.perf_counter()
-                    t_pre_ms = (t_pre_end - t_pre_start) * 1000.0
-
-                    with _torch_no_grad():
-                        t_infer_start = time.perf_counter()
-                        result = self.pipe(
-                            audio_source,
-                            chunk_length_s=self.chunk_length_sec,
-                            batch_size=dynamic_batch_size,
-                            return_timestamps=False,
-                            generate_kwargs=generate_kwargs
-                        )
-                        t_infer_end = time.perf_counter()
-                    t_infer_ms = (t_infer_end - t_infer_start) * 1000.0
-
-                    try:
-                        self.last_dynamic_batch_size = int(dynamic_batch_size)
-                    except Exception:
-                        self.last_dynamic_batch_size = None
-
-                    t_post_start = time.perf_counter()
-
-                    if result and "text" in result:
-                        text_result = result["text"].strip()
-                        if not text_result:
-                            text_result = "[No speech detected]"
-                        else:
-                            logging.info(
-                                "Segment transcription succeeded.",
-                                extra={"event": "segment_transcription", "status": "success"},
-                            )
-                    else:
-                        text_result = "[Transcription failed: Bad format]"
-                        logging.error(f"Unexpected transcription result format: {result}")
-
-                    t_post_end = time.perf_counter()
-                    t_post_ms = (t_post_end - t_post_start) * 1000.0
-                    t_total_ms = (t_post_end - t_total_start) * 1000.0
-
-                    self._log_model_event(
-                        "transcription_success",
-                        batch_size=dynamic_batch_size,
-                        chunk_length_s=float(self.chunk_length_sec),
-                        size=size_descriptor,
-                        agent_mode=agent_mode,
-                        duration_ms=t_total_ms,
-                    )
-
-                    try:
-                        logging.info(
-                            "Segment preprocessing completed.",
-                            extra={
-                                "event": "segment_timing",
-                                "stage": "pre",
-                                "duration_ms": t_pre_ms,
-                                "details": (
-                                    f"device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} "
-                                    f"dtype={dtype} attn={attn_impl}"
-                                ),
-                            },
-                        )
-                        logging.info(
-                            "Segment inference completed.",
-                            extra={
-                                "event": "segment_timing",
-                                "stage": "infer",
-                                "duration_ms": t_infer_ms,
-                                "details": (
-                                    f"device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} "
-                                    f"dtype={dtype} attn={attn_impl}"
-                                ),
-                            },
-                        )
-                        logging.info(
-                            "Segment post-processing completed.",
-                            extra={
-                                "event": "segment_timing",
-                                "stage": "post",
-                                "duration_ms": t_post_ms,
-                                "details": (
-                                    f"device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} "
-                                    f"dtype={dtype} attn={attn_impl}"
-                                ),
-                            },
-                        )
-                        logging.info(
-                            "Segment total duration recorded.",
-                            extra={
-                                "event": "segment_timing",
-                                "stage": "total",
-                                "duration_ms": t_total_ms,
-                                "details": (
-                                    f"device={device} chunk={self.chunk_length_sec} batch={dynamic_batch_size} "
-                                    f"dtype={dtype} attn={attn_impl}"
-                                ),
-                            },
-                        )
-                    except Exception:
-                        pass
-
-                    # Fim do bloco de processamento principal do segmento
-
-            except Exception as e:
-                # Tratamento de OOM e fallback automático (reduz batch, depois chunk) – não recria a pipeline
-                try:
-                    err_txt = str(e).lower()
-                    is_oom = any(
-                        tok in err_txt
-                        for tok in [
-                            "out of memory",
-                            "cuda oom",
-                            "cublas",
-                            "cudnn",
-                            "hip out of memory",
-                            "alloc",
-                        ]
-                    )
-                    if is_oom:
-                        logging.warning(
-                            "Out-of-memory detected during transcription. Initiating automatic recovery routine."
-                        )
-                        self._apply_oom_recovery(dynamic_batch_size)
-                    # Continua fluxo normal de erro
-                except Exception as _oom_adj_e:
-                    logging.debug(f"Failed to adjust parameters after OOM: {_oom_adj_e}")
-
-                if not logged_failure:
-                    if legacy_started_at is not None:
-                        duration_ms = (time.perf_counter() - legacy_started_at) * 1000.0
-                        self._log_model_event(
-                            "transcription_failure",
-                            level=logging.ERROR,
-                            batch_size=dynamic_batch_size,
-                            chunk_length_s=float(self.chunk_length_sec),
-                            size=size_descriptor,
-                            agent_mode=agent_mode,
-                            duration_ms=duration_ms,
-                            error=str(e),
-                        )
-                    else:
-                        self._log_model_event(
-                            "transcription_failure",
-                            level=logging.ERROR,
-                            batch_size=dynamic_batch_size,
-                            chunk_length_s=float(self.chunk_length_sec),
-                            size=size_descriptor,
-                            agent_mode=agent_mode,
-                            error=str(e),
-                        )
-
-                logging.error(f"Error during segment transcription: {e}", exc_info=True)
-                text_result = f"[Transcription Error: {e}]"
-
-        if self.transcription_cancel_event.is_set():
-            self._log_model_event(
-                "transcription_cancelled",
-                status="inference_cancelled",
-                agent_mode=agent_mode,
-            )
-            logging.info(
-                "Transcription cancelled by stop signal; result discarded.",
-                extra={"event": "transcription_cancel", "stage": "postprocess"},
-            )
-            self.transcription_cancel_event.clear()
-            return
-
-        if text_result and self.config_manager.get(DISPLAY_TRANSCRIPTS_KEY):
-            logging.info(
-                "Raw transcription generated.",
-                extra={"event": "transcription_output", "details": f"chars={len(text_result or '')}"},
-            )
-
-        if (
-            not text_result
-            or text_result == "[No speech detected]"
-            or text_result.strip().startswith("[Transcription Error:")
-        ):
-            logging.warning(f"Segment processed without meaningful text or with error: {text_result}")
-            if text_result and self.on_segment_transcribed_callback:
-                self.on_segment_transcribed_callback(text_result or "")
-            if (
-                not agent_mode
-                and text_result
-                and (
-                    not self.is_state_transcribing_fn
-                    or self.is_state_transcribing_fn()
-                )
-            ):
-                if self.on_transcription_result_callback:
-                    self.on_transcription_result_callback(text_result, text_result)
-            elif not agent_mode and text_result:
-                logging.warning(
-                    "Application state changed before transcription result. UI will not be updated."
-                )
-            return
-
+        warmup_failed = None
         try:
-            enable_clear = bool(self.config_manager.get(CLEAR_GPU_CACHE_CONFIG_KEY))
-            is_gpu = _torch_cuda_available() and getattr(self, "gpu_index", -1) >= 0
-            long_audio = float(getattr(self, "chunk_length_sec", 30.0)) >= 45.0
-            if enable_clear and is_gpu and long_audio:
-                t_ec_start = time.perf_counter()
-                assert torch is not None
-                before_b = (
-                    torch.cuda.memory_allocated()
-                    if hasattr(torch.cuda, "memory_allocated")
-                    else 0
-                )
-                torch.cuda.empty_cache()
-                after_b = (
-                    torch.cuda.memory_allocated()
-                    if hasattr(torch.cuda, "memory_allocated")
-                    else 0
-                )
-                t_ec_ms = (time.perf_counter() - t_ec_start) * 1000.0
-                freed_mb = max(0.0, (before_b - after_b) / (1024 ** 2))
-                logging.info(
-                    "CUDA cache cleared after transcription.",
-                    extra={
-                        "event": "empty_cache",
-                        "duration_ms": t_ec_ms,
-                        "details": f"freed_estimate_mb={freed_mb:.1f}",
-                    },
-                )
-        except Exception as _ec_e:
-            logging.debug(f"Failed to execute optional empty_cache: {_ec_e}")
+            self._asr_backend.warmup()
+        except Exception as warmup_error:
+            warmup_failed = warmup_error
+            logging.debug("ASR backend warmup failed: %s", warmup_error)
 
-        final_text = self._process_ai_pipeline(text_result, agent_mode)
-
-        if agent_mode:
-            if not self.on_agent_result_callback:
-                logging.debug("Agent result callback not configured.")
-                return
-            if not self.is_state_transcribing_fn or self.is_state_transcribing_fn():
-                self.on_agent_result_callback(final_text)
-            else:
-                logging.warning(
-                    "Application state changed before agent result. UI will not be updated."
-                )
-        else:
-            if not self.on_transcription_result_callback:
-                logging.debug("Transcription result callback not configured.")
-            elif not self.is_state_transcribing_fn or self.is_state_transcribing_fn():
-                self.on_transcription_result_callback(final_text, text_result)
-            else:
-                logging.warning(
-                    "Application state changed before transcription result. UI will not be updated."
-                )
-
-        if _torch_cuda_available():
-            logging.debug(
-                "GPU cache preserved for consecutive transcriptions."
-            )
-
-    def _handle_unexpected_transcription_error(
-        self,
-        error: Exception,
-        *,
-        audio_source: str | np.ndarray | bytes | bytearray | list[float] | None,
-        agent_mode: bool,
-    ) -> None:
-        """Garante tratamento uniforme para falhas não mapeadas durante a transcrição."""
-
-        error_message = f"[Transcription Error: {error}]"
-        logging.error(
-            "Unexpected error while transcribing audio: %s",
-            error,
-            exc_info=True,
+        duration_ms = (time.perf_counter() - load_started_at) * 1000.0
+        resolved_device = getattr(self._asr_backend, "device", effective_device)
+        resolved_model = getattr(self._asr_backend, "model_id", req_model_id)
+        resolved_dtype = load_kwargs.get("dtype", req_dtype)
+        resolved_compute = load_kwargs.get(
+            "ct2_compute_type",
+            self.config_manager.get(ASR_CT2_COMPUTE_TYPE_CONFIG_KEY),
         )
-
-        try:
-            self._log_model_event(
-                "transcription_failure",
-                level=logging.ERROR,
-                size=self._format_audio_source(audio_source),
-                agent_mode=agent_mode,
-                error=str(error),
-            )
-        except Exception:  # pragma: no cover - logging defensivo
-            logging.debug("Failed to log unexpected transcription failure.", exc_info=True)
-
-        if self.on_segment_transcribed_callback:
-            try:
-                self.on_segment_transcribed_callback(error_message)
-            except Exception:  # pragma: no cover - callback externo
-                logging.debug(
-                    "Failed to propagate segment-level error callback.",
-                    exc_info=True,
-                )
-
-        if self.on_model_error_callback:
-            try:
-                self.on_model_error_callback(str(error))
-            except Exception:  # pragma: no cover - callback externo
-                logging.debug(
-                    "Failed to propagate model error callback for unexpected error.",
-                    exc_info=True,
-                )
-
-        target_callback = (
-            self.on_agent_result_callback if agent_mode else self.on_transcription_result_callback
+        self._update_model_log_context(
+            backend=backend_candidate,
+            model=resolved_model,
+            device=resolved_device,
+            dtype=resolved_dtype,
+            compute_type=resolved_compute,
+            chunk_length_s=float(self.chunk_length_sec),
+            batch_size=self.batch_size,
         )
-        should_emit = (not self.is_state_transcribing_fn) or self.is_state_transcribing_fn()
-        if target_callback and should_emit:
-            try:
-                if agent_mode:
-                    target_callback(error_message)
-                else:
-                    target_callback(error_message, error_message)
-            except Exception:  # pragma: no cover - callback externo
-                logging.debug(
-                    "Failed to propagate unexpected transcription error to consumer.",
-                    exc_info=True,
-                )
-
-        self.transcription_cancel_event.clear()
-
-    def _apply_oom_recovery(self, current_batch_size: int | None) -> bool:
-        """Ajusta parâmetros internos após detectar falta de memória (OOM).
-
-        Args:
-            current_batch_size: Valor positivo que representa o batch utilizado
-                no momento da falha. Informe ``None`` para reaproveitar a última
-                configuração bem-sucedida.
-
-        Returns:
-            ``True`` quando algum ajuste temporário foi realizado para manter a
-            execução atual; ``False`` caso nenhum ajuste adicional esteja
-            disponível.
-        """
-
-        def _report(message: str) -> None:
-            core = getattr(self, "core_instance_ref", None)
-            if core and hasattr(core, "report_runtime_notice"):
-                try:
-                    core.report_runtime_notice(message, level=logging.WARNING)
-                    return
-                except Exception as exc:
-                    logging.debug("Failed to notify UI about OOM adjustment: %s", exc)
-            logging.warning(message)
-
-        old_batch_size: int | None = None
-        try:
-            if current_batch_size is not None:
-                old_batch_size = int(current_batch_size)
-        except Exception:
-            old_batch_size = None
-
-        if old_batch_size is None:
-            try:
-                if self.last_dynamic_batch_size is not None:
-                    old_batch_size = int(self.last_dynamic_batch_size)
-            except Exception:
-                old_batch_size = None
-
-        if old_batch_size is not None and old_batch_size > 1:
-            new_batch_size = max(1, old_batch_size // 2)
-            if new_batch_size < old_batch_size:
-                if self.batch_size_mode == "manual":
-                    self.manual_batch_size = new_batch_size
-                else:
-                    self.batch_size = new_batch_size
-                self.last_dynamic_batch_size = new_batch_size
-                message = (
-                    "OOM detected. Reducing batch_size from "
-                    f"{old_batch_size} to {new_batch_size} for this session only."
-                )
-                _report(message)
-                try:
-                    logging.info(
-                        "OOM recovery adjusted batch size.",
-                        extra={
-                            "event": "oom_recovery",
-                            "action": "reduce_batch",
-                            "details": f"mode={self.batch_size_mode} from={old_batch_size} to={new_batch_size}",
-                        },
-                    )
-                except Exception:
-                    pass
-                return True
-
-        # Se não conseguimos reduzir batch_size, ajusta chunk_length_sec
-        try:
-            old_chunk = float(self.chunk_length_sec)
-        except Exception:
-            old_chunk = 30.0
-
-        new_chunk = max(10.0, old_chunk * 0.66)
-        if new_chunk < old_chunk:
-            self.chunk_length_sec = new_chunk
-            message = (
-                "Persistent OOM. Reducing chunk_length_sec from "
-                f"{old_chunk:.1f}s to {new_chunk:.1f}s for this session only."
-            )
-            _report(message)
-            try:
-                logging.info(
-                    "OOM recovery adjusted chunk length.",
-                    extra={
-                        "event": "oom_recovery",
-                        "action": "reduce_chunk",
-                        "details": f"from={old_chunk:.1f}s to={new_chunk:.1f}s",
-                    },
-                )
-            except Exception:
-                pass
-            return True
-
-        _report(
-            "Persistent OOM. Batch size and chunk length are already at their minimum for this session."
+        self._log_model_event(
+            "load_success",
+            backend=backend_candidate,
+            device=resolved_device,
+            dtype=resolved_dtype,
+            compute_type=resolved_compute,
+            duration_ms=duration_ms,
+            status="warmup_failed" if warmup_failed else "ready",
         )
-        return False
-
-    def _effective_chunk_length(self) -> float:
-        """
-        Heurística simples para chunk_length_sec quando em modo 'auto'.
-        Baseada na VRAM livre estimada da GPU alvo.
-        """
-        try:
-            if not _torch_cuda_available() or self.gpu_index < 0:
-                return float(self.chunk_length_sec)  # manter o manual atual em CPU
-            torch_mod = _require_torch()
-            free_bytes, total_bytes = torch_mod.cuda.mem_get_info(
-                torch_mod.device(f"cuda:{self.gpu_index}")
-            )
-            free_gb = free_bytes / (1024 ** 3)
-            # Heurística: mais VRAM livre -> chunks maiores
-            if free_gb >= 12:
-                return 60.0
-            elif free_gb >= 8:
-                return 45.0
-            elif free_gb >= 6:
-                return 30.0
-            elif free_gb >= 4:
-                return 20.0
-            else:
-                return 15.0
-        except Exception:
-            # fallback seguro
-            try:
-                return float(self.chunk_length_sec)
-            except Exception:
-                return 30.0
-
-    def shutdown(self) -> None:
-        """Encerra o executor de transcrição."""
-        try:
-            # Sinaliza cancelamento para qualquer tarefa em andamento
-            self.transcription_cancel_event.set()
-
-            self.transcription_executor.shutdown(wait=False, cancel_futures=True)
-        except Exception as e:
-            logging.error(f"Erro ao encerrar o executor de transcrição: {e}")
-        finally:
-            if _torch_cuda_available():
-                assert torch is not None
-                torch.cuda.empty_cache()
-                logging.debug(
-                    "Cache da GPU liberado no encerramento do aplicativo."
-                )
+        self._model_load_started_at = None
+        logging.info(
+            "Backend '%s' initialized on device %s.",
+            self.backend_resolved,
+            self.device_in_use,
+        )
+        return self._asr_backend, None

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -138,8 +138,8 @@ def _backend_display_value_global(value: str | None) -> str:
     normalized = (value or "").strip().lower()
     if normalized in {"ct2", "ctranslate2"}:
         return "ctranslate2"
-    if normalized in {"faster whisper", "faster_whisper"}:
-        return "faster-whisper"
+    if normalized in {"faster whisper", "faster_whisper", "faster-whisper"}:
+        return "ctranslate2"
     return normalized
 
 class UIManager:
@@ -883,9 +883,10 @@ class UIManager:
                 installed = []
             entry = next((m for m in installed if m.get("id") == model_id), None)
         backend = entry.get("backend") if entry else None
-        if backend not in ("transformers", "ctranslate2", "faster-whisper"):
+        if not backend:
             return None
-        return backend
+        normalized = _backend_display_value_global(backend)
+        return normalized or None
 
     def _update_install_button_state(self) -> None:
         model_var = self._get_settings_var("asr_model_id_var")
@@ -2211,13 +2212,13 @@ class UIManager:
         asr_backend_menu = ctk.CTkOptionMenu(
             asr_backend_frame,
             variable=asr_backend_var,
-            values=["ctranslate2", "faster-whisper", "transformers"],
+            values=["ctranslate2"],
             command=_on_backend_change,
         )
         asr_backend_menu.pack(side="left", padx=5)
         Tooltip(
             asr_backend_menu,
-            "Inference backend for speech recognition.\nDerived from selected model; override in advanced mode.",
+            "CTranslate2 runtime used for all curated models.",
         )
 
         quant_frame = ctk.CTkFrame(asr_frame)
@@ -2453,9 +2454,7 @@ class UIManager:
             if entry is None:
                 entry = installed_by_id.get(model_id)
             backend = _backend_display_value_global(entry.get("backend") if entry else None)
-            if backend not in ("transformers", "ctranslate2", "faster-whisper"):
-                return None
-            return backend
+            return backend or None
 
         def _update_model_info(model_id: str) -> None:
             ui_elements["model_size_label"].configure(text="Download: calculating... | Installed: -")


### PR DESCRIPTION
## Summary
- remove the legacy Transformers backend factory path and ensure TranscriptionHandler raises when an unsupported backend is selected
- normalize configuration, UI flows, and onboarding to expose only the CTranslate2 runtime while updating documentation for the CT2-only policy
- drop the transformers dependency pins from requirements files to match the runtime changes

## Testing
- python -m compileall src
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e50380b06c83309094af0b061eea4f