### PR TITLE
Normalize ASR backend handling to CTranslate2 only

### DIFF
--- a/src/asr/backends.py
+++ b/src/asr/backends.py
@@ -24,8 +24,9 @@ class ASRBackend(Protocol):
 def make_backend(name: str) -> ASRBackend:
     """Factory that returns an ASR backend by name."""
     normalized = name.strip().lower()
-    if normalized in {"faster-whisper", "faster_whisper", "ct2", "ctranslate2"}:
+    if normalized in {"auto", "faster-whisper", "faster_whisper", "ct2", "ctranslate2"}:
         from .backend_faster_whisper import FasterWhisperBackend
+
         return FasterWhisperBackend()
     raise ValueError(
         f"Unsupported ASR backend '{name}'. Only the CTranslate2 runtime is available."

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -330,19 +330,31 @@ CONFIG_LOGGER = get_logger("whisper_flash_transcriber.config", component="Config
 
 def _normalize_asr_backend(name: str | None) -> str | None:
     """Return canonical backend name for persistence and UI consistency."""
-    if not isinstance(name, str):
+    if name is None or not isinstance(name, str):
         return name
+
     normalized = name.strip().lower()
-    if normalized in {
+    if not normalized:
+        return ""
+
+    allowed_aliases = {
         "ct2",
         "ctranslate2",
         "faster whisper",
         "faster_whisper",
         "faster-whisper",
         "auto",
-    }:
-        return "ctranslate2"
-    return normalized
+    }
+    if normalized not in allowed_aliases:
+        CONFIG_LOGGER.debug(
+            log_context(
+                "Mapping unsupported ASR backend to 'ctranslate2'.",
+                event="config.unsupported_backend_normalized",
+                backend=name,
+            )
+        )
+
+    return "ctranslate2"
 
 
 class ConfigManager:

--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -311,12 +311,31 @@ def find_existing_installation(
 
 def normalize_backend_label(backend: str | None) -> str:
     """Return a normalized backend label for UI/configuration."""
-    if not backend:
+    if backend is None:
         return ""
-    normalized = backend.strip().lower()
-    if normalized in {"ct2", "ctranslate2", "faster whisper", "faster_whisper", "faster-whisper"}:
-        return "ctranslate2"
-    return normalized
+
+    normalized = str(backend).strip().lower()
+    if not normalized:
+        return ""
+
+    allowed_aliases = {
+        "ct2",
+        "ctranslate2",
+        "faster whisper",
+        "faster_whisper",
+        "faster-whisper",
+        "auto",
+    }
+    if normalized not in allowed_aliases:
+        MODEL_LOGGER.debug(
+            log_context(
+                "Mapping unsupported backend label to 'ctranslate2'.",
+                event="model_manager.unsupported_backend_normalized",
+                backend=str(backend),
+            )
+        )
+
+    return "ctranslate2"
 
 
 def backend_storage_name(backend: str | None) -> str:


### PR DESCRIPTION
## Summary
- ensure the ASR backend factory only instantiates the CTranslate2 implementation
- normalize configuration values to map any backend selection to the CTranslate2 runtime
- harden model manager backend normalization and logging to drop leftover identifiers

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e529961e6c8330ac66d81c806f2b45