### PR TITLE
Add CI matrix workflow for pytest and flake8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    name: Python ${{ matrix.python-version }} • ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ['3.10', '3.11', '3.12']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
+
+      - name: Run pytest
+        shell: bash
+        run: |
+          set -o pipefail
+          pytest -q | tee pytest.log
+
+      - name: Run flake8
+        shell: bash
+        run: |
+          set -o pipefail
+          flake8 | tee flake8.log
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: |
+            pytest.log
+            flake8.log


### PR DESCRIPTION
## Summary
- add a new CI workflow triggered on push and pull requests
- run pytest and flake8 across Python 3.10-3.12 on Ubuntu and Windows
- upload pytest and flake8 logs as artifacts when jobs fail

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68e529b57fac833090f2a9f33fa0c729