### PR TITLE
Add headless bootstrap mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ tuning. You can later review and change the model from the **Settings → Transc
 ASR** section, where recommended and advanced options are grouped with download and
 installation estimates.
 
+### Headless Mode
+
+When you need background operation without the system tray icon or any Tk windows,
+launch Whisper Flash Transcriber in headless mode:
+
+```bash
+python src/main.py --headless
+```
+
+The recorder, transcription pipeline, hotkeys, and automatic paste continue to work,
+but all Tk-based UI surfaces (settings window, onboarding wizard, diagnostic dialogs)
+are suppressed. Any message box that would normally appear is logged instead so you
+can monitor issues from the console. Exit the process with <kbd>Ctrl</kbd> + <kbd>C</kbd>
+or by calling the shutdown hotkeys configured for your environment.
+On Windows you can achieve the same by invoking `Run Whisper.bat --headless`.
+
 ### Configuration
 
 - The application icon appears in the system tray.

--- a/Run Whisper.bat
+++ b/Run Whisper.bat
@@ -1,0 +1,23 @@
+@echo off
+setlocal enableextensions
+echo Whisper Flash Transcriber launcher
+
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%"
+
+set "PYTHON_CMD=python"
+set "HEADLESS_FLAG="
+
+if /I "%~1"=="--headless" (
+    set "HEADLESS_FLAG=--headless"
+    shift
+) else if /I "%~1"=="headless" (
+    set "HEADLESS_FLAG=--headless"
+    shift
+) else if /I "%~1"=="/headless" (
+    set "HEADLESS_FLAG=--headless"
+    shift
+)
+
+%PYTHON_CMD% src\main.py %HEADLESS_FLAG% %*
+endlocal


### PR DESCRIPTION
## Summary
- add a --headless CLI flag and a lightweight event loop so the bootstrap can run without Tk
- skip UI construction in headless mode, logging suppressed message boxes instead, and document the workflow
- provide a Windows launcher script that forwards the headless flag

## Testing
- python -m compileall src
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e529dafdc08330b1bf2ad607794eb9