### PR TITLE
Fix normalization of auto backend to ctranslate2

### DIFF
--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -326,7 +326,7 @@ def normalize_backend_label(backend: str | None) -> str:
         "faster-whisper": "ctranslate2",
         "transformer": "ctranslate2",
         "transformers": "ctranslate2",
-        "auto": "auto",
+        "auto": "ctranslate2",
     }
 
     mapped = alias_map.get(normalized)


### PR DESCRIPTION
## Summary
- map the `auto` backend alias to `ctranslate2` so configurations using `auto` continue working with the supported backend

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e52ee96d2c8330ab653a9b52105f1c