### PR TITLE
Refactor CUDA logging to rely on CTranslate2 diagnostics

### DIFF
--- a/docs/ui_vars.md
+++ b/docs/ui_vars.md
@@ -45,7 +45,7 @@ Este documento consolida todas as instâncias de `ctk.*Var` usadas na janela de 
 | ASR | `asr_model_id_var` | `StringVar` | Alimentado por `CTkOptionMenu` (`asr_model_menu`) via `asr_model_display_var` | `"asr_model_id"` | Guarda o identificador interno do modelo escolhido. |
 | ASR | `asr_model_display_var` | `StringVar` | `CTkOptionMenu` (`asr_model_menu`) | `"asr_model_id"` (mapeado por `display_to_id`) | Variável de exibição; converte nomes amigáveis para `asr_model_id_var`. |
 | ASR | `asr_compute_device_var` | `StringVar` | `CTkOptionMenu` (`asr_device_menu`) | `"asr_compute_device"` + `"gpu_index"` | Representa a seleção textual (*Auto*, *Force CPU*, *GPU X*), traduzida para backend e índice ao aplicar. |
-| ASR | `asr_ct2_compute_type_var` | `StringVar` | `CTkOptionMenu` (`asr_ct2_menu`) | `"asr_ct2_compute_type"` | Ajusta o compute type quando o backend é CTranslate2. |
+| ASR | `asr_ct2_compute_type_var` | `StringVar` | `CTkOptionMenu` (`asr_ct2_menu`) | `"asr_ct2_compute_type"` | Seleciona a precisão do pipeline exclusivo CTranslate2 (por exemplo, `auto`, `float16`, `int8`). |
 | ASR | `models_storage_dir_var` | `StringVar` | `CTkEntry` (`models_dir_entry`) | `"models_storage_dir"` (`advanced.storage.models_storage_dir`) | Diretório raiz usado para armazenar modelos e demais artefatos pesados; também serve de destino padrão quando o `storage_root_dir` muda sem override explícito. |
 | ASR | `asr_cache_dir_var` | `StringVar` | `CTkEntry` (`asr_cache_entry`) | `"asr_cache_dir"` (`advanced.storage.asr_cache_dir`) | Diretório raiz usado para armazenar modelos baixados. |
 


### PR DESCRIPTION
## Summary
- replace the Torch-based CUDA detection in src/main.py with diagnostics powered by CTranslate2, including resilient structured logging
- keep the FlashAttention probe while reporting device availability and compute types through the CTranslate2 runtime
- update docs/ui_vars.md to clarify that compute type selection belongs exclusively to the CTranslate2 pipeline

## Testing
- python -m compileall src/main.py docs/ui_vars.md
- rg "torch" src docs

------
https://chatgpt.com/codex/tasks/task_e_68e5317351a8833091b94f5c86c5ccda