### PR TITLE
Add operation context IDs to recording and transcription pipelines

### DIFF
--- a/src/action_orchestrator.py
+++ b/src/action_orchestrator.py
@@ -78,7 +78,12 @@ class ActionOrchestrator:
     # ------------------------------------------------------------------
     # Audio coordination
     # ------------------------------------------------------------------
-    def on_audio_segment_ready(self, audio_source: str | np.ndarray) -> None:
+    def on_audio_segment_ready(
+        self,
+        audio_source: str | np.ndarray,
+        *,
+        operation_id: str | None = None,
+    ) -> None:
         """Processa um segmento de áudio finalizado."""
 
         duration_seconds = self._compute_duration_seconds(audio_source)
@@ -92,6 +97,7 @@ class ActionOrchestrator:
                     event="audio.segment_discarded",
                     duration_seconds=round(duration_seconds, 2),
                     min_duration_seconds=round(min_duration, 2),
+                    operation_id=operation_id,
                 )
             )
             self._state_manager.set_state(
@@ -101,6 +107,7 @@ class ActionOrchestrator:
                     f"{min_duration:.2f}s)"
                 ),
                 source="audio_handler",
+                operation_id=operation_id,
             )
             return
 
@@ -114,6 +121,7 @@ class ActionOrchestrator:
                     event="audio.dispatch_failed",
                     stage="transcription",
                     agent_mode=agent_mode,
+                    operation_id=operation_id,
                 )
             )
             if agent_mode:
@@ -125,6 +133,7 @@ class ActionOrchestrator:
                 sm.StateEvent.AUDIO_ERROR,
                 details="Transcription handler unavailable",
                 source="action_orchestrator",
+                operation_id=operation_id,
             )
             return
 
@@ -135,6 +144,7 @@ class ActionOrchestrator:
                 audio_source,
                 agent_mode,
                 correlation_id=correlation_id,
+                operation_id=operation_id,
             )
         except Exception as exc:  # pragma: no cover - defensive guard around handler
             LOGGER.error(
@@ -163,6 +173,7 @@ class ActionOrchestrator:
                         "Agent mode request preserved: transcription handler rejected audio segment (model likely unavailable).",
                         event="agent_mode.wait",
                         stage="transcription",
+                        operation_id=operation_id,
                     )
                 )
                 self._log_status(
@@ -182,13 +193,20 @@ class ActionOrchestrator:
                 stage="transcription",
                 duration_seconds=round(duration_seconds, 2),
                 agent_mode=agent_mode,
+                operation_id=operation_id,
             )
         )
 
     # ------------------------------------------------------------------
     # Result handling
     # ------------------------------------------------------------------
-    def handle_transcription_result(self, corrected_text: str | None, raw_text: str | None) -> None:
+    def handle_transcription_result(
+        self,
+        corrected_text: str | None,
+        raw_text: str | None,
+        *,
+        operation_id: str | None = None,
+    ) -> None:
         """Trata o resultado final da transcrição."""
 
         final_text = (corrected_text or "").strip()
@@ -211,6 +229,7 @@ class ActionOrchestrator:
             sm.StateEvent.TRANSCRIPTION_COMPLETED,
             details=f"Transcription finalized ({len(final_text)} chars)",
             source="transcription",
+            operation_id=operation_id,
         )
         self._close_live_transcription_ui()
         if self._reset_transcription_buffer:
@@ -220,10 +239,19 @@ class ActionOrchestrator:
 
         LOGGER.info(
             "Transcription ready for consumption.",
-            extra={"event": "transcription_ready", "details": f"chars={len(final_text)}"},
+            extra={
+                "event": "transcription_ready",
+                "details": f"chars={len(final_text)}",
+                "operation_id": operation_id,
+            },
         )
 
-    def handle_agent_result(self, agent_response_text: str) -> None:
+    def handle_agent_result(
+        self,
+        agent_response_text: str,
+        *,
+        operation_id: str | None = None,
+    ) -> None:
         """Trata o resultado do modo agente."""
 
         response = (agent_response_text or "").strip()
@@ -231,7 +259,7 @@ class ActionOrchestrator:
             self._log_status("Agent command returned an empty response.", error=True)
             LOGGER.warning(
                 "Agent command returned an empty response.",
-                extra={"event": "agent_response_empty"},
+                extra={"event": "agent_response_empty", "operation_id": operation_id},
             )
             return
 
@@ -246,6 +274,7 @@ class ActionOrchestrator:
             sm.StateEvent.AGENT_COMMAND_COMPLETED,
             details=f"Agent response delivered ({len(response)} chars)",
             source="agent_mode",
+            operation_id=operation_id,
         )
         self._close_live_transcription_ui()
         if self._delete_temp_audio_callback:

--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -32,6 +32,7 @@ from .logging_utils import (
     get_logger,
     log_context,
     log_operation,
+    operation_context,
     scoped_correlation_id,
 )
 
@@ -124,6 +125,7 @@ class AudioHandler:
         self.storage_root_dir: Path | None = None
         self.recordings_dir: Path | None = None
         self._session_id: str | None = None
+        self._current_operation_id: str | None = None
 
         # Dedicated queue and thread for audio processing
         self.audio_queue = queue.Queue()
@@ -151,7 +153,20 @@ class AudioHandler:
 
         storage_mode = "memory" if self.in_memory_mode else "disk"
         thread_name = threading.current_thread().name
+        op_id = self._current_operation_id
+        if op_id:
+            return self._logger.bind(
+                storage=storage_mode,
+                thread=thread_name,
+                operation_id=op_id,
+            )
         return self._logger.bind(storage=storage_mode, thread=thread_name)
+
+    @property
+    def current_operation_id(self) -> str | None:
+        """Return the operation identifier assigned to the active recording."""
+
+        return self._current_operation_id
 
     def _audio_callback(self, indata, frames, time_data, status):
         if status:
@@ -591,127 +606,137 @@ class AudioHandler:
 
         try:
             with scoped_correlation_id(session_id):
-                with log_operation(
-                    self._log,
-                    "Initializing audio recording session.",
-                    event="audio.recording.session",
-                    details={
-                        "requested_mode": self.record_storage_mode,
-                        "vad_enabled": bool(self.use_vad),
-                    },
-                ):
-                    if not self._processing_thread or not self._processing_thread.is_alive():
-                        self.audio_queue = queue.Queue()
-                        self._processing_thread = threading.Thread(
-                            target=self._process_audio_queue,
-                            daemon=True,
-                        )
-                        self._processing_thread.start()
-
-                    if self._record_thread and self._record_thread.is_alive():
-                        self._log.debug(
-                            "Waiting for the previous recording thread to finish.",
-                            extra={"event": "record_thread_join", "stage": "recording"},
-                        )
-                        self._stop_event.set()
-                        self._record_thread.join(timeout=2)
-
-                    self._stop_event.clear()
-
-                    self._enforce_record_storage_limit(exclude_paths=[self.temp_file_path])
-
-                    if self.record_storage_mode == "memory":
-                        self.in_memory_mode = True
-                        reason = "configured for memory"
-                    elif self.record_storage_mode == "disk":
-                        self.in_memory_mode = False
-                        reason = "configured for disk"
-                    else:
-                        available_mb = get_available_memory_mb()
-                        if available_mb >= self.min_free_ram_mb and self.max_memory_seconds > 0:
-                            self.in_memory_mode = True
-                            reason = (
-                                f"auto: free RAM {available_mb:.0f}MB >= {self.min_free_ram_mb}MB"
+                with operation_context("recording") as operation_id:
+                    self._current_operation_id = operation_id
+                    with log_operation(
+                        self._log,
+                        "Initializing audio recording session.",
+                        event="audio.recording.session",
+                        details={
+                            "requested_mode": self.record_storage_mode,
+                            "vad_enabled": bool(self.use_vad),
+                        },
+                        operation_id=operation_id,
+                        operation_name="recording",
+                    ):
+                        if not self._processing_thread or not self._processing_thread.is_alive():
+                            self.audio_queue = queue.Queue()
+                            self._processing_thread = threading.Thread(
+                                target=self._process_audio_queue,
+                                daemon=True,
                             )
-                        else:
-                            self.in_memory_mode = False
-                            reason = (
-                                f"auto: free RAM {available_mb:.0f}MB < {self.min_free_ram_mb}MB"
-                            )
+                            self._processing_thread.start()
 
-                    if self.max_memory_seconds_mode == "auto":
-                        self.current_max_memory_seconds = self._calculate_auto_memory_seconds()
-                    else:
-                        self.current_max_memory_seconds = self.max_memory_seconds
-                    self._memory_limit_samples = int(self.current_max_memory_seconds * AUDIO_SAMPLE_RATE)
-
-                    self._log.info(
-                        StructuredMessage(
-                            "Recording storage mode decided.",
-                            event="audio.storage_selected",
-                            in_memory=self.in_memory_mode,
-                            rationale=reason,
-                            max_buffer_seconds=self.current_max_memory_seconds,
-                        )
-                    )
-
-                    with self.storage_lock:
-                        self.is_recording = True
-                        self.start_time = time.time()
-                        self._sample_count = 0
-                        self._memory_samples = 0
-
-                        if self.in_memory_mode:
-                            self.temp_file_path = None
-                            self._sf_writer = None
-                            self._audio_frames = []
-                        else:
-                            raw_tmp = self._create_temp_wav_file()
-                            self.temp_file_path = raw_tmp.name
-                            raw_tmp.close()
-                            self._sf_writer = sf.SoundFile(
-                                self.temp_file_path,
-                                mode="w",
-                                samplerate=AUDIO_SAMPLE_RATE,
-                                channels=AUDIO_CHANNELS,
-                            )
-
-                    if self.use_vad and self.vad_manager:
-                        try:
-                            self.vad_manager.reset_states()
-                        except Exception:
+                        if self._record_thread and self._record_thread.is_alive():
                             self._log.debug(
-                                "Failed to reset VAD states for new recording.",
-                                exc_info=True,
-                                extra={"event": "vad_reset_failed", "stage": "recording"},
+                                "Waiting for the previous recording thread to finish.",
+                                extra={"event": "record_thread_join", "stage": "recording"},
                             )
-                    self._log.debug(
-                        "VAD reset for new recording.",
-                        extra={"event": "vad_reset", "stage": "recording"},
-                    )
+                            self._stop_event.set()
+                            self._record_thread.join(timeout=2)
 
-                    self.state_manager.set_state("RECORDING")
+                        self._stop_event.clear()
 
-                    self._record_thread = threading.Thread(
-                        target=self._record_audio_task,
-                        daemon=True,
-                        name="AudioRecordThread",
-                    )
-                    self._record_thread.start()
+                        self._enforce_record_storage_limit(exclude_paths=[self.temp_file_path])
 
-                    threading.Thread(
-                        target=self._play_generated_tone_stream,
-                        kwargs={"is_start": True},
-                        daemon=True,
-                        name="StartSoundThread",
-                    ).start()
-                    return True
+                        if self.record_storage_mode == "memory":
+                            self.in_memory_mode = True
+                            reason = "configured for memory"
+                        elif self.record_storage_mode == "disk":
+                            self.in_memory_mode = False
+                            reason = "configured for disk"
+                        else:
+                            available_mb = get_available_memory_mb()
+                            if available_mb >= self.min_free_ram_mb and self.max_memory_seconds > 0:
+                                self.in_memory_mode = True
+                                reason = (
+                                    f"auto: free RAM {available_mb:.0f}MB >= {self.min_free_ram_mb}MB"
+                                )
+                            else:
+                                self.in_memory_mode = False
+                                reason = (
+                                    f"auto: free RAM {available_mb:.0f}MB < {self.min_free_ram_mb}MB"
+                                )
+
+                        if self.max_memory_seconds_mode == "auto":
+                            self.current_max_memory_seconds = self._calculate_auto_memory_seconds()
+                        else:
+                            self.current_max_memory_seconds = self.max_memory_seconds
+                        self._memory_limit_samples = int(self.current_max_memory_seconds * AUDIO_SAMPLE_RATE)
+
+                        self._log.info(
+                            StructuredMessage(
+                                "Recording storage mode decided.",
+                                event="audio.storage_selected",
+                                in_memory=self.in_memory_mode,
+                                rationale=reason,
+                                max_buffer_seconds=self.current_max_memory_seconds,
+                            )
+                        )
+
+                        with self.storage_lock:
+                            self.is_recording = True
+                            self.start_time = time.time()
+                            self._sample_count = 0
+                            self._memory_samples = 0
+
+                            if self.in_memory_mode:
+                                self.temp_file_path = None
+                                self._sf_writer = None
+                                self._audio_frames = []
+                            else:
+                                raw_tmp = self._create_temp_wav_file()
+                                self.temp_file_path = raw_tmp.name
+                                raw_tmp.close()
+                                self._sf_writer = sf.SoundFile(
+                                    self.temp_file_path,
+                                    mode="w",
+                                    samplerate=AUDIO_SAMPLE_RATE,
+                                    channels=AUDIO_CHANNELS,
+                                )
+
+                        if self.use_vad and self.vad_manager:
+                            try:
+                                self.vad_manager.reset_states()
+                            except Exception:
+                                self._log.debug(
+                                    "Failed to reset VAD states for new recording.",
+                                    exc_info=True,
+                                    extra={"event": "vad_reset_failed", "stage": "recording"},
+                                )
+                        self._log.debug(
+                            "VAD reset for new recording.",
+                            extra={"event": "vad_reset", "stage": "recording"},
+                        )
+
+                        self.state_manager.set_state(
+                            "RECORDING",
+                            operation_id=operation_id,
+                            source="audio_handler",
+                        )
+
+                        self._record_thread = threading.Thread(
+                            target=self._record_audio_task,
+                            daemon=True,
+                            name="AudioRecordThread",
+                        )
+                        self._record_thread.start()
+
+                        threading.Thread(
+                            target=self._play_generated_tone_stream,
+                            kwargs={"is_start": True},
+                            daemon=True,
+                            name="StartSoundThread",
+                        ).start()
+                        return True
         except Exception:
             self._session_id = None
+            self._current_operation_id = None
             raise
 
     def stop_recording(self):
         session_id = self._session_id
+        operation_id = self._current_operation_id
         try:
             with scoped_correlation_id(session_id, preserve_existing=True):
                 if not self.is_recording:
@@ -719,6 +744,7 @@ class AudioHandler:
                         StructuredMessage(
                             "Stop request ignored because no recording is active.",
                             event="audio.stop_ignored",
+                            operation_id=operation_id,
                         )
                     )
                     return False
@@ -730,6 +756,7 @@ class AudioHandler:
                         event="audio.recording.stop_request",
                         storage_mode=storage_mode,
                         samples=self._sample_count,
+                        operation_id=operation_id,
                     )
                 )
 
@@ -785,10 +812,15 @@ class AudioHandler:
                         StructuredMessage(
                             "Stop request ignored because audio stream never started.",
                             event="audio.stop_without_stream",
+                            operation_id=operation_id,
                         )
                     )
                     self._cleanup_temp_file()
-                    self.state_manager.set_state("IDLE")
+                    self.state_manager.set_state(
+                        "IDLE",
+                        operation_id=operation_id,
+                        source="audio_handler",
+                    )
                     return False
 
                 recording_duration = time.time() - self.start_time
@@ -801,6 +833,7 @@ class AudioHandler:
                             captured_seconds=rounded,
                             minimum_seconds=self.min_record_duration,
                             samples_recorded=self._sample_count,
+                            operation_id=operation_id,
                         )
                     )
                     LOGGER.warning(
@@ -810,10 +843,15 @@ class AudioHandler:
                             captured_seconds=rounded,
                             minimum_seconds=self.min_record_duration,
                             samples_recorded=self._sample_count,
+                            operation_id=operation_id,
                         )
                     )
                     self._cleanup_temp_file()
-                    self.state_manager.set_state("IDLE")
+                    self.state_manager.set_state(
+                        "IDLE",
+                        operation_id=operation_id,
+                        source="audio_handler",
+                    )
                     return False
 
                 if self.in_memory_mode:
@@ -822,7 +860,10 @@ class AudioHandler:
                         if self._audio_frames
                         else np.empty((0, AUDIO_CHANNELS), dtype=np.float32)
                     )
-                    self.on_audio_segment_ready_callback(audio_data.flatten())
+                    self.on_audio_segment_ready_callback(
+                        audio_data.flatten(),
+                        operation_id=operation_id,
+                    )
                 else:
                     if self.config_manager.get(SAVE_TEMP_RECORDINGS_CONFIG_KEY):
                         try:
@@ -854,6 +895,7 @@ class AudioHandler:
                                     size_bytes=target_path.stat().st_size
                                     if target_path.exists()
                                     else None,
+                                    operation_id=operation_id,
                                 )
                             )
                             self._enforce_record_storage_limit(exclude_paths=[target_path])
@@ -865,7 +907,10 @@ class AudioHandler:
                             except Exception:
                                 pass
                             self.temp_file_path = str(source_path)
-                    self.on_audio_segment_ready_callback(self.temp_file_path)
+                    self.on_audio_segment_ready_callback(
+                        self.temp_file_path,
+                        operation_id=operation_id,
+                    )
                     protected_paths: list[Path] = []
                     if self.temp_file_path:
                         try:
@@ -885,11 +930,13 @@ class AudioHandler:
                         storage_mode=storage_mode,
                         duration_seconds=round(recording_duration, 2),
                         samples=self._sample_count,
+                        operation_id=operation_id,
                     )
                 )
                 return True
         finally:
             self._session_id = None
+            self._current_operation_id = None
 
     # ------------------------------------------------------------------
     # Beep notification sound

--- a/src/core.py
+++ b/src/core.py
@@ -242,6 +242,7 @@ class AppCore:
         self._active_recording_correlation_id: str | None = None
         self._recording_started_at: float | None = None
         self._onboarding_active = False
+        self._active_recording_operation_id: str | None = None
 
         # Inicializar atributos dependentes da configuração antes de acionar o fluxo de modelo
         self._apply_initial_config_to_core_attributes()
@@ -1527,6 +1528,7 @@ class AppCore:
         *,
         metadata: dict[str, Any] | None = None,
         is_final: bool = False,
+        operation_id: str | None = None,
     ):
         """Callback para enviar texto de segmento para a UI ao vivo."""
         if text:
@@ -1534,12 +1536,19 @@ class AppCore:
         if is_final:
             self._segment_stream_finalized = True
             self.full_transcription = self.full_transcription.strip()
+        normalized_metadata = metadata
+        if isinstance(metadata, dict) and operation_id and "operation_id" not in metadata:
+            normalized_metadata = dict(metadata)
+            normalized_metadata["operation_id"] = operation_id
+        elif metadata is None and operation_id:
+            normalized_metadata = {"operation_id": operation_id}
         if self.on_segment_transcribed:
             try:
                 self.on_segment_transcribed(
                     text,
-                    metadata=metadata,
+                    metadata=normalized_metadata,
                     is_final=is_final,
+                    operation_id=operation_id,
                 )
             except TypeError:
                 self.on_segment_transcribed(text)
@@ -1771,6 +1780,11 @@ class AppCore:
         correlation = self._active_recording_correlation_id
         if correlation:
             details["correlation_id"] = correlation
+        op_id = self._active_recording_operation_id or getattr(
+            self.audio_handler, "current_operation_id", None
+        )
+        if op_id:
+            details["operation_id"] = op_id
         return details
 
     # --- Hotkey Logic (movida de WhisperCore) ---
@@ -2017,6 +2031,10 @@ class AppCore:
             ) as collected:
                 start_success = self.audio_handler.start_recording()
                 collected["audio_session_id"] = getattr(self.audio_handler, "_session_id", None)
+                current_operation = getattr(self.audio_handler, "current_operation_id", None)
+                if current_operation:
+                    collected["operation_id"] = current_operation
+                    self._active_recording_operation_id = current_operation
                 collected["audio_handler_ack"] = bool(start_success)
                 if start_success:
                     self._reset_full_transcription()
@@ -2028,6 +2046,7 @@ class AppCore:
                     collected.setdefault("status", "noop")
             if not start_success:
                 self._active_recording_correlation_id = None
+                self._active_recording_operation_id = None
                 self._recording_started_at = None
                 self._log_status(
                     "Audio subsystem rejected the recording start request.",
@@ -2055,6 +2074,9 @@ class AppCore:
             if self._recording_started_at is not None:
                 elapsed = max(time.monotonic() - self._recording_started_at, 0.0)
                 base_details["elapsed_ms"] = int(elapsed * 1000)
+            op_id = self._active_recording_operation_id or getattr(
+                self.audio_handler, "current_operation_id", None
+            )
             with log_duration(
                 LOGGER,
                 "Recording session shutdown.",
@@ -2063,6 +2085,8 @@ class AppCore:
                 log_start=True,
                 start_level=logging.DEBUG,
             ) as collected:
+                if op_id:
+                    collected["operation_id"] = op_id
                 was_valid = self.audio_handler.stop_recording()
                 collected["recording_valid"] = bool(was_valid)
                 if was_valid is False:
@@ -2071,6 +2095,7 @@ class AppCore:
                     collected.setdefault("status", "completed")
         self._active_recording_correlation_id = None
         self._recording_started_at = None
+        self._active_recording_operation_id = None
 
         if was_valid is False:
             if hasattr(self.transcription_handler, "stop_transcription"):
@@ -2079,6 +2104,7 @@ class AppCore:
                 sm.StateEvent.AUDIO_RECORDING_DISCARDED,
                 details="Recording discarded after stop",
                 source="audio_handler",
+                operation_id=op_id,
             )
             self.action_orchestrator.deactivate_agent_mode()
 

--- a/src/state_manager.py
+++ b/src/state_manager.py
@@ -71,6 +71,7 @@ class StateNotification:
     previous_state: str | None = None
     details: object | None = None
     source: str | None = None
+    operation_id: str | None = None
 
 
 STATE_FOR_EVENT: dict[StateEvent, str] = {
@@ -178,6 +179,7 @@ class StateManager:
             details={
                 "state": notification.state,
                 "event_name": event_name,
+                "operation_id": notification.operation_id,
             },
         ) as log_details:
             log_details["subscriber_count"] = len(self._subscribers)
@@ -209,6 +211,7 @@ class StateManager:
         *,
         details: object | None = None,
         source: str | None = None,
+        operation_id: str | None = None,
     ):
         """Applies a state transition and notifies subscribers."""
         event_obj: StateEvent | None
@@ -262,6 +265,7 @@ class StateManager:
                 previous_state=previous_state,
                 details=detail_payload if detail_payload is not None else message,
                 source=source,
+                operation_id=operation_id,
             )
             self._current_state = mapped_state
             self._last_notification = notification
@@ -276,6 +280,7 @@ class StateManager:
                 origin=origin_label,
                 message=message,
                 source=source,
+                operation_id=operation_id,
             )
         )
 

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -176,6 +176,8 @@ class UIManager:
         self._download_snapshot: list[dict[str, Any]] = []
         self._download_history: list[dict[str, Any]] = []
 
+        self._last_operation_id: str | None = None
+
 
         # Assign methods to the instance
         self.show_live_transcription_window = self._show_live_transcription_window
@@ -2727,6 +2729,7 @@ class UIManager:
                 "details": getattr(notification, "details", None),
                 "source": getattr(notification, "source", None),
                 "previous_state": getattr(notification, "previous_state", None),
+                "operation_id": getattr(notification, "operation_id", None),
             }
             return context["state"], None, context
 
@@ -2758,6 +2761,10 @@ class UIManager:
                 event_name = str(event_obj)
         if event_name:
             parts.append(f"event={event_name}")
+
+        op_id = context.get("operation_id")
+        if op_id and not parts:
+            parts.append(f"op={op_id}")
 
         return f" — {' | '.join(parts)}" if parts else ""
 
@@ -2858,9 +2865,11 @@ class UIManager:
             self._handle_download_progress(context)
         if context:
             self._last_state_notification = context.get("notification")
+            self._last_operation_id = context.get("operation_id")
             self._state_context_suffix = self._build_state_context_suffix(state_str, context)
         else:
             self._last_state_notification = None
+            self._last_operation_id = None
             self._state_context_suffix = ""
 
         suffix = self._state_context_suffix


### PR DESCRIPTION
## Summary
- Introduce an `operation_context` helper and let `log_operation` reuse externally provided identifiers for consistent logging
- Track recording operation IDs in the audio handler and core, forwarding them through the action orchestrator, transcription handler, and state manager/UI notifications
- Attach operation identifiers to transcription callbacks, structured log messages, and state events so the same ID accompanies each recording through completion

## Testing
- python -m compileall src
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e529c37a988330a87c90f2ffa6514a