### PR TITLE
Atualizar identidade do app para Whisper Flash Transcriber

### DIFF
--- a/src/app_identity.py
+++ b/src/app_identity.py
@@ -1,0 +1,7 @@
+"""Application identity constants shared across modules."""
+
+APP_LOG_NAMESPACE = "whisper_flash_transcriber"
+APP_ID = APP_LOG_NAMESPACE
+APP_DISPLAY_NAME = "Whisper Flash Transcriber"
+APP_OFFICIAL_URL = "https://github.com/Isaque-0/whisper-flash-transcriber"
+

--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -23,9 +23,10 @@ except Exception:  # pragma: no cover - allow runtime fallback
     snapshot_download = None  # type: ignore[assignment]
 
 from .logging_utils import get_logger, log_context
+from .app_identity import APP_LOG_NAMESPACE
 
 
-MODEL_LOGGER = get_logger("whisper_recorder.model", component="ModelManager")
+MODEL_LOGGER = get_logger(f"{APP_LOG_NAMESPACE}.model", component="ModelManager")
 
 
 _CT2_KNOWN_QUANTIZATIONS: set[str] = {

--- a/src/openrouter_api.py
+++ b/src/openrouter_api.py
@@ -8,8 +8,9 @@ from typing import Optional
 import requests
 
 from .logging_utils import get_logger, log_context
+from .app_identity import APP_DISPLAY_NAME, APP_OFFICIAL_URL, APP_LOG_NAMESPACE
 
-LOGGER = get_logger('whisper_flash_transcriber.openrouter', component='OpenRouterAPI')
+LOGGER = get_logger(f"{APP_LOG_NAMESPACE}.openrouter", component='OpenRouterAPI')
 
 
 class OpenRouterAPI:
@@ -51,8 +52,8 @@ class OpenRouterAPI:
         self.headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
-            "HTTP-Referer": "https://whisper-recorder.app",
-            "X-Title": "Whisper Recorder",
+            "HTTP-Referer": APP_OFFICIAL_URL,
+            "X-Title": APP_DISPLAY_NAME,
         }
 
     def _normalize_timeout(
@@ -109,6 +110,8 @@ class OpenRouterAPI:
                 self.request_timeout,
             )
         self.headers["Authorization"] = f"Bearer {self.api_key}"
+        self.headers["HTTP-Referer"] = APP_OFFICIAL_URL
+        self.headers["X-Title"] = APP_DISPLAY_NAME
         LOGGER.info(
             "OpenRouter API client re/initialized with model '%s'",
             self.model_id,


### PR DESCRIPTION
## Summary
- consolidar as constantes de identidade do aplicativo e alinhar os prefixos de logger
- atualizar tooltips, janela de configurações e identificador do ícone para Whisper Flash Transcriber
- ajustar os cabeçalhos enviados ao OpenRouter para usar o novo nome e a URL oficial do repositório

## Testing
- python -m compileall src
- python src/main.py *(falha: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68e52c03abc48330bba534a13fbcaa23