### PR TITLE
Add guarded state transitions for recording workflows

### DIFF
--- a/src/action_orchestrator.py
+++ b/src/action_orchestrator.py
@@ -94,7 +94,8 @@ class ActionOrchestrator:
                     min_duration_seconds=round(min_duration, 2),
                 )
             )
-            self._state_manager.set_state(
+            self._state_manager.transition_if(
+                (sm.STATE_RECORDING, sm.STATE_IDLE),
                 sm.StateEvent.AUDIO_RECORDING_DISCARDED,
                 details=(
                     f"Segment shorter than minimum ({duration_seconds:.2f}s < "
@@ -207,7 +208,8 @@ class ActionOrchestrator:
         else:
             self._log_status("Transcription complete. Auto-paste disabled.")
 
-        self._state_manager.set_state(
+        self._state_manager.transition_if(
+            (sm.STATE_TRANSCRIBING, sm.STATE_IDLE),
             sm.StateEvent.TRANSCRIPTION_COMPLETED,
             details=f"Transcription finalized ({len(final_text)} chars)",
             source="transcription",
@@ -242,7 +244,8 @@ class ActionOrchestrator:
         else:
             self._log_status("Agent command executed (auto-paste disabled).")
 
-        self._state_manager.set_state(
+        self._state_manager.transition_if(
+            (sm.STATE_TRANSCRIBING, sm.STATE_IDLE),
             sm.StateEvent.AGENT_COMMAND_COMPLETED,
             details=f"Agent response delivered ({len(response)} chars)",
             source="agent_mode",

--- a/src/audio_handler.py
+++ b/src/audio_handler.py
@@ -19,6 +19,7 @@ import soundfile as sf
 # mantenha esta limitação em mente ao depurar gravações.
 from .utils.memory import get_available_memory_mb, get_total_memory_mb
 
+from . import state_manager as sm
 from .vad_manager import VADManager
 from .config_manager import (
     RECORDINGS_DIR_CONFIG_KEY,
@@ -499,11 +500,11 @@ class AudioHandler:
             except sd.PortAudioError as e:
                 self._log.error(f"PortAudio error during recording: {e}", exc_info=True)
                 self.is_recording = False
-                self.state_manager.set_state("ERROR_AUDIO")
+                self.state_manager.set_state(sm.STATE_ERROR_AUDIO)
             except Exception as e:
                 self._log.error(f"Error in audio recording thread: {e}", exc_info=True)
                 self.is_recording = False
-                self.state_manager.set_state("ERROR_AUDIO")
+                self.state_manager.set_state(sm.STATE_ERROR_AUDIO)
             finally:
                 if self.audio_stream is not None:
                     self._close_input_stream()
@@ -690,7 +691,43 @@ class AudioHandler:
                         extra={"event": "vad_reset", "stage": "recording"},
                     )
 
-                    self.state_manager.set_state("RECORDING")
+                    if not self.state_manager.transition_if(
+                        sm.STATE_IDLE,
+                        sm.StateEvent.AUDIO_RECORDING_STARTED,
+                        source="audio_handler",
+                    ):
+                        self._log.debug(
+                            "Recording start aborted: state guard rejected transition.",
+                            extra={"event": "audio.state_guard_rejected", "stage": "recording"},
+                        )
+                        cleanup_path: str | os.PathLike[str] | None = None
+                        with self.storage_lock:
+                            self.is_recording = False
+                            self.start_time = None
+                            self._sample_count = 0
+                            self._memory_samples = 0
+                            if self._sf_writer is not None:
+                                try:
+                                    self._sf_writer.close()
+                                except Exception:
+                                    self._log.debug(
+                                        "Failed to close temporary writer after guard rejection.",
+                                        exc_info=True,
+                                        extra={"event": "audio.writer_cleanup", "stage": "recording"},
+                                    )
+                                self._sf_writer = None
+                            if not self.in_memory_mode:
+                                cleanup_path = self.temp_file_path
+                        if cleanup_path:
+                            try:
+                                self._cleanup_temp_file(target_path=cleanup_path)
+                            except Exception:
+                                self._log.debug(
+                                    "Failed to clean up temporary file after guard rejection.",
+                                    exc_info=True,
+                                    extra={"event": "audio.temp_cleanup", "stage": "recording"},
+                                )
+                        return False
 
                     self._record_thread = threading.Thread(
                         target=self._record_audio_task,
@@ -788,7 +825,11 @@ class AudioHandler:
                         )
                     )
                     self._cleanup_temp_file()
-                    self.state_manager.set_state("IDLE")
+                    self.state_manager.transition_if(
+                        (sm.STATE_RECORDING, sm.STATE_IDLE),
+                        sm.StateEvent.AUDIO_RECORDING_STOPPED,
+                        source="audio_handler",
+                    )
                     return False
 
                 recording_duration = time.time() - self.start_time
@@ -813,7 +854,11 @@ class AudioHandler:
                         )
                     )
                     self._cleanup_temp_file()
-                    self.state_manager.set_state("IDLE")
+                    self.state_manager.transition_if(
+                        (sm.STATE_RECORDING, sm.STATE_IDLE),
+                        sm.StateEvent.AUDIO_RECORDING_STOPPED,
+                        source="audio_handler",
+                    )
                     return False
 
                 if self.in_memory_mode:

--- a/src/core.py
+++ b/src/core.py
@@ -2075,7 +2075,8 @@ class AppCore:
         if was_valid is False:
             if hasattr(self.transcription_handler, "stop_transcription"):
                 self.transcription_handler.stop_transcription()
-            self.state_manager.set_state(
+            self.state_manager.transition_if(
+                (sm.STATE_RECORDING, sm.STATE_IDLE),
                 sm.StateEvent.AUDIO_RECORDING_DISCARDED,
                 details="Recording discarded after stop",
                 source="audio_handler",

--- a/src/state_manager.py
+++ b/src/state_manager.py
@@ -4,7 +4,7 @@ This file will contain the StateManager class and related state management logic
 from threading import RLock
 from dataclasses import dataclass
 from enum import Enum, auto, unique
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 
 from .logging_utils import get_logger, log_context, log_duration
 
@@ -203,19 +203,14 @@ class StateManager:
             if had_errors:
                 log_details["status"] = "partial"
 
-    def set_state(
+    def _resolve_transition(
         self,
         event: StateEvent | str,
-        *,
-        details: object | None = None,
-        source: str | None = None,
-    ):
-        """Applies a state transition and notifies subscribers."""
+        detail_payload: object | None,
+    ) -> tuple[StateEvent | None, str, str | None, object | None]:
         event_obj: StateEvent | None
         mapped_state: str
         message: str | None
-
-        detail_payload = details
 
         if isinstance(event, StateEvent):
             event_obj = event
@@ -240,32 +235,53 @@ class StateManager:
         else:
             raise ValueError(f"Unsupported state event payload: {event!r}")
 
-        with self._state_lock:
-            previous_state = self._current_state
-            last_event = self._last_notification.event if self._last_notification else None
-            last_state = self._last_notification.state if self._last_notification else None
-            if last_event == event_obj and last_state == mapped_state:
-                self._logger.debug(
-                    log_context(
-                        "Duplicate state notification suppressed.",
-                        event="state.duplicate_suppressed",
-                        state=mapped_state,
-                        event_name=event_obj.name if event_obj else None,
-                        source=source,
-                    )
+        return event_obj, mapped_state, message, detail_payload
+
+    def _apply_transition_locked(
+        self,
+        *,
+        event_obj: StateEvent | None,
+        mapped_state: str,
+        detail_payload: object | None,
+        message: str | None,
+        source: str | None,
+    ) -> tuple[StateNotification, str] | None:
+        previous_state = self._current_state
+        last_event = self._last_notification.event if self._last_notification else None
+        last_state = self._last_notification.state if self._last_notification else None
+        if last_event == event_obj and last_state == mapped_state:
+            self._logger.debug(
+                log_context(
+                    "Duplicate state notification suppressed.",
+                    event="state.duplicate_suppressed",
+                    state=mapped_state,
+                    event_name=event_obj.name if event_obj else None,
+                    source=source,
                 )
-                return
-
-            notification = StateNotification(
-                event=event_obj,
-                state=mapped_state,
-                previous_state=previous_state,
-                details=detail_payload if detail_payload is not None else message,
-                source=source,
             )
-            self._current_state = mapped_state
-            self._last_notification = notification
+            return None
 
+        notification = StateNotification(
+            event=event_obj,
+            state=mapped_state,
+            previous_state=previous_state,
+            details=detail_payload if detail_payload is not None else message,
+            source=source,
+        )
+        self._current_state = mapped_state
+        self._last_notification = notification
+        return notification, previous_state
+
+    def _emit_transition(
+        self,
+        notification: StateNotification,
+        *,
+        previous_state: str,
+        event_obj: StateEvent | None,
+        mapped_state: str,
+        message: str | None,
+        source: str | None,
+    ) -> None:
         origin_label = event_obj.name if event_obj else f"STATE:{mapped_state}"
         self._logger.info(
             log_context(
@@ -278,8 +294,135 @@ class StateManager:
                 source=source,
             )
         )
-
         self._notify_subscribers(notification)
+
+    def set_state(
+        self,
+        event: StateEvent | str,
+        *,
+        details: object | None = None,
+        source: str | None = None,
+    ):
+        """Applies a state transition and notifies subscribers."""
+
+        event_obj, mapped_state, message, detail_payload = self._resolve_transition(event, details)
+
+        with self._state_lock:
+            result = self._apply_transition_locked(
+                event_obj=event_obj,
+                mapped_state=mapped_state,
+                detail_payload=detail_payload,
+                message=message,
+                source=source,
+            )
+            if result is None:
+                return
+            notification, previous_state = result
+
+        self._emit_transition(
+            notification,
+            previous_state=previous_state,
+            event_obj=event_obj,
+            mapped_state=mapped_state,
+            message=message,
+            source=source,
+        )
+
+    def _normalize_expected_states(
+        self,
+        expected_state: str | StateEvent | Iterable[str | StateEvent],
+    ) -> set[str]:
+        if isinstance(expected_state, StateEvent):
+            return {STATE_FOR_EVENT[expected_state]}
+        if isinstance(expected_state, str):
+            normalized = expected_state.strip().upper()
+            if not normalized:
+                raise ValueError("expected_state must not be empty")
+            return {normalized}
+
+        try:
+            candidates = list(expected_state)
+        except TypeError as exc:  # pragma: no cover - defensive path
+            raise TypeError(
+                "expected_state must be a state string, StateEvent, or iterable of them."
+            ) from exc
+
+        normalized_states: set[str] = set()
+        for candidate in candidates:
+            if isinstance(candidate, StateEvent):
+                normalized_states.add(STATE_FOR_EVENT[candidate])
+            elif isinstance(candidate, str):
+                normalized = candidate.strip().upper()
+                if normalized:
+                    normalized_states.add(normalized)
+            elif candidate is None:
+                continue
+            else:
+                text = str(candidate).strip().upper()
+                if text:
+                    normalized_states.add(text)
+
+        if not normalized_states:
+            raise ValueError("expected_state must resolve to at least one state value")
+
+        return normalized_states
+
+    def transition_if(
+        self,
+        expected_state: str | StateEvent | Iterable[str | StateEvent],
+        event: StateEvent | str,
+        *,
+        details: object | None = None,
+        source: str | None = None,
+    ) -> bool:
+        """Conditionally apply a transition when the current state matches ``expected_state``.
+
+        This helper should be used by code paths where multiple threads may signal
+        competing transitions (for example, hotkey handlers racing against audio or
+        transcription workers). By guarding the transition with the expected
+        current state we avoid reverting a newer state and reduce race-condition
+        windows when coordinating long-running operations.
+        """
+
+        event_obj, mapped_state, message, detail_payload = self._resolve_transition(event, details)
+        expected_states = self._normalize_expected_states(expected_state)
+
+        with self._state_lock:
+            current_state = self._current_state
+            if current_state not in expected_states:
+                self._logger.debug(
+                    log_context(
+                        "State transition guard rejected request.",
+                        event="state.transition_guard_blocked",
+                        expected_states=sorted(expected_states),
+                        current_state=current_state,
+                        requested_state=mapped_state,
+                        requested_event=event_obj.name if event_obj else None,
+                        source=source,
+                    )
+                )
+                return False
+
+            result = self._apply_transition_locked(
+                event_obj=event_obj,
+                mapped_state=mapped_state,
+                detail_payload=detail_payload,
+                message=message,
+                source=source,
+            )
+            if result is None:
+                return True
+            notification, previous_state = result
+
+        self._emit_transition(
+            notification,
+            previous_state=previous_state,
+            event_obj=event_obj,
+            mapped_state=mapped_state,
+            message=message,
+            source=source,
+        )
+        return True
 
     def get_current_state(self) -> str:
         """Returns the current state."""


### PR DESCRIPTION
## Summary
- add a guarded `transition_if` helper to `StateManager` with documentation on avoiding race conditions
- update audio, action orchestration, and hotkey-triggered paths to use the new guard for ordered transitions
- ensure audio start failures clean up resources when the guard blocks a transition

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e529f01334833094444ed55942a8cb