### PR TITLE
Add Windows elevation guidance for auto-paste reliability

### DIFF
--- a/scripts/quick_bench_asr.py
+++ b/scripts/quick_bench_asr.py
@@ -458,7 +458,7 @@ def test_apply_settings_payload_headless():
     core_stub = CoreStub()
     config_stub = SimpleNamespace()
     root_stub = SimpleNamespace()
-    ui = UIManager(root_stub, config_stub, core_stub)
+    ui = UIManager(root_stub, config_stub, core_stub, is_running_as_admin=False)
 
     payload = {
         "new_key": "f5",

--- a/src/core.py
+++ b/src/core.py
@@ -5,6 +5,7 @@ import os
 import sys
 import threading
 import time
+import ctypes
 from collections.abc import Callable, Iterable
 from typing import Any, Mapping, TYPE_CHECKING
 from pathlib import Path
@@ -89,6 +90,23 @@ LOGGER = get_logger('whisper_flash_transcriber.core', component='Core')
 MODEL_LOGGER = get_logger('whisper_recorder.model', component='ModelManager')
 
 
+def _detect_admin_privileges() -> bool:
+    """Return True when the current process has administrative privileges."""
+
+    if os.name != "nt":
+        return False
+
+    try:
+        # ``IsUserAnAdmin`` returns a non-zero value for administrators.
+        return bool(ctypes.windll.shell32.IsUserAnAdmin())  # type: ignore[attr-defined]
+    except Exception:
+        LOGGER.debug(
+            "Failed to probe administrative privileges; assuming standard user.",
+            exc_info=True,
+        )
+        return False
+
+
 
 StateUpdateCallback = Callable[[sm.StateNotification], None]
 
@@ -123,6 +141,7 @@ class AppCore:
 
         # --- Módulos ---
         self.config_manager = config_manager or ConfigManager()
+        self.is_running_as_admin = _detect_admin_privileges()
         self.dependency_audit_result: DependencyAuditResult | None = None
         self._dependency_audit_failure_message: str | None = None
         self._dependency_audit_event_sent = False

--- a/src/main.py
+++ b/src/main.py
@@ -633,6 +633,7 @@ def main(argv: list[str] | None = None) -> int:
             app_core_instance.config_manager,
             app_core_instance,
             model_manager=app_core_instance.model_manager,
+            is_running_as_admin=app_core_instance.is_running_as_admin,
         )
         app_core_instance.ui_manager = ui_manager_instance
         ui_manager_instance.setup_tray_icon()

--- a/src/onboarding/first_run_wizard.py
+++ b/src/onboarding/first_run_wizard.py
@@ -354,6 +354,13 @@ class FirstRunWizard(ctk.CTkToplevel):
                     f"Os arquivos de configuração serão armazenados em:\n{self._profile_dir}",
                 ]
             )
+        message_lines.extend(
+            [
+                "\n",
+                "Se você precisar colar resultados em aplicativos que rodam como administrador, "
+                "execute o Whisper Flash Transcriber com o mesmo nível de privilégio para evitar bloqueios do Windows.",
+            ]
+        )
         text = " ".join(message_lines)
         label = ctk.CTkLabel(frame, text=text, wraplength=600, justify="left")
         label.pack(anchor="w", padx=16, pady=20)
@@ -731,6 +738,11 @@ class FirstRunWizard(ctk.CTkToplevel):
             f"Gravações: {self.recordings_dir_var.get().strip()}",
             "",
             "Download imediato: " + ("Sim" if self.download_now_var.get() else "Não"),
+            "",
+            (
+                "Dica: alinhe o nível de privilégio do aplicativo com o destino da auto-colagem para evitar que "
+                "o Windows bloqueie a automação."
+            ),
         ]
         self.summary_text_var.set("\n".join(lines))
 

--- a/src/ui_manager.py
+++ b/src/ui_manager.py
@@ -142,7 +142,15 @@ def _backend_display_value_global(value: str | None) -> str:
     return normalized
 
 class UIManager:
-    def __init__(self, main_tk_root, config_manager, core_instance_ref, model_manager=None):
+    def __init__(
+        self,
+        main_tk_root,
+        config_manager,
+        core_instance_ref,
+        model_manager=None,
+        *,
+        is_running_as_admin: bool = False,
+    ):
         self.main_tk_root = main_tk_root
         self.config_manager = config_manager
         self.core_instance_ref = core_instance_ref # Reference to the AppCore instance
@@ -176,6 +184,9 @@ class UIManager:
         self._download_snapshot: list[dict[str, Any]] = []
         self._download_history: list[dict[str, Any]] = []
 
+        self.is_running_as_admin = bool(is_running_as_admin)
+        self._is_windows = sys.platform.startswith("win")
+
 
         # Assign methods to the instance
         self.show_live_transcription_window = self._show_live_transcription_window
@@ -198,6 +209,9 @@ class UIManager:
 
         # Controle interno para atualizar a tooltip durante a gravação
         self.recording_timer_thread = None
+
+    def _should_warn_about_elevation(self) -> bool:
+        return self._is_windows and not self.is_running_as_admin
         self.stop_recording_timer_event = threading.Event()
 
         # Controle interno para atualizar a tooltip durante a transcrição
@@ -3819,6 +3833,25 @@ class UIManager:
                 general_frame.pack(fill="x", padx=10, pady=5)
                 ctk.CTkLabel(general_frame, text="Configurações Gerais", font=ctk.CTkFont(weight="bold")).pack(pady=(5, 10), anchor="w")
 
+                if self._should_warn_about_elevation():
+                    warning_frame = ctk.CTkFrame(general_frame, fg_color=("#2d2416", "#1f1f1f"))
+                    warning_frame.pack(fill="x", padx=5, pady=(0, 8))
+                    warning_label = ctk.CTkLabel(
+                        warning_frame,
+                        text=(
+                            "Aviso: o Windows bloqueia automações entre níveis de privilégio. "
+                            "Se precisar auto-colar em aplicativos executados como administrador, "
+                            "execute o Whisper Flash Transcriber com o mesmo nível para evitar falhas."
+                        ),
+                        wraplength=520,
+                        justify="left",
+                    )
+                    warning_label.pack(anchor="w", padx=8, pady=8)
+                    Tooltip(
+                        warning_frame,
+                        "Auto-colar pode ser bloqueado por aplicativos elevados quando o transcritor roda sem privilégios de administrador.",
+                    )
+
                 # Record Hotkey
                 key_frame = ctk.CTkFrame(general_frame)
                 key_frame.pack(fill="x", pady=5)
@@ -3866,7 +3899,13 @@ class UIManager:
                 paste_frame.pack(fill="x", pady=5)
                 paste_switch = ctk.CTkSwitch(paste_frame, text="Auto-colar", variable=auto_paste_var)
                 paste_switch.pack(side="left", padx=5)
-                Tooltip(paste_switch, "Cola automaticamente a transcrição.")
+                paste_tooltip = "Cola automaticamente a transcrição."
+                if self._should_warn_about_elevation():
+                    paste_tooltip += (
+                        "\nObservação: No Windows, aplicativos executados como administrador ignoram o auto-colar"
+                        " se este aplicativo não estiver com o mesmo nível de privilégio."
+                    )
+                Tooltip(paste_switch, paste_tooltip)
 
                 # Hotkey Stability Service
                 stability_service_frame = ctk.CTkFrame(general_frame)


### PR DESCRIPTION
## Summary
- detect administrative privileges during core bootstrap and surface the flag to the UI layer
- warn Windows users in the settings UI when elevated targets can block auto-paste and extend the tooltip
- update onboarding messaging to remind users to match privilege levels when needed

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e529fd51448330b2c5136b823b1830