### PR TITLE
Map auto backend label to ctranslate2

### DIFF
--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -326,7 +326,7 @@ def normalize_backend_label(backend: str | None) -> str:
         "faster-whisper": "ctranslate2",
         "transformer": "ctranslate2",
         "transformers": "ctranslate2",
-        "auto": "auto",
+        "auto": "ctranslate2",
     }
 
     mapped = alias_map.get(normalized)


### PR DESCRIPTION
## Summary
- normalize the `auto` backend label to `ctranslate2` so existing components continue to load the ASR backend

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e52ee094c4833090dcc9fd7f0fd141