### PR TITLE
Fix normalization of auto ASR backend

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -359,7 +359,7 @@ def _normalize_asr_backend(name: str | None) -> str | None:
         "faster-whisper": "ctranslate2",
         "transformer": "ctranslate2",
         "transformers": "ctranslate2",
-        "auto": "auto",
+        "auto": "ctranslate2",
     }
 
     mapped = alias_map.get(normalized)

--- a/src/model_manager.py
+++ b/src/model_manager.py
@@ -326,6 +326,12 @@ def normalize_backend_label(backend: str | None) -> str:
     if not normalized:
         return ""
 
+    if normalized == "auto":
+        # O restante do pipeline não reconhece "auto" como backend válido.
+        # Normalizamos explicitamente para o identificador CT2 até que exista
+        # um modo automático real.
+        return "ctranslate2"
+
     alias_map = {
         "ct2": "ctranslate2",
         "ctranslate2": "ctranslate2",
@@ -334,7 +340,6 @@ def normalize_backend_label(backend: str | None) -> str:
         "faster-whisper": "ctranslate2",
         "transformer": "ctranslate2",
         "transformers": "ctranslate2",
-        "auto": "ctranslate2",
     }
 
     mapped = alias_map.get(normalized)


### PR DESCRIPTION
## Summary
- map persisted `asr_backend` values of `auto` to `ctranslate2` to keep configuration compatible
- guard `normalize_backend_label` against propagating `auto` so downstream loaders always receive the supported backend id

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e532886fec83309e862ee5c656b9e9