### PR TITLE
Ensure bootstrap dependency setup is consistent

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -2220,6 +2220,18 @@ class ConfigManager:
     def set_deps_install_dir(self, value: str):
         self.config[DEPS_INSTALL_DIR_CONFIG_KEY] = os.path.expanduser(str(value))
 
+    def get_python_packages_dir(self) -> str:
+        return self.config.get(
+            PYTHON_PACKAGES_DIR_CONFIG_KEY,
+            self.default_config.get(
+                PYTHON_PACKAGES_DIR_CONFIG_KEY,
+                _DEFAULT_PYTHON_PACKAGES_DIR,
+            ),
+        )
+
+    def set_python_packages_dir(self, value: str):
+        self.config[PYTHON_PACKAGES_DIR_CONFIG_KEY] = os.path.expanduser(str(value))
+
     def get_hf_home_dir(self) -> str:
         return self.config.get(
             HF_HOME_DIR_CONFIG_KEY,
@@ -2231,6 +2243,18 @@ class ConfigManager:
 
     def set_hf_home_dir(self, value: str):
         self.config[HF_HOME_DIR_CONFIG_KEY] = os.path.expanduser(str(value))
+
+    def get_hf_cache_dir(self) -> str:
+        return self.config.get(
+            HF_CACHE_DIR_CONFIG_KEY,
+            self.default_config.get(
+                HF_CACHE_DIR_CONFIG_KEY,
+                _DEFAULT_HF_CACHE_DIR,
+            ),
+        )
+
+    def set_hf_cache_dir(self, value: str):
+        self.config[HF_CACHE_DIR_CONFIG_KEY] = os.path.expanduser(str(value))
 
     def get_recordings_dir(self) -> str:
         return self.config.get(


### PR DESCRIPTION
## Summary
- import and use the dependency installer during bootstrap using new configuration accessors
- create the Tk root window before wiring UI components and guard exit handling
- expose python packages and Hugging Face cache directory getters/setters in the config manager

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e52e2fd8c88330bb30cb7428a77abf