### PR TITLE
Normalize legacy ASR backend aliases

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -235,23 +235,28 @@ def _normalize_asr_backend(name: str | None) -> str | None:
     if not normalized:
         return ""
 
-    allowed_aliases = {
-        "ct2",
-        "ctranslate2",
-        "faster whisper",
-        "faster_whisper",
-        "faster-whisper",
-        "auto",
+    alias_map = {
+        "ct2": "ctranslate2",
+        "ctranslate2": "ctranslate2",
+        "faster whisper": "ctranslate2",
+        "faster_whisper": "ctranslate2",
+        "faster-whisper": "ctranslate2",
+        "transformer": "ctranslate2",
+        "transformers": "ctranslate2",
+        "auto": "auto",
     }
-    if normalized not in allowed_aliases:
-        CONFIG_LOGGER.debug(
-            log_context(
-                "Mapping unsupported ASR backend to 'ctranslate2'.",
-                event="config.unsupported_backend_normalized",
-                backend=name,
-            )
-        )
 
+    mapped = alias_map.get(normalized)
+    if mapped:
+        return mapped
+
+    CONFIG_LOGGER.debug(
+        log_context(
+            "Mapping unsupported ASR backend to 'ctranslate2'.",
+            event="config.unsupported_backend_normalized",
+            backend=name,
+        )
+    )
     return "ctranslate2"
 
 

--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -318,22 +318,28 @@ def normalize_backend_label(backend: str | None) -> str:
     if not normalized:
         return ""
 
-    allowed_aliases = {
-        "ct2",
-        "ctranslate2",
-        "faster whisper",
-        "faster_whisper",
-        "faster-whisper",
-        "auto",
+    alias_map = {
+        "ct2": "ctranslate2",
+        "ctranslate2": "ctranslate2",
+        "faster whisper": "ctranslate2",
+        "faster_whisper": "ctranslate2",
+        "faster-whisper": "ctranslate2",
+        "transformer": "ctranslate2",
+        "transformers": "ctranslate2",
+        "auto": "auto",
     }
-    if normalized not in allowed_aliases:
-        MODEL_LOGGER.debug(
-            log_context(
-                "Mapping unsupported backend label to 'ctranslate2'.",
-                event="model_manager.unsupported_backend_normalized",
-                backend=str(backend),
-            )
+
+    mapped = alias_map.get(normalized)
+    if mapped:
+        return mapped
+
+    MODEL_LOGGER.debug(
+        log_context(
+            "Mapping unsupported backend label to 'ctranslate2'.",
+            event="model_manager.unsupported_backend_normalized",
+            backend=str(backend),
         )
+    )
 
     return "ctranslate2"
 


### PR DESCRIPTION
## Summary
- ensure configuration normalization maps legacy "transformers" backend values to the supported ctranslate2 runtime
- keep model manager backend normalization consistent so UI and runtime use the same aliases

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e52ab1752c833081f08d45f6cfddad