### PR TITLE
Bloquear início da gravação com dispositivo incompatível

### DIFF
--- a/src/startup_diagnostics.py
+++ b/src/startup_diagnostics.py
@@ -99,11 +99,10 @@ def _result_from_payload(name: str, payload: dict[str, Any], *, success_status: 
     ok = bool(payload.get("ok"))
     status = success_status if ok else "error"
     message = payload.get("message", "")
-    suggestion = payload.get("suggestion")
+    suggestion = payload.get("recommendation") or payload.get("suggestion")
     fatal = bool(payload.get("fatal"))
-    details = {
-        key: value for key, value in payload.items() if key not in {"ok", "message", "suggestion", "fatal"}
-    }
+    excluded_keys = {"ok", "message", "suggestion", "recommendation", "fatal"}
+    details = {key: value for key, value in payload.items() if key not in excluded_keys}
     result = DiagnosticResult(
         name=name,
         status=status,


### PR DESCRIPTION
## Summary
- adiciona uma verificação de pré-voo no `AudioHandler` para impedir a abertura do stream quando o dispositivo padrão rejeita a taxa/canais requisitados e registra recomendações de correção
- propaga os detalhes da falha para o núcleo e para a UI, exibindo mensagem orientativa ao usuário quando a captura não pode iniciar
- alinha o relatório de diagnósticos para expor recomendações de ajuste no caso de incompatibilidade do dispositivo de áudio

## Testing
- python -m compileall src
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e529edd8788330a86d73f5373facaa