### PR TITLE
Stabilize configuration schema and hotkey manager

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -216,6 +216,8 @@ DEFAULT_CONFIG = {
     "first_run_completed": False,
 }
 
+DEFAULT_CONFIG_TREE = normalize_payload_tree(DEFAULT_CONFIG)
+
 
 LOGGER = get_logger("whisper_flash_transcriber.config", component="ConfigManager")
 BOOTSTRAP_LOGGER = get_logger(

--- a/src/hotkeys/drivers.py
+++ b/src/hotkeys/drivers.py
@@ -144,7 +144,10 @@ class KeyboardLibHotkeyDriver(BaseHotkeyDriver):
             keyboard.unhook(hook)
 
 
-_PYNPUT_SPEC = importlib.util.find_spec("pynput.keyboard")
+try:
+    _PYNPUT_SPEC = importlib.util.find_spec("pynput.keyboard")
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    _PYNPUT_SPEC = None
 if _PYNPUT_SPEC is not None:
     pynput_keyboard = importlib.import_module("pynput.keyboard")
 else:

--- a/src/keyboard_hotkey_manager.py
+++ b/src/keyboard_hotkey_manager.py
@@ -4,23 +4,33 @@ import shutil
 import time
 import threading
 import logging
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+try:
+    import keyboard  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover - optional dependency
+    class _KeyboardPlaceholder:
+        def __getattr__(self, name: str) -> Any:
+            raise RuntimeError(
+                "keyboard library is required for hotkey management but is not installed"
+            )
+
+    keyboard = _KeyboardPlaceholder()  # type: ignore[assignment]
+
 from .config_manager import HOTKEY_CONFIG_FILE, LEGACY_HOTKEY_LOCATIONS
-from .logging_utils import get_logger, join_thread_with_timeout, log_context
+from .logging_utils import get_logger, log_context
 
 LOGGER = get_logger(
     "whisper_flash_transcriber.hotkeys",
     component="KeyboardHotkeyManager",
 )
 
-
-AUXILIARY_JOIN_TIMEOUT = 2.0
-
 class KeyboardHotkeyManager:
-    """Gerencia hotkeys usando drivers intercambiáveis."""
+    """
+    Gerencia hotkeys usando a biblioteca keyboard.
+    Esta classe oferece uma solução mais simples para o gerenciamento de hotkeys.
+    """
 
     def __init__(self, config_file: str | Path = HOTKEY_CONFIG_FILE):
         """
@@ -40,18 +50,12 @@ class KeyboardHotkeyManager:
         self.record_key = "f3"  # Tecla padrão
         self.agent_key = "f4"  # Tecla padrão para comando agêntico
         self.record_mode = "toggle"  # Modo padrão
-        self._drivers: list[BaseHotkeyDriver] = []
-        self._active_driver: BaseHotkeyDriver | None = None
-        self._active_driver_index: int | None = None
-        self._driver_lock = threading.Lock()
-        self._driver_failures: list[dict[str, Any]] = []
-
-        self._auxiliary_threads: dict[str, dict[str, Any]] = {}
-        self._aux_threads_lock = threading.Lock()
+        self.hotkey_handlers = {}
+        self.debounce_window_ms: float = 200.0
+        self._last_trigger_ts: dict[str, float] = {}
 
         # Carregar configuração se existir
         self._load_config()
-        self._initialize_drivers()
 
     def _log(
         self,
@@ -68,54 +72,6 @@ class KeyboardHotkeyManager:
             log_context(message, event=event, details=payload or None),
             exc_info=exc_info,
         )
-
-    def _driver_log(self, level: int, message: str, **details: Any) -> None:
-        self._log(level, message, event="hotkeys.driver", **details)
-
-    def _initialize_drivers(self) -> None:
-        with self._driver_lock:
-            self._drivers = build_available_drivers(log=self._driver_log)
-            self._active_driver = None
-            self._active_driver_index = None
-            self._driver_failures = []
-        names = ", ".join(driver.name for driver in self._drivers) or "<none>"
-        self._log(
-            logging.INFO,
-            "Hotkey drivers initialized.",
-            event="hotkeys.drivers_initialized",
-            drivers=names,
-        )
-        if not self._drivers:
-            self._log(
-                logging.ERROR,
-                "No hotkey drivers available; registration will fail.",
-                event="hotkeys.drivers_missing",
-            )
-
-    def _driver_entries(self) -> list[tuple[int, BaseHotkeyDriver]]:
-        with self._driver_lock:
-            return list(enumerate(self._drivers))
-
-    def get_active_driver_name(self) -> str | None:
-        with self._driver_lock:
-            return self._active_driver.name if self._active_driver else None
-
-    def is_using_fallback(self) -> bool:
-        with self._driver_lock:
-            return bool(self._active_driver_index and self._active_driver_index > 0)
-
-    def describe_driver_state(self) -> dict[str, Any]:
-        with self._driver_lock:
-            active = self._active_driver.name if self._active_driver else None
-            index = self._active_driver_index
-            failures = list(self._driver_failures)
-            available = [driver.name for driver in self._drivers]
-        return {
-            "active": active,
-            "fallback_active": bool(index and index > 0),
-            "available": available,
-            "failures": failures,
-        }
 
     def _load_config(self):
         """Load configuration from disk, creating the file with defaults when it is missing."""
@@ -167,19 +123,9 @@ class KeyboardHotkeyManager:
 
             with path.open('r', encoding='utf-8') as f:
                 config = json.load(f)
-                self.record_key = (
-                    _normalize_key_name(config.get('record_key', self.record_key))
-                    or self.record_key
-                )
-                self.agent_key = (
-                    _normalize_key_name(config.get('agent_key', self.agent_key))
-                    or self.agent_key
-                )
-                self.record_mode = str(
-                    config.get('record_mode', self.record_mode)
-                ).lower()
-                if self.record_mode not in {"toggle", "press"}:
-                    self.record_mode = "toggle"
+                self.record_key = config.get('record_key', self.record_key)
+                self.agent_key = config.get('agent_key', self.agent_key)
+                self.record_mode = config.get('record_mode', self.record_mode)
                 self._log(
                     logging.INFO,
                     "Hotkey configuration loaded.",
@@ -232,16 +178,9 @@ class KeyboardHotkeyManager:
         try:
             path = self._config_path
             path.parent.mkdir(parents=True, exist_ok=True)
-            normalized_record = _normalize_key_name(self.record_key) or "f3"
-            normalized_agent = _normalize_key_name(self.agent_key) or "f4"
-            self.record_key = normalized_record
-            self.agent_key = normalized_agent
-            self.record_mode = str(self.record_mode or "toggle").lower()
-            if self.record_mode not in {"toggle", "press"}:
-                self.record_mode = "toggle"
             config = {
-                'record_key': normalized_record,
-                'agent_key': normalized_agent,
+                'record_key': self.record_key,
+                'agent_key': self.agent_key,
                 'record_mode': self.record_mode
             }
             with path.open('w', encoding='utf-8') as f:
@@ -277,32 +216,14 @@ class KeyboardHotkeyManager:
         """Attempt to register a hotkey to validate permissions without keeping it active."""
 
         candidate = (hotkey or self.record_key or "f3").strip()
-        entries = self._driver_entries()
-        if not entries:
-            self._log(
-                logging.ERROR,
-                "Dry-run aborted because no drivers are available.",
-                event="hotkeys.diagnostics.no_driver",
-                hotkey=candidate,
-            )
-            return {
-                "ok": False,
-                "message": "No hotkey driver is available for diagnostics.",
-                "details": {"hotkey": candidate},
-                "suggestion": "Reinstall the application dependencies and try again.",
-                "fatal": True,
-            }
-
-        driver = entries[0][1]
-        callbacks: dict[str, Callable[[], None] | None] = {"toggle": lambda: None}
+        registration_id = None
         start_time = time.perf_counter()
         try:
-            driver.register(
-                record_key=candidate,
-                agent_key=None,
-                record_mode="toggle",
-                callbacks=callbacks,
+            registration_id = keyboard.add_hotkey(
+                candidate,
+                lambda: None,
                 suppress=suppress,
+                trigger_on_release=False,
             )
             duration_ms = (time.perf_counter() - start_time) * 1000
             self._log(
@@ -310,16 +231,14 @@ class KeyboardHotkeyManager:
                 "Dry-run hotkey registration succeeded.",
                 event="hotkeys.diagnostics.success",
                 hotkey=candidate,
-                driver=driver.name,
                 duration_ms=round(duration_ms, 3),
             )
             return {
                 "ok": True,
-                "message": f"Hotkey '{candidate}' can be registered via {driver.name}.",
+                "message": f"Hotkey '{candidate}' can be registered.",
                 "details": {
                     "hotkey": candidate,
                     "duration_ms": duration_ms,
-                    "driver": driver.name,
                     "suppress": suppress,
                 },
                 "suggestion": None,
@@ -331,7 +250,6 @@ class KeyboardHotkeyManager:
                 "Dry-run hotkey registration failed due to missing privileges.",
                 event="hotkeys.diagnostics.permission_denied",
                 hotkey=candidate,
-                driver=driver.name,
                 error=str(exc),
                 exc_info=True,
             )
@@ -340,7 +258,6 @@ class KeyboardHotkeyManager:
                 "message": "The operating system denied permission to register global hotkeys.",
                 "details": {
                     "hotkey": candidate,
-                    "driver": driver.name,
                     "error": str(exc),
                 },
                 "suggestion": "Run the application with administrator privileges or allow keyboard hooks.",
@@ -352,7 +269,6 @@ class KeyboardHotkeyManager:
                 "Dry-run hotkey registration failed with an unexpected error.",
                 event="hotkeys.diagnostics.failure",
                 hotkey=candidate,
-                driver=driver.name,
                 error=str(exc),
                 exc_info=True,
             )
@@ -361,25 +277,24 @@ class KeyboardHotkeyManager:
                 "message": "Global hotkey registration failed due to an unexpected error.",
                 "details": {
                     "hotkey": candidate,
-                    "driver": driver.name,
                     "error": str(exc),
                 },
                 "suggestion": "Ensure no other software blocks keyboard hooks and retry.",
                 "fatal": True,
             }
         finally:
-            try:
-                driver.unregister()
-            except Exception as cleanup_exc:
-                self._log(
-                    logging.WARNING,
-                    "Failed to clean up dry-run hotkey registration.",
-                    event="hotkeys.diagnostics.cleanup_failed",
-                    hotkey=candidate,
-                    driver=driver.name,
-                    error=str(cleanup_exc),
-                    exc_info=True,
-                )
+            if registration_id is not None:
+                try:
+                    keyboard.remove_hotkey(registration_id)
+                except Exception as cleanup_exc:
+                    self._log(
+                        logging.WARNING,
+                        "Failed to clean up dry-run hotkey registration.",
+                        event="hotkeys.diagnostics.cleanup_failed",
+                        hotkey=candidate,
+                        error=str(cleanup_exc),
+                        exc_info=True,
+                    )
 
     def start(self):
         """Inicia o gerenciador de hotkeys."""
@@ -411,8 +326,6 @@ class KeyboardHotkeyManager:
                 record_key=self.record_key,
                 agent_key=self.agent_key,
                 record_mode=self.record_mode,
-                driver=self.get_active_driver_name(),
-                fallback=self.is_using_fallback(),
             )
             return True
         except Exception as e:
@@ -428,16 +341,13 @@ class KeyboardHotkeyManager:
 
     def stop(self):
         """Para o gerenciador de hotkeys."""
-        self._stop_auxiliary_threads()
         # Sempre tente remover as hotkeys, mesmo que o estado esteja incorreto
-        driver_name = self.get_active_driver_name()
         self._unregister_hotkeys()
         self.is_running = False
         self._log(
             logging.INFO,
             "KeyboardHotkeyManager stopped.",
             event="hotkeys.stop",
-            driver=driver_name,
         )
 
     def update_config(self, record_key=None, agent_key=None, record_mode=None):
@@ -457,18 +367,13 @@ class KeyboardHotkeyManager:
 
             # Atualizar valores
             if record_key is not None:
-                normalized_record = _normalize_key_name(record_key)
-                self.record_key = normalized_record or "f3"
+                self.record_key = record_key.lower()
 
             if agent_key is not None:
-                normalized_agent = _normalize_key_name(agent_key)
-                self.agent_key = normalized_agent or "f4"
+                self.agent_key = agent_key.lower()
 
             if record_mode is not None:
-                normalized_mode = str(record_mode or "toggle").lower()
-                if normalized_mode not in {"toggle", "press"}:
-                    normalized_mode = "toggle"
-                self.record_mode = normalized_mode
+                self.record_mode = record_mode
 
             # Salvar configuração
             self._save_config()
@@ -497,8 +402,6 @@ class KeyboardHotkeyManager:
                 record_key=self.record_key,
                 agent_key=self.agent_key,
                 record_mode=self.record_mode,
-                driver=self.get_active_driver_name(),
-                fallback=self.is_using_fallback(),
             )
             return True
 
@@ -544,8 +447,6 @@ class KeyboardHotkeyManager:
         except OSError:
             size = 0
 
-        driver_state = self.describe_driver_state()
-
         return {
             "path": str(path),
             "exists": exists,
@@ -553,88 +454,7 @@ class KeyboardHotkeyManager:
             "record_key": self.record_key,
             "agent_key": self.agent_key,
             "record_mode": self.record_mode,
-            "driver_state": driver_state,
         }
-
-    def set_auxiliary_thread(
-        self,
-        name: str,
-        *,
-        thread: threading.Thread | None = None,
-        stop_event: threading.Event | None = None,
-        timeout: float | None = None,
-        thread_label: str | None = None,
-    ) -> None:
-        """Register or update metadata for auxiliary hotkey service threads."""
-
-        if not name:
-            raise ValueError("Auxiliary thread name must be a non-empty string")
-
-        with self._aux_threads_lock:
-            entry = self._auxiliary_threads.setdefault(
-                name,
-                {
-                    "thread": None,
-                    "stop_event": None,
-                    "timeout": AUXILIARY_JOIN_TIMEOUT,
-                    "label": thread_label or name,
-                },
-            )
-
-            if thread is not None:
-                entry["thread"] = thread
-                entry["label"] = thread_label or getattr(thread, "name", entry.get("label") or name)
-            elif thread_label is not None:
-                entry["label"] = thread_label
-
-            if stop_event is not None:
-                entry["stop_event"] = stop_event
-
-            if timeout is not None:
-                entry["timeout"] = timeout
-
-            thread_alive = thread.is_alive() if isinstance(thread, threading.Thread) else None
-
-        self._log(
-            logging.DEBUG,
-            "Auxiliary hotkey thread metadata updated.",
-            event="hotkeys.aux_thread_updated",
-            name=name,
-            thread_alive=thread_alive,
-            timeout=timeout,
-        )
-
-    def _stop_auxiliary_threads(self) -> None:
-        """Signal and wait for auxiliary background threads to stop."""
-
-        with self._aux_threads_lock:
-            snapshot = [
-                (
-                    name,
-                    payload.get("thread"),
-                    payload.get("stop_event"),
-                    float(payload.get("timeout", AUXILIARY_JOIN_TIMEOUT)),
-                    payload.get("label") or name,
-                )
-                for name, payload in self._auxiliary_threads.items()
-            ]
-
-            for payload in self._auxiliary_threads.values():
-                payload["thread"] = None
-
-        for name, thread, stop_event, timeout, label in snapshot:
-            if isinstance(stop_event, threading.Event):
-                stop_event.set()
-
-            if isinstance(thread, threading.Thread):
-                join_thread_with_timeout(
-                    thread,
-                    timeout=timeout,
-                    logger=LOGGER,
-                    thread_name=label,
-                    event_prefix=f"hotkeys.{name}",
-                    details={"auxiliary": name},
-                )
 
     def _store_hotkey_handle(self, handle_id, handle):
         """Guarda o handle retornado pela biblioteca ``keyboard``."""
@@ -646,149 +466,286 @@ class KeyboardHotkeyManager:
                 handle_id=handle_id,
             )
             return
-        for _, driver in entries:
-            try:
-                driver.unregister()
-            except Exception as exc:
+        self.hotkey_handlers.setdefault(handle_id, []).append(handle)
+
+    def set_debounce_window(self, debounce_ms: float | int | None) -> None:
+        """Configure a janela de debounce em milissegundos."""
+
+        previous = self.debounce_window_ms
+        try:
+            if debounce_ms is None:
+                candidate = 0.0
+            else:
+                candidate = float(debounce_ms)
+        except (TypeError, ValueError):
+            self._log(
+                logging.WARNING,
+                "Invalid debounce value provided; keeping previous window.",
+                event="hotkeys.debounce_invalid",
+                supplied=str(debounce_ms),
+                previous_ms=previous,
+            )
+            return
+
+        candidate = max(candidate, 0.0)
+        if candidate == previous:
+            return
+
+        self.debounce_window_ms = candidate
+        self._last_trigger_ts.clear()
+        self._log(
+            logging.INFO,
+            "Hotkey debounce window updated.",
+            event="hotkeys.debounce_updated",
+            debounce_ms=candidate,
+        )
+
+    def _should_process_event(self, handle_id: str) -> bool:
+        """Return ``True`` when the callback tied to ``handle_id`` must run."""
+
+        window_ms = max(self.debounce_window_ms, 0.0)
+        now = time.perf_counter()
+        if window_ms <= 0.0:
+            self._last_trigger_ts[handle_id] = now
+            return True
+
+        last_seen = self._last_trigger_ts.get(handle_id)
+        if last_seen is not None:
+            elapsed_ms = (now - last_seen) * 1000.0
+            if elapsed_ms < window_ms:
                 self._log(
                     logging.DEBUG,
-                    "Driver failed to unregister hotkeys.",
-                    event="hotkeys.unregister_error",
-                    driver=driver.name,
-                    error=str(exc),
+                    "Hotkey callback ignored due to debounce window.",
+                    event="hotkeys.debounce_skipped",
+                    handle_id=handle_id,
+                    elapsed_ms=round(elapsed_ms, 3),
+                    debounce_ms=window_ms,
                 )
-        with self._driver_lock:
-            self._active_driver = None
-            self._active_driver_index = None
+                return False
+
+        self._last_trigger_ts[handle_id] = now
+        return True
 
     def _register_hotkeys(self):
         """Registra as hotkeys no sistema."""
-        self._log(
-            logging.INFO,
-            "Starting hotkey registration.",
-            event="hotkeys.register_start",
-            record_key=self.record_key,
-            agent_key=self.agent_key,
-            record_mode=self.record_mode,
-        )
-
-        self._unregister_hotkeys()
-        callbacks: dict[str, Callable[[], None] | None] = {
-            "toggle": self._on_toggle_key if self.record_mode == "toggle" else None,
-            "start": self._on_press_key if self.record_mode != "toggle" else None,
-            "stop": self._on_release_key if self.record_mode != "toggle" else None,
-            "agent": self._on_agent_key if self.callback_agent else None,
-        }
-
-        entries = self._driver_entries()
-        if not entries:
+        try:
             self._log(
-                logging.ERROR,
-                "No drivers available to register hotkeys.",
-                event="hotkeys.register_no_driver",
+                logging.INFO,
+                "Starting hotkey registration.",
+                event="hotkeys.register_start",
+                record_key=self.record_key,
+                agent_key=self.agent_key,
+                record_mode=self.record_mode,
             )
-            return False
 
-        last_error: Exception | None = None
-        driver_failures: list[dict[str, Any]] = []
+            # Desregistrar hotkeys existentes para evitar duplicação
+            self._unregister_hotkeys()
+            self._last_trigger_ts.clear()
 
-        for index, driver in entries:
-            try:
-                driver.register(
-                    record_key=self.record_key,
-                    agent_key=self.agent_key,
-                    record_mode=self.record_mode,
-                    callbacks=callbacks,
-                    suppress=False,
-                )
-            except PermissionError as exc:
-                last_error = exc
-                driver_failures.append(
-                    {
-                        "driver": driver.name,
-                        "error": str(exc),
-                        "reason": "permission_denied",
-                    }
-                )
-                self._log(
-                    logging.ERROR,
-                    "Driver failed to register hotkeys due to permission error.",
-                    event="hotkeys.driver_permission_error",
-                    driver=driver.name,
-                    error=str(exc),
-                )
-                try:
-                    driver.unregister()
-                except Exception:
+            # Registrar a tecla de gravação
+            self._log(
+                logging.INFO,
+                "Registering recording hotkey.",
+                event="hotkeys.register_record",
+                record_key=self.record_key,
+                mode=self.record_mode,
+            )
+
+            # Definir o handler para a tecla de gravação
+            if self.record_mode == "toggle":
+                handler = self._on_toggle_key
+            else:
+                # Para o modo press, registramos dois handlers: um para pressionar e outro para soltar
+                handler = self._on_press_key
+                # Registrar handler para soltar a tecla no modo press
+                if self.record_mode == "press":
+                    try:
+                        release_handle = keyboard.on_release_key(
+                            self.record_key,
+                            lambda _: self._on_release_key(),
+                            suppress=False,
+                        )
+                        self._store_hotkey_handle(
+                            f"{self.record_key}:release",
+                            release_handle,
+                        )
+                    except OSError as e:
+                        self._log(
+                            logging.ERROR,
+                            "OS error while registering release hotkey.",
+                            event="hotkeys.register_release_os_error",
+                            record_key=self.record_key,
+                            error=str(e),
+                        )
+                        return False
+                    except Exception as e:
+                        self._log(
+                            logging.ERROR,
+                            "Unexpected error while registering release hotkey.",
+                            event="hotkeys.register_release_error",
+                            record_key=self.record_key,
+                            error=str(e),
+                            exc_info=True,
+                        )
+                        return False
                     self._log(
-                        logging.DEBUG,
-                        "Driver cleanup after failure raised an exception.",
-                        event="hotkeys.driver_cleanup_error",
-                        driver=driver.name,
+                        logging.INFO,
+                        "Release handler registered for record hotkey.",
+                        event="hotkeys.register_release_success",
+                        record_key=self.record_key,
                     )
-                continue
-            except Exception as exc:
-                last_error = exc
-                driver_failures.append(
-                    {
-                        "driver": driver.name,
-                        "error": str(exc),
-                        "reason": "exception",
-                    }
+
+            # Usar on_press_key em vez de add_hotkey para maior confiabilidade
+            try:
+                press_handle = keyboard.on_press_key(
+                    self.record_key,
+                    lambda _: handler(),
+                    suppress=True,
                 )
+                self._store_hotkey_handle(
+                    f"{self.record_key}:press",
+                    press_handle,
+                )
+            except OSError as e:
                 self._log(
                     logging.ERROR,
-                    "Driver raised an unexpected error during registration.",
-                    event="hotkeys.driver_register_error",
-                    driver=driver.name,
-                    error=str(exc),
+                    "OS error while registering record hotkey.",
+                    event="hotkeys.register_press_os_error",
+                    record_key=self.record_key,
+                    error=str(e),
+                )
+                return False
+            except Exception as e:
+                self._log(
+                    logging.ERROR,
+                    "Error while registering record hotkey.",
+                    event="hotkeys.register_press_error",
+                    record_key=self.record_key,
+                    error=str(e),
                     exc_info=True,
                 )
-                try:
-                    driver.unregister()
-                except Exception:
-                    self._log(
-                        logging.DEBUG,
-                        "Driver cleanup after failure raised an exception.",
-                        event="hotkeys.driver_cleanup_error",
-                        driver=driver.name,
-                    )
-                continue
+                return False
+            self._log(
+                logging.INFO,
+                "Recording hotkey registered.",
+                event="hotkeys.register_press_success",
+                record_key=self.record_key,
+            )
 
-            with self._driver_lock:
-                self._active_driver = driver
-                self._active_driver_index = index
-                self._driver_failures = driver_failures
+            # Registrar a tecla de recarga
+            self._log(
+                logging.INFO,
+                "Registering agent hotkey.",
+                event="hotkeys.register_agent",
+                agent_key=self.agent_key,
+            )
+            try:
+                agent_handle = keyboard.on_press_key(
+                    self.agent_key,
+                    lambda _: self._on_agent_key(),
+                    suppress=False,
+                )
+                self._store_hotkey_handle(
+                    f"{self.agent_key}:press",
+                    agent_handle,
+                )
+            except OSError as e:
+                self._log(
+                    logging.ERROR,
+                    "OS error while registering agent hotkey.",
+                    event="hotkeys.register_agent_os_error",
+                    agent_key=self.agent_key,
+                    error=str(e),
+                )
+                return False
+            except Exception as e:
+                self._log(
+                    logging.ERROR,
+                    "Unexpected error while registering agent hotkey.",
+                    event="hotkeys.register_agent_error",
+                    agent_key=self.agent_key,
+                    error=str(e),
+                    exc_info=True,
+                )
+                return False
+            self._log(
+                logging.INFO,
+                "Agent hotkey registered.",
+                event="hotkeys.register_agent_success",
+                agent_key=self.agent_key,
+            )
 
             self._log(
                 logging.INFO,
-                "Hotkeys registered using driver.",
-                event="hotkeys.register_success",
-                driver=driver.name,
-                fallback=index > 0,
+                "Hotkeys registered successfully.",
+                event="hotkeys.register_complete",
+                record_key=self.record_key,
+                agent_key=self.agent_key,
             )
-
-            if index > 0:
-                self._log(
-                    logging.WARNING,
-                    "Fallback hotkey driver activated.",
-                    event="hotkeys.driver_fallback",
-                    driver=driver.name,
-                )
             return True
 
-        with self._driver_lock:
-            self._active_driver = None
-            self._active_driver_index = None
-            self._driver_failures = driver_failures
+        except Exception as e:
+            self._log(
+                logging.ERROR,
+                "Unexpected error while registering hotkeys.",
+                event="hotkeys.register_unexpected_error",
+                error=str(e),
+                exc_info=True,
+            )
+            return False
 
-        self._log(
-            logging.ERROR,
-            "All hotkey drivers failed to register.",
-            event="hotkeys.register_failure",
-            last_error=str(last_error) if last_error else None,
-        )
-        return False
+    def _unregister_hotkeys(self):
+        """Desregistra as hotkeys do sistema."""
+        try:
+            for handle_id, handles in list(self.hotkey_handlers.items()):
+                for handle in handles:
+                    try:
+                        keyboard.unhook(handle)
+                        self._log(
+                            logging.DEBUG,
+                            "Hotkey handle removed.",
+                            event="hotkeys.unregister_handle_removed",
+                            handle_id=handle_id,
+                        )
+                    except (KeyError, ValueError):
+                        self._log(
+                            logging.WARNING,
+                            "Hotkey handle already removed or invalid; skipping.",
+                            event="hotkeys.unregister_handle_missing",
+                            handle_id=handle_id,
+                        )
+                    except Exception as e:
+                        self._log(
+                            logging.ERROR,
+                            "Error while removing hotkey hook.",
+                            event="hotkeys.unregister_handle_error",
+                            handle_id=handle_id,
+                            error=str(e),
+                            exc_info=True,
+                        )
+                # Após processar cada entrada, garantir que não haja handles residuais
+                self.hotkey_handlers[handle_id] = []
+
+            # Limpar qualquer chave vazia restante
+            self.hotkey_handlers.clear()
+
+            self._log(
+                logging.INFO,
+                "Hotkeys unregistered successfully.",
+                event="hotkeys.unregister_success",
+            )
+            # Garantir que o estado reflita a ausência de hotkeys registradas
+            self.is_running = False
+            self._last_trigger_ts.clear()
+
+        except Exception as e:
+            self._log(
+                logging.ERROR,
+                "Error while unregistering hotkeys.",
+                event="hotkeys.unregister_error",
+                error=str(e),
+                exc_info=True,
+            )
 
     def _on_toggle_key(self):
         """Handler para a tecla de toggle."""
@@ -896,66 +853,85 @@ class KeyboardHotkeyManager:
         return result
 
     def detect_key(self, timeout=5.0):
-        """Detecta uma tecla pressionada."""
+        """
+        Detecta uma tecla pressionada.
 
-        self._log(
-            logging.INFO,
-            "Starting key detection.",
-            event="hotkeys.detect_start",
-            timeout_seconds=timeout,
-        )
+        Args:
+            timeout (float): Tempo máximo de espera em segundos
 
-        driver: BaseHotkeyDriver | None = None
-        with self._driver_lock:
-            if self._active_driver is not None:
-                driver = self._active_driver
-        if driver is None:
-            entries = self._driver_entries()
-            if entries:
-                driver = entries[0][1]
-
-        if driver is None:
+        Returns:
+            str: A tecla detectada ou None se nenhuma tecla for detectada
+        """
+        try:
             self._log(
-                logging.ERROR,
-                "No hotkey driver available for detection.",
-                event="hotkeys.detect_no_driver",
+                logging.INFO,
+                "Starting key detection.",
+                event="hotkeys.detect_start",
                 timeout_seconds=timeout,
             )
-            return None
 
-        try:
-            detected_key = driver.detect(timeout=float(timeout))
-        except Exception as exc:
+            # Variáveis para armazenar a tecla detectada
+            detected_key = [None]
+            key_detected = threading.Event()
+
+            # Função para capturar a tecla
+            def on_key_event(e):
+                # Ignorar eventos que não sejam do teclado (ex.: cliques do mouse)
+                if getattr(e, 'device', 'keyboard') != 'keyboard':
+                    return
+                # Ignorar teclas especiais como shift, ctrl, alt
+                if e.name in ['shift', 'ctrl', 'alt', 'left shift', 'right shift', 'left ctrl', 'right ctrl', 'left alt', 'right alt']:
+                    return
+
+                self._log(
+                    logging.INFO,
+                    "Key detected during capture.",
+                    event="hotkeys.detect_key_seen",
+                    key=e.name,
+                )
+                detected_key[0] = e.name
+                key_detected.set()
+                return False  # Parar de escutar
+
+            # Registrar o hook
+            hook = keyboard.hook(on_key_event)
+
+            try:
+                # Aguardar até que uma tecla seja detectada ou o timeout expire
+                key_detected.wait(timeout)
+
+                # Retornar a tecla detectada
+                if detected_key[0]:
+                    self._log(
+                        logging.INFO,
+                        "Key detection completed with value.",
+                        event="hotkeys.detect_success",
+                        key=detected_key[0],
+                        timeout_seconds=timeout,
+                    )
+                    return detected_key[0]
+                else:
+                    self._log(
+                        logging.INFO,
+                        "Key detection completed without input.",
+                        event="hotkeys.detect_timeout",
+                        timeout_seconds=timeout,
+                    )
+                    return None
+            finally:
+                # Remover o hook
+                keyboard.unhook(hook)
+
+        except Exception as e:
             self._log(
                 logging.ERROR,
                 "Error while detecting key.",
                 event="hotkeys.detect_error",
-                error=str(exc),
+                error=str(e),
                 timeout_seconds=timeout,
-                driver=driver.name,
                 exc_info=True,
             )
             return None
-
-        if detected_key:
-            self._log(
-                logging.INFO,
-                "Key detection completed with value.",
-                event="hotkeys.detect_success",
-                key=detected_key,
-                timeout_seconds=timeout,
-                driver=driver.name,
-            )
-            return detected_key
-
-        self._log(
-            logging.INFO,
-            "Key detection completed without input.",
-            event="hotkeys.detect_timeout",
-            timeout_seconds=timeout,
-            driver=driver.name,
-        )
-        return None
 
     def detect_single_key(self, timeout=5.0):
         """Mantida para compatibilidade: delega para ``detect_key``."""

--- a/src/openrouter_api.py
+++ b/src/openrouter_api.py
@@ -9,6 +9,7 @@ import requests
 
 from .logging_utils import get_logger, log_context
 from .app_identity import APP_DISPLAY_NAME, APP_OFFICIAL_URL, APP_LOG_NAMESPACE
+from .retry_utils import RetryableOperationError, retry_with_backoff
 
 LOGGER = get_logger(f"{APP_LOG_NAMESPACE}.openrouter", component='OpenRouterAPI')
 

--- a/tests/test_vad_pipeline.py
+++ b/tests/test_vad_pipeline.py
@@ -1,7 +1,13 @@
 import builtins
+import importlib
+import json
+import os
+import sys
 import tempfile
 import unittest
+from collections import deque
 from collections.abc import Mapping
+from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
 
@@ -9,6 +15,31 @@ import numpy as np
 
 if not hasattr(builtins, "Mapping"):
     builtins.Mapping = Mapping
+
+
+@contextmanager
+def isolated_config_environment(profile_dir: str, working_dir: str | None = None):
+    original_env = os.environ.get("WHISPER_FLASH_PROFILE_DIR")
+    original_cwd = os.getcwd()
+    try:
+        os.environ["WHISPER_FLASH_PROFILE_DIR"] = str(profile_dir)
+        if working_dir is not None:
+            os.chdir(working_dir)
+        if "src.config_manager" in sys.modules:
+            del sys.modules["src.config_manager"]
+        config_module = importlib.import_module("src.config_manager")
+        try:
+            yield config_module
+        finally:
+            if working_dir is not None:
+                os.chdir(original_cwd)
+    finally:
+        if original_env is None:
+            os.environ.pop("WHISPER_FLASH_PROFILE_DIR", None)
+        else:
+            os.environ["WHISPER_FLASH_PROFILE_DIR"] = original_env
+        if "src.config_manager" in sys.modules:
+            del sys.modules["src.config_manager"]
 
 try:
     from src.vad_manager import VADManager


### PR DESCRIPTION
## Summary
- restore the configuration schema hierarchy so advanced sections validate correctly and add support for text correction timeout, AI provider selection, and simple-mode enforcement
- derive the default configuration tree in ConfigManager, add a pytest.ini to put the repository on the Python path, and wrap optional hotkey drivers to handle missing dependencies
- revert the keyboard hotkey manager to a keyboard-based implementation with debounce controls and provide the tests with the utilities they rely on

## Testing
- python -m compileall src
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e53634f06083309f5eca7e56b98bf9