### PR TITLE
Fix hotkey normalizer to preserve literal plus key

### DIFF
--- a/src/hotkey_normalization.py
+++ b/src/hotkey_normalization.py
@@ -66,6 +66,7 @@ _KEY_ALIASES: dict[str, str] = {
     "tabulacao": "tab",
     "delete": "del",
     "seta": "arrow",
+    "+": "plus",
 }
 
 def _strip_accents(value: str) -> str:
@@ -118,9 +119,25 @@ def _normalize_key_name(value: str | None) -> str:
     if not text:
         return ""
 
-    parts = _HOTKEY_SEPARATOR.split(text)
     normalized_parts: list[str] = []
-    for raw_part in parts:
+    tokens: list[str] = []
+    last_index = 0
+
+    for match in _HOTKEY_SEPARATOR.finditer(text):
+        token = text[last_index : match.start()]
+        if token:
+            tokens.append(token)
+        else:
+            tokens.append("+")
+        last_index = match.end()
+
+    trailing = text[last_index:]
+    if trailing:
+        tokens.append(trailing)
+    elif not tokens and text:
+        tokens.append(text)
+
+    for raw_part in tokens:
         candidate = _sanitize_token(raw_part)
         if not candidate:
             continue


### PR DESCRIPTION
## Summary
- update the hotkey normalizer to emit literal plus tokens instead of dropping them
- add a direct mapping from '+' to the keyboard library's `plus` key to keep existing ctrl++ and shift++ shortcuts intact

## Testing
- python -m compileall src
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e5321f9a1c833096a0b3968e3722d9