### PR TITLE
Improve configuration isolation and hotkey stability

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -216,6 +216,8 @@ DEFAULT_CONFIG = {
     "first_run_completed": False,
 }
 
+DEFAULT_CONFIG_TREE = normalize_payload_tree(DEFAULT_CONFIG)
+
 
 LOGGER = get_logger("whisper_flash_transcriber.config", component="ConfigManager")
 BOOTSTRAP_LOGGER = get_logger(

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -156,58 +156,62 @@ class SoundSettings(BaseModel):
     volume: float = Field(default=0.5, ge=0.0)
 
 
-class AdvancedHotkeyConfig(BaseModel):
-    """Advanced toggles related to auxiliary hotkeys and modifiers."""
+class AdvancedConfig(BaseModel):
+    """Container for advanced configuration namespaces."""
 
-    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
+    model_config = ConfigDict(extra="allow", str_strip_whitespace=True)
+
+    hotkeys: dict[str, Any] = Field(default_factory=dict)
+    ai: dict[str, Any] = Field(default_factory=dict)
+    performance: dict[str, Any] = Field(default_factory=dict)
+    storage: dict[str, Any] = Field(default_factory=dict)
+    vad: dict[str, Any] = Field(default_factory=dict)
+    workflow: dict[str, Any] = Field(default_factory=dict)
+    system: dict[str, Any] = Field(default_factory=dict)
+
+    @staticmethod
+    def _coerce_section(value: Any) -> dict[str, Any]:
+        if value is None:
+            return {}
+        if isinstance(value, Mapping):
+            return {str(key): value[key] for key in value}
+        raise ValueError("Advanced configuration sections must be mappings")
+
+    @field_validator(
+        "hotkeys",
+        "ai",
+        "performance",
+        "storage",
+        "vad",
+        "workflow",
+        "system",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_sections(cls, value: Any) -> dict[str, Any]:
+        return cls._coerce_section(value)
+
+
+class AppConfig(BaseModel):
+    """Primary configuration schema for Whisper Flash Transcriber."""
+
+    model_config = ConfigDict(extra="allow", str_strip_whitespace=True)
 
     show_advanced: bool = False
     record_key: str = "F3"
     record_mode: str = "toggle"
+    hotkey_debounce_ms: int = Field(default=200, ge=0)
     auto_paste: bool = True
+    agent_auto_paste: bool = True
     auto_paste_modifier: str = "auto"
-    agent_auto_paste: bool | None = None
     min_record_duration: float = Field(default=0.5, ge=0.0)
-    sound_enabled: bool = True
-    sound_frequency: int = Field(default=400, ge=0)
-    sound_duration: float = Field(default=0.3, ge=0.0)
-    sound_volume: float = Field(default=0.5, ge=0.0)
-    agent_key: str = "F4"
-    agent_auto_paste: bool | None = True
-    auto_paste_modifier: str = "auto"
-    hotkey_stability_service_enabled: bool = True
-    keyboard_library: str = "win32"
-
-    @field_validator("agent_key", mode="before")
-    @classmethod
-    def _coerce_agent_key(cls, value: Any) -> str:
-        return _coerce_key(value)
-
-    @field_validator("auto_paste_modifier", mode="before")
-    @classmethod
-    def _normalize_modifier(cls, value: Any) -> str:
-        return _normalize_auto_paste_modifier(value)
-
-    @field_validator("agent_auto_paste", mode="before")
-    @classmethod
-    def _coerce_optional_bool(cls, value: Any) -> bool | None:
-        return _optional_bool(value)
-
-
-class AdvancedAIConfig(BaseModel):
-    """Optional AI post-processing and agent integrations."""
-
-    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
-
+    sound: SoundSettings = Field(default_factory=SoundSettings)
     text_correction_enabled: bool = False
     text_correction_service: str = "none"
     openrouter_api_key: str = ""
     openrouter_model: str = "deepseek/deepseek-chat-v3-0324:free"
-    gemini_api_key: str = ""
-    gemini_model: str = "gemini-2.5-flash-lite"
-    gemini_agent_model: str = "gemini-2.5-flash-lite"
     openrouter_timeout: int = Field(default=30, ge=1)
-    gemini_timeout: int = Field(default=120, ge=1)
+    openrouter_max_attempts: int = Field(default=3, ge=1)
     text_correction_timeout: float = Field(default=15.0, gt=0.0)
     ai_provider: str = "gemini"
     openrouter_prompt: str = ""
@@ -229,6 +233,10 @@ class AdvancedAIConfig(BaseModel):
         "- Return ONLY the corrected text, with no additional comments or explanations. "
         "Transcribed speech: {text}"
     )
+    gemini_api_key: str = ""
+    gemini_model: str = "gemini-2.5-flash-lite"
+    gemini_agent_model: str = "gemini-2.5-flash-lite"
+    gemini_timeout: int = Field(default=120, ge=1)
     gemini_model_options: list[str] = Field(
         default_factory=lambda: [
             "gemini-2.5-flash-lite",
@@ -236,6 +244,72 @@ class AdvancedAIConfig(BaseModel):
             "gemini-2.5-pro",
         ]
     )
+    ui_language: str = _DEFAULT_UI_LANGUAGE
+    batch_size: int = Field(default=16, ge=1)
+    batch_size_mode: str = "auto"
+    manual_batch_size: int = Field(default=8, ge=1)
+    gpu_index: int = Field(default=0, ge=-1)
+    hotkey_stability_service_enabled: bool = True
+    use_vad: bool = False
+    vad_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
+    vad_silence_duration: float = Field(default=1.0, ge=0.0)
+    vad_pre_speech_padding_ms: int = Field(default=150, ge=0)
+    vad_post_speech_padding_ms: int = Field(default=300, ge=0)
+    display_transcripts_in_terminal: bool = False
+    save_temp_recordings: bool = False
+    record_storage_mode: str = "auto"
+    record_storage_limit: int = Field(default=0, ge=0)
+    max_memory_seconds_mode: str = "auto"
+    max_memory_seconds: float = Field(default=30.0, ge=0.0)
+    min_free_ram_mb: int = Field(default=1000, ge=0)
+    auto_ram_threshold_percent: int = Field(default=10, ge=1, le=50)
+    max_parallel_downloads: int = Field(default=1, ge=1, le=8)
+    min_transcription_duration: float = Field(default=1.0, ge=0.0)
+    chunk_length_sec: float = Field(default=30.0, ge=0.0)
+    chunk_length_mode: str = "auto"
+    launch_at_startup: bool = False
+    clear_gpu_cache: bool = True
+    enable_torch_compile: bool = False
+    storage_root_dir: str = str(_DEFAULT_STORAGE_ROOT)
+    models_storage_dir: str = _DEFAULT_MODELS_STORAGE_DIR
+    recordings_dir: str = _DEFAULT_RECORDINGS_DIR
+    deps_install_dir: str = _DEFAULT_DEPS_INSTALL_DIR
+    hf_home_dir: str = _DEFAULT_HF_HOME_DIR
+    asr_cache_dir: str = _DEFAULT_ASR_CACHE_DIR
+    python_packages_dir: str = _DEFAULT_PYTHON_PACKAGES_DIR
+    vad_models_dir: str = _DEFAULT_VAD_MODELS_DIR
+    hf_cache_dir: str = _DEFAULT_HF_CACHE_DIR
+    asr_model_id: str = "distil-whisper/distil-large-v3"
+    asr_backend: str = "ctranslate2"
+    asr_compute_device: str = "auto"
+    asr_ct2_compute_type: str = "int8_float16"
+    asr_ct2_cpu_threads: int = Field(default=0, ge=0)
+    asr_installed_models: list[str] = Field(default_factory=list)
+    asr_curated_catalog: list[dict[str, Any]] = Field(default_factory=list_catalog)
+    asr_curated_catalog_url: str = ""
+    asr_last_download_status: ASRDownloadStatus = Field(default_factory=ASRDownloadStatus)
+    asr_download_history: list[ASRDownloadHistoryEntry] = Field(default_factory=list)
+    asr_last_prompt_decision: ASRPromptDecision = Field(default_factory=ASRPromptDecision)
+    first_run_completed: bool = False
+    advanced: AdvancedConfig = Field(default_factory=AdvancedConfig)
+
+    @field_validator("record_key", mode="before")
+    @classmethod
+    def _coerce_record_key(cls, value: Any) -> str:
+        return _coerce_key(value)
+
+    @field_validator("auto_paste_modifier", mode="before")
+    @classmethod
+    def _normalize_modifier(cls, value: Any) -> str:
+        return _normalize_auto_paste_modifier(value)
+
+    @field_validator("agent_auto_paste", mode="before")
+    @classmethod
+    def _normalize_agent_auto_paste(cls, value: Any) -> bool:
+        coerced = _optional_bool(value)
+        if coerced is None:
+            return True
+        return bool(coerced)
 
     @field_validator("text_correction_service", mode="before")
     @classmethod
@@ -254,72 +328,8 @@ class AdvancedAIConfig(BaseModel):
         if value is None:
             return []
         if isinstance(value, (list, tuple, set)):
-            coerced: list[str] = []
-            for item in value:
-                if item is None:
-                    continue
-                coerced.append(str(item).strip())
-            return coerced
+            return [str(item).strip() for item in value if item is not None]
         return [str(value)]
-
-
-class AdvancedPerformanceConfig(BaseModel):
-    """Performance tunables kept behind the advanced namespace."""
-
-    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
-
-    batch_size: int = Field(default=16, ge=1)
-    batch_size_mode: str = "auto"
-    manual_batch_size: int = Field(default=8, ge=1)
-    gpu_index: int = Field(default=0, ge=-1)
-    hotkey_stability_service_enabled: bool = True
-    hotkey_debounce_ms: int = Field(default=200, ge=0)
-    use_vad: bool = False
-    vad_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
-    vad_silence_duration: float = Field(default=1.0, ge=0.0)
-    vad_pre_speech_padding_ms: int = Field(default=150, ge=0)
-    vad_post_speech_padding_ms: int = Field(default=300, ge=0)
-    display_transcripts_in_terminal: bool = False
-    gemini_model_options: list[str] = Field(default_factory=list)
-    save_temp_recordings: bool = False
-    record_storage_mode: str = "auto"
-    record_storage_limit: int = Field(default=0, ge=0)
-    max_memory_seconds_mode: str = "auto"
-    max_memory_seconds: float = Field(default=30.0, ge=0.0)
-    min_free_ram_mb: int = Field(default=1000, ge=0)
-    auto_ram_threshold_percent: int = Field(default=10, ge=1, le=50)
-    max_parallel_downloads: int = Field(default=1, ge=1, le=8)
-    min_transcription_duration: float = Field(default=1.0, ge=0.0)
-    chunk_length_sec: float = Field(default=30.0, ge=0.0)
-    chunk_length_mode: str = "auto"
-    launch_at_startup: bool = False
-    clear_gpu_cache: bool = True
-    models_storage_dir: str = _DEFAULT_MODELS_STORAGE_DIR
-    recordings_dir: str = _DEFAULT_RECORDINGS_DIR
-    asr_cache_dir: str = _DEFAULT_ASR_CACHE_DIR
-    deps_install_dir: str = _DEFAULT_DEPS_INSTALL_DIR
-    hf_home_dir: str = _DEFAULT_HF_HOME_DIR
-    python_packages_dir: str = str((_DEFAULT_STORAGE_ROOT / "python_packages").expanduser())
-    vad_models_dir: str = str((_DEFAULT_STORAGE_ROOT / "vad").expanduser())
-    hf_cache_dir: str = str((_DEFAULT_STORAGE_ROOT / "hf_cache").expanduser())
-    storage_root_dir: str = str(_DEFAULT_STORAGE_ROOT)
-    recordings_dir: str = str((_DEFAULT_STORAGE_ROOT / "recordings").expanduser())
-    asr_model_id: str = "distil-whisper/distil-large-v3"
-    asr_backend: str = "ctranslate2"
-    ui_language: str = _DEFAULT_UI_LANGUAGE
-    advanced: AdvancedConfig = Field(default_factory=AdvancedConfig)
-    asr_installed_models: list[str] = Field(default_factory=list)
-    asr_curated_catalog: list[dict[str, Any]] = Field(default_factory=list_catalog)
-    asr_curated_catalog_url: str = ""
-    asr_last_download_status: ASRDownloadStatus = Field(default_factory=ASRDownloadStatus)
-    asr_download_history: list[ASRDownloadHistoryEntry] = Field(default_factory=list)
-    asr_last_prompt_decision: ASRPromptDecision = Field(default_factory=ASRPromptDecision)
-    first_run_completed: bool = False
-
-    @field_validator("record_key", mode="before")
-    @classmethod
-    def _coerce_record_key(cls, value: Any) -> str:
-        return _coerce_key(value)
 
     @field_validator("ui_language", mode="before")
     @classmethod
@@ -345,6 +355,21 @@ class AdvancedPerformanceConfig(BaseModel):
             return _normalize_lower(value, allowed={"toggle", "press"}, field_name="record_mode")
         raise ValueError("record_mode must be a string")
 
+    @field_validator(
+        "models_storage_dir",
+        "recordings_dir",
+        "deps_install_dir",
+        "hf_home_dir",
+        "asr_cache_dir",
+        "python_packages_dir",
+        "vad_models_dir",
+        "hf_cache_dir",
+        "storage_root_dir",
+        mode="before",
+    )
+    @classmethod
+    def _expand_paths(cls, value: Any) -> str:
+        return _expand_path(value)
 
     @field_validator("asr_installed_models", mode="before")
     @classmethod
@@ -362,7 +387,7 @@ class AdvancedPerformanceConfig(BaseModel):
             raise ValueError("asr_model_id must be a string")
         normalized = value.strip()
         if not normalized:
-            raise ValueError("asr_model_id must not be empty")
+            raise ValueError("asr_model_id cannot be empty")
 
         allowed_ids = set(_CURATED_MODEL_IDS)
         runtime_ids: set[str] = set()
@@ -413,6 +438,59 @@ class AdvancedPerformanceConfig(BaseModel):
                 f"asr_backend must be one of {sorted(_ALLOWED_ASR_BACKENDS)}"
             )
         return normalized
+
+    @model_validator(mode="after")
+    def _enforce_simple_mode_defaults(cls, values: "AppConfig") -> "AppConfig":
+        defaults = cls.model_fields
+
+        def _default(name: str) -> Any:
+            field = defaults.get(name)
+            return field.default if field is not None else None
+
+        simple_targets: dict[str, Any] = {
+            "text_correction_enabled": False,
+            "text_correction_service": "none",
+            "batch_size_mode": _default("batch_size_mode"),
+            "manual_batch_size": _default("manual_batch_size"),
+            "use_vad": _default("use_vad"),
+            "vad_threshold": _default("vad_threshold"),
+            "vad_silence_duration": _default("vad_silence_duration"),
+            "vad_pre_speech_padding_ms": _default("vad_pre_speech_padding_ms"),
+            "vad_post_speech_padding_ms": _default("vad_post_speech_padding_ms"),
+            "save_temp_recordings": _default("save_temp_recordings"),
+            "record_storage_mode": _default("record_storage_mode"),
+            "record_storage_limit": _default("record_storage_limit"),
+            "max_memory_seconds_mode": "auto",
+            "max_memory_seconds": _default("max_memory_seconds"),
+            "chunk_length_mode": "auto",
+            "chunk_length_sec": _default("chunk_length_sec"),
+        }
+
+        advanced_signals = [
+            bool(values.text_correction_enabled),
+            str(values.text_correction_service or "none").lower() not in {"", "none"},
+            bool(values.use_vad),
+            str(values.batch_size_mode or "auto").lower()
+            != str(simple_targets["batch_size_mode"] or "auto").lower(),
+            values.manual_batch_size != simple_targets["manual_batch_size"],
+            str(values.record_storage_mode or "auto").lower()
+            != str(simple_targets["record_storage_mode"] or "auto").lower(),
+            values.record_storage_limit != simple_targets["record_storage_limit"],
+            str(values.max_memory_seconds_mode or "auto").lower() not in {"auto"},
+            values.max_memory_seconds != simple_targets["max_memory_seconds"],
+            str(values.chunk_length_mode or "auto").lower() not in {"auto"},
+            values.chunk_length_sec != simple_targets["chunk_length_sec"],
+            bool(values.save_temp_recordings),
+        ]
+
+        if not values.show_advanced and any(advanced_signals):
+            values.show_advanced = True
+            return values
+
+        if not values.show_advanced:
+            for field_name, default_value in simple_targets.items():
+                setattr(values, field_name, default_value)
+        return values
 
 
 KEY_PATH_OVERRIDES: dict[str, tuple[str, ...]] = {

--- a/src/hotkeys/drivers.py
+++ b/src/hotkeys/drivers.py
@@ -11,7 +11,10 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any, Mapping
 
-import keyboard  # type: ignore[import]
+try:  # pragma: no cover - optional dependency
+    import keyboard  # type: ignore[import]
+except ModuleNotFoundError:  # pragma: no cover - handled gracefully
+    keyboard = None  # type: ignore[assignment]
 
 LOGGER = logging.getLogger("whisper_flash_transcriber.hotkeys.drivers")
 
@@ -59,6 +62,8 @@ class KeyboardLibHotkeyDriver(BaseHotkeyDriver):
     name = "keyboard"
 
     def __init__(self, *, log: Callable[[int, str], None] | None = None) -> None:
+        if keyboard is None:
+            raise RuntimeError("keyboard library is not available")
         super().__init__(log=log)
         self._handles: list[tuple[str, Any]] = []
         self._lock = threading.Lock()
@@ -144,9 +149,16 @@ class KeyboardLibHotkeyDriver(BaseHotkeyDriver):
             keyboard.unhook(hook)
 
 
-_PYNPUT_SPEC = importlib.util.find_spec("pynput.keyboard")
+try:  # pragma: no cover - optional dependency
+    _PYNPUT_SPEC = importlib.util.find_spec("pynput.keyboard")
+except ModuleNotFoundError:  # pragma: no cover - absent dependency
+    _PYNPUT_SPEC = None
+
 if _PYNPUT_SPEC is not None:
-    pynput_keyboard = importlib.import_module("pynput.keyboard")
+    try:  # pragma: no cover - optional dependency
+        pynput_keyboard = importlib.import_module("pynput.keyboard")
+    except ModuleNotFoundError:  # pragma: no cover - absent dependency
+        pynput_keyboard = None
 else:
     pynput_keyboard = None
 

--- a/src/keyboard_hotkey_manager.py
+++ b/src/keyboard_hotkey_manager.py
@@ -1,14 +1,21 @@
 # -*- coding: utf-8 -*-
 import json
-import shutil
-import time
-import threading
 import logging
+import shutil
+import threading
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+try:  # pragma: no cover - optional dependency
+    import keyboard  # type: ignore[import]
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    keyboard = None  # type: ignore[assignment]
+
 from .config_manager import HOTKEY_CONFIG_FILE, LEGACY_HOTKEY_LOCATIONS
+from .hotkey_normalization import _normalize_key_name
+from .hotkeys.drivers import BaseHotkeyDriver, build_available_drivers
 from .logging_utils import get_logger, join_thread_with_timeout, log_context
 
 LOGGER = get_logger(
@@ -40,6 +47,9 @@ class KeyboardHotkeyManager:
         self.record_key = "f3"  # Tecla padrão
         self.agent_key = "f4"  # Tecla padrão para comando agêntico
         self.record_mode = "toggle"  # Modo padrão
+        self.hotkey_handlers: dict[str, list[Any]] = {}
+        self._last_trigger_ts: dict[str, float] = {}
+        self._debounce_window_ms = 0
         self._drivers: list[BaseHotkeyDriver] = []
         self._active_driver: BaseHotkeyDriver | None = None
         self._active_driver_index: int | None = None
@@ -180,6 +190,13 @@ class KeyboardHotkeyManager:
                 ).lower()
                 if self.record_mode not in {"toggle", "press"}:
                     self.record_mode = "toggle"
+                debounce_value = config.get('hotkey_debounce_ms')
+                if debounce_value is not None:
+                    try:
+                        self._debounce_window_ms = max(0, int(debounce_value))
+                    except Exception:
+                        self._debounce_window_ms = max(0, int(self._debounce_window_ms))
+                self._last_trigger_ts.clear()
                 self._log(
                     logging.INFO,
                     "Hotkey configuration loaded.",
@@ -242,7 +259,8 @@ class KeyboardHotkeyManager:
             config = {
                 'record_key': normalized_record,
                 'agent_key': normalized_agent,
-                'record_mode': self.record_mode
+                'record_mode': self.record_mode,
+                'hotkey_debounce_ms': int(self._debounce_window_ms),
             }
             with path.open('w', encoding='utf-8') as f:
                 json.dump(config, f, indent=4)
@@ -534,6 +552,20 @@ class KeyboardHotkeyManager:
         if agent is not None:
             self.callback_agent = agent
 
+    def set_debounce_window(self, milliseconds: int) -> None:
+        """Define a janela de debounce para eventos repetidos."""
+
+        if milliseconds is None:
+            raise ValueError("Debounce window must be a non-negative integer")
+        try:
+            window_ms = int(milliseconds)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Debounce window must be a non-negative integer") from exc
+        if window_ms < 0:
+            raise ValueError("Debounce window must be non-negative")
+        self._debounce_window_ms = window_ms
+        self._last_trigger_ts.clear()
+
     def describe_persistence_state(self) -> dict[str, object]:
         """Retorna informações de diagnóstico do arquivo de hotkeys."""
 
@@ -646,20 +678,36 @@ class KeyboardHotkeyManager:
                 handle_id=handle_id,
             )
             return
-        for _, driver in entries:
-            try:
-                driver.unregister()
-            except Exception as exc:
-                self._log(
-                    logging.DEBUG,
-                    "Driver failed to unregister hotkeys.",
-                    event="hotkeys.unregister_error",
-                    driver=driver.name,
-                    error=str(exc),
-                )
+        handles = self.hotkey_handlers.setdefault(handle_id, [])
+        handles.append(handle)
+
+    def _unregister_hotkeys(self) -> None:
+        """Remove todas as hotkeys atualmente registradas."""
+
+        handles_snapshot = list(self.hotkey_handlers.items())
+        self.hotkey_handlers = {}
+        if keyboard is None:
+            return
+        for group, handles in handles_snapshot:
+            for handle in handles:
+                try:
+                    if hasattr(keyboard, "unhook"):
+                        keyboard.unhook(handle)
+                    elif hasattr(keyboard, "remove_hotkey"):
+                        keyboard.remove_hotkey(handle)
+                except Exception as exc:
+                    self._log(
+                        logging.DEBUG,
+                        "Failed to unregister hotkey handle.",
+                        event="hotkeys.unregister_error",
+                        handle_group=group,
+                        handle_id=str(handle),
+                        error=str(exc),
+                    )
         with self._driver_lock:
             self._active_driver = None
             self._active_driver_index = None
+            self._driver_failures = []
 
     def _register_hotkeys(self):
         """Registra as hotkeys no sistema."""
@@ -788,6 +836,20 @@ class KeyboardHotkeyManager:
             event="hotkeys.register_failure",
             last_error=str(last_error) if last_error else None,
         )
+        return False
+
+    def _should_process_event(self, event: str) -> bool:
+        """Return True when the event should be processed respecting debounce."""
+
+        window_ms = max(0, int(self._debounce_window_ms))
+        now = time.perf_counter()
+        if window_ms <= 0:
+            self._last_trigger_ts[event] = now
+            return True
+        last = self._last_trigger_ts.get(event)
+        if last is None or (now - last) * 1000 >= window_ms:
+            self._last_trigger_ts[event] = now
+            return True
         return False
 
     def _on_toggle_key(self):

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -7,6 +7,7 @@ import statistics
 import threading
 import time
 import os
+from collections import deque
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 import numpy as np
@@ -60,6 +61,7 @@ from . import model_manager as model_manager_module
 from .logging_utils import (
     current_correlation_id,
     get_logger,
+    log_context,
     operation_context,
     scoped_correlation_id,
 )


### PR DESCRIPTION
## Summary
- ensure the pytest suite injects the repository into sys.path and provides an isolated configuration context helper
- harden optional hotkey dependencies and rebuild the configuration schema to validate the flattened defaults
- add debounce and unregister support to the keyboard hotkey manager while exposing a stub keyboard module for tests
- cache the normalized default configuration tree for migration routines

## Testing
- python -m compileall src
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e53633aff88330a35cf186360d2723