### PR TITLE
Refactor CT2 batch sizing and remove default torch dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,12 @@ Whisper Flash Transcriber is a high-performance, hotkey-driven audio transcripti
    ```bash
    pip install -r requirements.txt
    ```
-   The pinned dependencies include the CPU build of PyTorch (2.5.1) so that Windows users can install the project without
-   touching custom package indexes. If you plan to leverage a GPU, install the base requirements first and then follow the
-   guidance in the section below to swap in the CUDA-enabled wheel that matches your driver.
+   The pinned dependencies focus on the CTranslate2 backend. Install PyTorch separately only if you intend to use the optional
+   Transformers backend or experiment with `torch.compile` tweaks.
 
 ### Optional: GPU Acceleration
 
-For significantly faster transcription you can leverage an NVIDIA GPU. Install PyTorch with CUDA support following the official instructions once the base requirements are installed:
+For significantly faster transcription you can leverage an NVIDIA GPU. Install PyTorch with CUDA support following the official instructions after the base requirements when opting into the optional Transformers backend:
 
 1. Visit the [PyTorch installation guide](https://pytorch.org/get-started/locally/).
 2. Select the desired PyTorch build, operating system, package manager, Python version, and CUDA version.

--- a/config.json
+++ b/config.json
@@ -22,9 +22,6 @@
   "prompt_agentico": "You are an AI assistant that executes text commands. The user will provide an instruction followed by the text to be processed. Your task is to execute the instruction on the text and return ONLY the final result. Do not add explanations, greetings, or any extra text. The output language should match the main language of the provided text.",
   "gemini_prompt": "You are a meticulous speech-to-text correction AI. Your primary task is to correct punctuation, capitalization, and minor transcription errors in the text below while preserving the original content and structure as closely as possible. Key instructions: - Correct punctuation, such as adding commas, periods, and question marks. - Fix capitalization at the beginning of sentences. - Remove only obvious speech disfluencies (e.g., \"I-I mean\"). - DO NOT summarize, paraphrase, or change the original meaning. - Return ONLY the corrected text, with no additional comments or explanations. Transcribed speech: {text}",
   "batch_size": 16,
-  "batch_size_mode": "auto",
-  "manual_batch_size": 8,
-  "gpu_index": -1,
   "hotkey_stability_service_enabled": false,
   "use_vad": true,
   "vad_threshold": 0.5,
@@ -75,7 +72,5 @@
     "decision": "",
     "timestamp": 0
   },
-  "batch_size_specified": true,
-  "gpu_index_specified": true,
   "record_to_memory": false
 }

--- a/docs/ui_vars.md
+++ b/docs/ui_vars.md
@@ -43,7 +43,7 @@ Este documento consolida todas as instâncias de `ctk.*Var` usadas na janela de 
 | ASR | `asr_backend_var` | `StringVar` | `CTkOptionMenu` (`asr_backend_menu`) | `"asr_backend"` | Permite sobrepor o backend inferido pelo modelo selecionado. |
 | ASR | `asr_model_id_var` | `StringVar` | Alimentado por `CTkOptionMenu` (`asr_model_menu`) via `asr_model_display_var` | `"asr_model_id"` | Guarda o identificador interno do modelo escolhido. |
 | ASR | `asr_model_display_var` | `StringVar` | `CTkOptionMenu` (`asr_model_menu`) | `"asr_model_id"` (mapeado por `display_to_id`) | Variável de exibição; converte nomes amigáveis para `asr_model_id_var`. |
-| ASR | `asr_compute_device_var` | `StringVar` | `CTkOptionMenu` (`asr_device_menu`) | `"asr_compute_device"` + `"gpu_index"` | Representa a seleção textual (*Auto*, *Force CPU*, *GPU X*), traduzida para backend e índice ao aplicar. |
+| ASR | `asr_compute_device_var` | `StringVar` | `CTkOptionMenu` (`asr_device_menu`) | `"asr_compute_device"` | Representa a seleção textual (*Auto*, *Prefer GPU*, *Force CPU*), mapeada para o dispositivo aceito pelo CTranslate2 sem exigir índices de GPU. |
 | ASR | `asr_dtype_var` | `StringVar` | `CTkOptionMenu` (`asr_dtype_menu`) | `"asr_dtype"` | Define a precisão dos tensores do backend Torch. |
 | ASR | `asr_ct2_compute_type_var` | `StringVar` | `CTkOptionMenu` (`asr_ct2_menu`) | `"asr_ct2_compute_type"` | Ajusta o compute type quando o backend é CTranslate2. |
 | ASR | `models_storage_dir_var` | `StringVar` | `CTkEntry` (`models_dir_entry`) | `"models_storage_dir"` | Diretório raiz usado para armazenar modelos e demais artefatos pesados; também serve de destino padrão quando o `storage_root_dir` muda sem override explícito. |

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,6 +1,8 @@
 # Optional dependencies for additional ASR backends and advanced GPU features
 faster-whisper>=1.0
 ctranslate2>=4.6
+# PyTorch is required only for the optional Transformers backend.
+torch==2.5.1
 # bitsandbytes publishes wheels only for Linux (and WSL/conda environments).
 # The environment marker prevents pip from attempting an install on Windows.
 bitsandbytes>=0.43.0 ; platform_system != "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-torch==2.5.1
 sounddevice==0.5.2
 numpy==2.3.0
 pyautogui==0.9.54

--- a/src/asr/backend_faster_whisper.py
+++ b/src/asr/backend_faster_whisper.py
@@ -219,9 +219,12 @@ class FasterWhisperBackend:
 
 def _has_cuda() -> bool:
     try:
-        import torch
+        import ctranslate2  # type: ignore
+    except Exception:
+        return False
 
-        return torch.cuda.is_available()
+    try:
+        return bool(ctranslate2.get_supported_compute_types("cuda"))
     except Exception:
         return False
 

--- a/src/asr/backend_transformers.py
+++ b/src/asr/backend_transformers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import importlib
 import logging
 
 from ..logging_utils import get_logger, log_context
@@ -31,7 +32,13 @@ class TransformersBackend:
     ) -> None:
         """Load model and processor, constructing the inference pipeline."""
         from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq, pipeline
-        import torch
+
+        try:
+            torch = importlib.import_module("torch")
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "The Transformers backend requires the 'torch' package. Install it using the optional requirements."
+            ) from exc
 
         model_override = kwargs.pop("model_id", None)
         if model_override:

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -112,9 +112,6 @@ class AppConfig(BaseModel):
     gemini_prompt: str = ""
     ui_language: str = _DEFAULT_UI_LANGUAGE
     batch_size: int = Field(default=16, ge=1)
-    batch_size_mode: str = "auto"
-    manual_batch_size: int = Field(default=8, ge=1)
-    gpu_index: int = Field(default=0, ge=-1)
     hotkey_stability_service_enabled: bool = True
     use_vad: bool = False
     vad_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
@@ -215,13 +212,6 @@ class AppConfig(BaseModel):
         if isinstance(value, str):
             return cls._normalize_lower(value, allowed={"toggle", "press"}, field_name="record_mode")
         raise ValueError("record_mode must be a string")
-
-    @field_validator("batch_size_mode", mode="before")
-    @classmethod
-    def _validate_batch_size_mode(cls, value: Any) -> str:
-        if isinstance(value, str):
-            return cls._normalize_lower(value, allowed={"auto", "manual"}, field_name="batch_size_mode")
-        raise ValueError("batch_size_mode must be a string")
 
     @field_validator("record_storage_mode", mode="before")
     @classmethod

--- a/src/core.py
+++ b/src/core.py
@@ -2181,7 +2181,6 @@ class AppCore:
             "new_agent_model": "gemini_agent_model",
             "new_gemini_prompt": GEMINI_PROMPT_CONFIG_KEY,
             "new_batch_size": "batch_size",
-            "new_gpu_index": "gpu_index",
             "new_hotkey_stability_service_enabled": "hotkey_stability_service_enabled",
             "new_min_transcription_duration": "min_transcription_duration",
             "new_min_record_duration": "min_record_duration",
@@ -2456,9 +2455,7 @@ class AppCore:
             set_launch_at_startup(bool(value))
 
         transcription_config_keys = {
-            "batch_size_mode",
-            "manual_batch_size",
-            "gpu_index",
+            "batch_size",
             "min_transcription_duration",
             "record_to_memory",
             "max_memory_seconds",


### PR DESCRIPTION
## Summary
- redesign the batch size helper and transcription flow to rely on CTranslate2 settings instead of torch-based VRAM inspection
- simplify configuration, UI controls, and diagnostics by removing manual batch/GPU index options and querying CTranslate2 capabilities
- move torch to optional dependencies and update documentation and requirements accordingly

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e50be14f8c8330bbab51211ad4303c