### PR TITLE
Add unit tests for keyboard hotkey manager behavior

### DIFF
--- a/tests/test_vad_pipeline.py
+++ b/tests/test_vad_pipeline.py
@@ -1,15 +1,25 @@
+import builtins
+import tempfile
 import unittest
+from collections.abc import Mapping
+from pathlib import Path
+from unittest import mock
 
 import numpy as np
 
+if not hasattr(builtins, "Mapping"):
+    builtins.Mapping = Mapping
+
 try:
     from src.vad_manager import VADManager
+    from src.keyboard_hotkey_manager import KeyboardHotkeyManager
 except ModuleNotFoundError:  # pragma: no cover - fallback when running directly
     import os
     import sys
 
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
     from src.vad_manager import VADManager
+    from src.keyboard_hotkey_manager import KeyboardHotkeyManager
 
 
 class DummyConfigManager:
@@ -108,6 +118,84 @@ class TestVADPipeline(unittest.TestCase):
         is_speech_silence, frames_silence = manager.process_chunk(silence)
         self.assertFalse(is_speech_silence)
         self.assertEqual(frames_silence, [])
+
+
+class TestKeyboardHotkeys(unittest.TestCase):
+    def setUp(self):
+        self.keyboard_mock = mock.Mock()
+        self.keyboard_patch = mock.patch(
+            "src.keyboard_hotkey_manager.keyboard",
+            self.keyboard_mock,
+        )
+        self.keyboard_patch.start()
+        self.addCleanup(self.keyboard_patch.stop)
+
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.config_path = Path(self.temp_dir.name) / "hotkeys.json"
+
+    def _create_manager(self):
+        return KeyboardHotkeyManager(config_file=self.config_path)
+
+    def test_stop_clears_hotkey_state(self):
+        manager = self._create_manager()
+        manager.is_running = True
+        manager.hotkey_handlers = {
+            "record:press": ["handle-1", "handle-2"],
+            "agent:press": ["handle-3"],
+        }
+
+        manager.stop()
+
+        self.assertEqual(
+            self.keyboard_mock.unhook.call_args_list,
+            [
+                mock.call("handle-1"),
+                mock.call("handle-2"),
+                mock.call("handle-3"),
+            ],
+        )
+        self.assertEqual(manager.hotkey_handlers, {})
+        self.assertFalse(manager.is_running)
+
+    def test_restart_debounces_and_restarts_handlers(self):
+        manager = self._create_manager()
+        manager.is_running = True
+        manager.hotkey_handlers = {"record:press": ["handle-1"]}
+
+        call_order: list[str] = []
+        original_stop = manager.stop
+
+        def stop_side_effect():
+            call_order.append("stop")
+            return original_stop()
+
+        def start_side_effect():
+            call_order.append("start")
+            manager.is_running = True
+            manager.hotkey_handlers = {"record:press": ["new-handle"]}
+            return True
+
+        with mock.patch.object(manager, "stop", side_effect=stop_side_effect) as mock_stop:
+            with mock.patch.object(manager, "start", side_effect=start_side_effect) as mock_start:
+                with mock.patch("src.keyboard_hotkey_manager.time.sleep") as mock_sleep:
+                    mock_sleep.side_effect = lambda duration: call_order.append(f"sleep:{duration}")
+                    result = manager.restart()
+
+        self.assertTrue(result)
+        self.assertEqual(call_order, ["stop", "sleep:0.5", "sleep:0.5", "start"])
+        mock_stop.assert_called_once()
+        mock_start.assert_called_once()
+        self.assertEqual(
+            mock_sleep.call_args_list,
+            [mock.call(0.5), mock.call(0.5)],
+        )
+        self.assertEqual(
+            self.keyboard_mock.unhook.call_args_list,
+            [mock.call("handle-1")],
+        )
+        self.assertIn("record:press", manager.hotkey_handlers)
+        self.assertNotIn("handle-1", manager.hotkey_handlers["record:press"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `TestKeyboardHotkeys` coverage using `unittest.mock` to simulate the `keyboard` module
- verify `KeyboardHotkeyManager.stop` clears handlers and resets its running flag
- ensure `KeyboardHotkeyManager.restart` calls `stop`, waits for the debounce, and invokes `start`

## Testing
- pytest tests/test_vad_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e52a0279b48330bf081ba912ca5ee5