### PR TITLE
Stabilize config schema and hotkey handling

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -155,55 +156,24 @@ class SoundSettings(BaseModel):
     volume: float = Field(default=0.5, ge=0.0)
 
 
-class AdvancedConfig(BaseModel):
-    """Container for advanced configuration namespaces."""
+class AdvancedHotkeyConfig(BaseModel):
+    """Normalized representation of hotkey-related overrides."""
 
-    model_config = ConfigDict(extra="allow", str_strip_whitespace=True)
+    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
 
-    hotkeys: dict[str, Any] = Field(default_factory=dict)
-    ai: dict[str, Any] = Field(default_factory=dict)
-    performance: dict[str, Any] = Field(default_factory=dict)
-    storage: dict[str, Any] = Field(default_factory=dict)
-    vad: dict[str, Any] = Field(default_factory=dict)
-    workflow: dict[str, Any] = Field(default_factory=dict)
-    system: dict[str, Any] = Field(default_factory=dict)
-
-    @staticmethod
-    def _coerce_section(value: Any) -> dict[str, Any]:
-        if value is None:
-            return {}
-        if isinstance(value, Mapping):
-            return {str(key): value[key] for key in value}
-        raise ValueError("Advanced configuration sections must be mappings")
-
-    @field_validator(
-        "hotkeys",
-        "ai",
-        "performance",
-        "storage",
-        "vad",
-        "workflow",
-        "system",
-        mode="before",
-    )
-    @classmethod
-    def _normalize_sections(cls, value: Any) -> dict[str, Any]:
-        return cls._coerce_section(value)
-
-
-class AppConfig(BaseModel):
-    """Primary configuration schema for Whisper Flash Transcriber."""
-
-    model_config = ConfigDict(extra="allow", str_strip_whitespace=True)
-
+    record_key: str = "F3"
+    record_mode: str = "toggle"
+    auto_paste: bool = True
+    agent_auto_paste: bool | None = True
+    auto_paste_modifier: str = "auto"
     agent_key: str = "F4"
-    hotkey_stability_service_enabled: bool = True
     keyboard_library: str = "win32"
     hotkey_debounce_ms: int = Field(default=200, ge=0)
+    hotkey_stability_service_enabled: bool = True
 
-    @field_validator("agent_key", mode="before")
+    @field_validator("record_key", "agent_key", mode="before")
     @classmethod
-    def _coerce_agent_key(cls, value: Any) -> str:
+    def _coerce_hotkey(cls, value: Any) -> str:
         return _coerce_key(value)
 
     @field_validator("auto_paste_modifier", mode="before")
@@ -213,7 +183,7 @@ class AppConfig(BaseModel):
 
     @field_validator("agent_auto_paste", mode="before")
     @classmethod
-    def _coerce_optional_bool(cls, value: Any) -> bool | None:
+    def _coerce_agent_auto_paste(cls, value: Any) -> bool | None:
         return _optional_bool(value)
 
 
@@ -260,73 +230,6 @@ class AdvancedAIConfig(BaseModel):
             "gemini-2.5-pro",
         ]
     )
-    ui_language: str = _DEFAULT_UI_LANGUAGE
-    batch_size: int = Field(default=16, ge=1)
-    batch_size_mode: str = "auto"
-    manual_batch_size: int = Field(default=8, ge=1)
-    gpu_index: int = Field(default=0, ge=-1)
-    hotkey_stability_service_enabled: bool = True
-    use_vad: bool = False
-    vad_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
-    vad_silence_duration: float = Field(default=1.0, ge=0.0)
-    vad_pre_speech_padding_ms: int = Field(default=150, ge=0)
-    vad_post_speech_padding_ms: int = Field(default=300, ge=0)
-    display_transcripts_in_terminal: bool = False
-    save_temp_recordings: bool = False
-    record_storage_mode: str = "auto"
-    record_storage_limit: int = Field(default=0, ge=0)
-    max_memory_seconds_mode: str = "auto"
-    max_memory_seconds: float = Field(default=30.0, ge=0.0)
-    min_free_ram_mb: int = Field(default=1000, ge=0)
-    auto_ram_threshold_percent: int = Field(default=10, ge=1, le=50)
-    max_parallel_downloads: int = Field(default=1, ge=1, le=8)
-    chunk_length_sec: float = Field(default=30.0, ge=0.0)
-    chunk_length_mode: str = "auto"
-    launch_at_startup: bool = False
-    clear_gpu_cache: bool = True
-    enable_torch_compile: bool = False
-    storage_root_dir: str = str(_DEFAULT_STORAGE_ROOT)
-    models_storage_dir: str = _DEFAULT_MODELS_STORAGE_DIR
-    recordings_dir: str = _DEFAULT_RECORDINGS_DIR
-    deps_install_dir: str = _DEFAULT_DEPS_INSTALL_DIR
-    hf_home_dir: str = _DEFAULT_HF_HOME_DIR
-    asr_cache_dir: str = _DEFAULT_ASR_CACHE_DIR
-    python_packages_dir: str = _DEFAULT_PYTHON_PACKAGES_DIR
-    vad_models_dir: str = _DEFAULT_VAD_MODELS_DIR
-    hf_cache_dir: str = _DEFAULT_HF_CACHE_DIR
-    asr_model_id: str = "distil-whisper/distil-large-v3"
-    asr_backend: str = "ctranslate2"
-    asr_compute_device: str = "auto"
-    asr_ct2_compute_type: str = "int8_float16"
-    asr_ct2_cpu_threads: int = Field(default=0, ge=0)
-    asr_installed_models: list[str] = Field(default_factory=list)
-    asr_curated_catalog: list[dict[str, Any]] = Field(default_factory=list_catalog)
-    asr_curated_catalog_url: str = ""
-    asr_last_download_status: ASRDownloadStatus = Field(default_factory=ASRDownloadStatus)
-    asr_download_history: list[ASRDownloadHistoryEntry] = Field(default_factory=list)
-    asr_last_prompt_decision: ASRPromptDecision = Field(default_factory=ASRPromptDecision)
-    batch_size_specified: bool = False
-    gpu_index_specified: bool = False
-    first_run_completed: bool = False
-    advanced: AdvancedConfig = Field(default_factory=AdvancedConfig)
-
-    @field_validator("record_key", mode="before")
-    @classmethod
-    def _coerce_record_key(cls, value: Any) -> str:
-        return _coerce_key(value)
-
-    @field_validator("auto_paste_modifier", mode="before")
-    @classmethod
-    def _normalize_modifier(cls, value: Any) -> str:
-        return _normalize_auto_paste_modifier(value)
-
-    @field_validator("agent_auto_paste", mode="before")
-    @classmethod
-    def _normalize_agent_auto_paste(cls, value: Any) -> bool:
-        coerced = _optional_bool(value)
-        if coerced is None:
-            return True
-        return bool(coerced)
 
     @field_validator("text_correction_service", mode="before")
     @classmethod
@@ -476,11 +379,11 @@ class AppConfig(BaseModel):
     agent_auto_paste: bool | None = True
     auto_paste_modifier: str = "auto"
     min_record_duration: float = Field(default=0.5, ge=0.0)
-    sound: SoundSettings = Field(default_factory=SoundSettings)
     sound_enabled: bool = True
     sound_frequency: int = Field(default=400, ge=0)
     sound_duration: float = Field(default=0.3, ge=0.0)
     sound_volume: float = Field(default=0.5, ge=0.0)
+    sound: SoundSettings = Field(default_factory=SoundSettings)
     agent_key: str = "F4"
     keyboard_library: str = "win32"
     hotkey_stability_service_enabled: bool = True
@@ -506,10 +409,13 @@ class AppConfig(BaseModel):
             "gemini-2.5-pro",
         ]
     )
+    ui_language: str = _DEFAULT_UI_LANGUAGE
     batch_size: int = Field(default=16, ge=1)
     batch_size_mode: str = "auto"
     manual_batch_size: int = Field(default=8, ge=1)
     gpu_index: int = Field(default=0, ge=-1)
+    batch_size_specified: bool = False
+    gpu_index_specified: bool = False
     use_vad: bool = False
     vad_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
     vad_silence_duration: float = Field(default=1.0, ge=0.0)
@@ -542,6 +448,7 @@ class AppConfig(BaseModel):
     chunk_length_sec: float = Field(default=30.0, ge=0.0)
     chunk_length_mode: str = "auto"
     clear_gpu_cache: bool = True
+    enable_torch_compile: bool = False
     launch_at_startup: bool = False
     asr_model_id: str = "distil-whisper/distil-large-v3"
     asr_backend: str = "ctranslate2"
@@ -551,40 +458,12 @@ class AppConfig(BaseModel):
     asr_last_download_status: ASRDownloadStatus = Field(default_factory=ASRDownloadStatus)
     asr_download_history: list[ASRDownloadHistoryEntry] = Field(default_factory=list)
     asr_last_prompt_decision: ASRPromptDecision = Field(default_factory=ASRPromptDecision)
-    ui_language: str = _DEFAULT_UI_LANGUAGE
     advanced: AdvancedConfig = Field(default_factory=AdvancedConfig)
     first_run_completed: bool = False
-    sound: SoundSettings = Field(default_factory=SoundSettings)
-    advanced: AdvancedConfig = Field(default_factory=AdvancedConfig)
 
-    @field_validator("record_key", mode="before")
+    @field_validator("record_key", "agent_key", mode="before")
     @classmethod
-    def _coerce_record_key(cls, value: Any) -> str:
-        return _coerce_key(value)
-
-    @field_validator("agent_key", mode="before")
-    @classmethod
-    def _coerce_agent_key(cls, value: Any) -> str:
-        return _coerce_key(value)
-
-    @field_validator("auto_paste_modifier", mode="before")
-    @classmethod
-    def _normalize_simple_modifier(cls, value: Any) -> str:
-        return _normalize_auto_paste_modifier(value)
-
-    @field_validator("agent_auto_paste", mode="before")
-    @classmethod
-    def _coerce_simple_optional_bool(cls, value: Any) -> bool | None:
-        return _optional_bool(value)
-
-    @field_validator("recordings_dir", "storage_root_dir", "models_storage_dir", mode="before")
-    @classmethod
-    def _normalize_primary_paths(cls, value: Any) -> str:
-        return _expand_path(value)
-
-    @field_validator("ui_language", mode="before")
-    @classmethod
-    def _coerce_agent_key(cls, value: Any) -> str:
+    def _coerce_hotkey(cls, value: Any) -> str:
         return _coerce_key(value)
 
     @field_validator("auto_paste_modifier", mode="before")
@@ -594,10 +473,33 @@ class AppConfig(BaseModel):
 
     @field_validator("agent_auto_paste", mode="before")
     @classmethod
-    def _coerce_agent_auto_paste(cls, value: Any) -> bool:
+    def _coerce_optional_bool(cls, value: Any) -> bool | None:
+        return _optional_bool(value)
+
+    @field_validator(
+        "storage_root_dir",
+        "models_storage_dir",
+        "recordings_dir",
+        "asr_cache_dir",
+        "deps_install_dir",
+        "hf_home_dir",
+        "transformers_cache_dir",
+        "python_packages_dir",
+        "vad_models_dir",
+        "hf_cache_dir",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_paths(cls, value: Any) -> str:
+        return _expand_path(value)
+
+    @field_validator("ui_language", mode="before")
+    @classmethod
+    def _normalize_ui_language(cls, value: Any) -> str:
         if value is None:
-            return True
-        return bool(value)
+            return _DEFAULT_UI_LANGUAGE
+        key = str(value).strip().lower()
+        return _SUPPORTED_UI_LANGUAGE_MAP.get(key, _DEFAULT_UI_LANGUAGE)
 
     @field_validator("text_correction_service", mode="before")
     @classmethod
@@ -610,20 +512,20 @@ class AppConfig(BaseModel):
             )
         raise ValueError("text_correction_service must be a string")
 
-    @field_validator("text_correction_service", mode="before")
+    @field_validator("ai_provider", mode="before")
     @classmethod
-    def _simple_text_service(cls, value: Any) -> str:
+    def _normalize_ai_provider(cls, value: Any) -> str:
         if isinstance(value, str):
             return _normalize_lower(
                 value,
-                allowed={"none", "openrouter", "gemini"},
-                field_name="text_correction_service",
+                allowed={"gemini", "openrouter", "none"},
+                field_name="ai_provider",
             )
-        raise ValueError("text_correction_service must be a string")
+        raise ValueError("ai_provider must be a string")
 
     @field_validator("gemini_model_options", mode="before")
     @classmethod
-    def _coerce_simple_model_options(cls, value: Any) -> list[str]:
+    def _coerce_model_options(cls, value: Any) -> list[str]:
         if value is None:
             return []
         if isinstance(value, (list, tuple, set)):
@@ -698,213 +600,101 @@ class AppConfig(BaseModel):
             )
         return normalized
 
-    @model_validator(mode="after")
-    def _finalize(cls, values: "AppConfig") -> "AppConfig":
-        """Synchronize simple fields, enforce defaults, and mirror advanced sections."""
+    def model_post_init(self, __context: Any) -> None:
+        advanced = self.advanced
+        if not isinstance(advanced, AdvancedConfig):
+            advanced = AdvancedConfig.model_validate(advanced)
+            self.advanced = advanced
 
-        advanced_defaults = AdvancedConfig()
-        advanced = values.advanced
+        default_adv = AdvancedConfig()
+        monitored_sections = ("ai", "performance", "storage", "vad", "workflow", "system")
+        if any(
+            advanced.model_dump()[section] != default_adv.model_dump()[section]
+            for section in monitored_sections
+        ):
+            self.show_advanced = self.show_advanced or True
 
-        simple_targets = {
-            "ai.text_correction_enabled": advanced_defaults.ai.text_correction_enabled,
-            "ai.text_correction_service": advanced_defaults.ai.text_correction_service,
-            "ai.openrouter_prompt": advanced_defaults.ai.openrouter_prompt,
-            "ai.openrouter_timeout": advanced_defaults.ai.openrouter_timeout,
-            "ai.openrouter_max_attempts": advanced_defaults.ai.openrouter_max_attempts,
-            "ai.gemini_timeout": advanced_defaults.ai.gemini_timeout,
-            "ai.gemini_model": advanced_defaults.ai.gemini_model,
-            "ai.gemini_agent_model": advanced_defaults.ai.gemini_agent_model,
-            "ai.ai_provider": advanced_defaults.ai.ai_provider,
-            "ai.text_correction_timeout": advanced_defaults.ai.text_correction_timeout,
-            "ai.prompt_agentico": advanced_defaults.ai.prompt_agentico,
-            "ai.gemini_model_options": list(advanced_defaults.ai.gemini_model_options),
-            "performance.batch_size_mode": advanced_defaults.performance.batch_size_mode,
-            "performance.manual_batch_size": advanced_defaults.performance.manual_batch_size,
-            "performance.chunk_length_mode": advanced_defaults.performance.chunk_length_mode,
-            "performance.chunk_length_sec": advanced_defaults.performance.chunk_length_sec,
-            "performance.max_parallel_downloads": advanced_defaults.performance.max_parallel_downloads,
-            "storage.record_storage_mode": advanced_defaults.storage.record_storage_mode,
-            "storage.record_storage_limit": advanced_defaults.storage.record_storage_limit,
-            "storage.max_memory_seconds_mode": advanced_defaults.storage.max_memory_seconds_mode,
-            "storage.max_memory_seconds": advanced_defaults.storage.max_memory_seconds,
-            "storage.min_free_ram_mb": advanced_defaults.storage.min_free_ram_mb,
-            "storage.auto_ram_threshold_percent": advanced_defaults.storage.auto_ram_threshold_percent,
-            "storage.save_temp_recordings": advanced_defaults.storage.save_temp_recordings,
-            "vad.use_vad": advanced_defaults.vad.use_vad,
-            "vad.vad_threshold": advanced_defaults.vad.vad_threshold,
-            "vad.vad_silence_duration": advanced_defaults.vad.vad_silence_duration,
-            "vad.vad_pre_speech_padding_ms": advanced_defaults.vad.vad_pre_speech_padding_ms,
-            "vad.vad_post_speech_padding_ms": advanced_defaults.vad.vad_post_speech_padding_ms,
-        }
-
-        advanced_signals = [
-            bool(advanced.ai.text_correction_enabled),
-            str(advanced.ai.text_correction_service or "none").lower() not in {"", "none"},
-            bool(advanced.vad.use_vad),
-            str(advanced.performance.batch_size_mode or "auto").lower()
-            != str(simple_targets["performance.batch_size_mode"] or "auto").lower(),
-            advanced.performance.manual_batch_size
-            != simple_targets["performance.manual_batch_size"],
-            str(advanced.storage.record_storage_mode or "auto").lower()
-            != str(simple_targets["storage.record_storage_mode"] or "auto").lower(),
-            advanced.storage.record_storage_limit
-            != simple_targets["storage.record_storage_limit"],
-            str(advanced.storage.max_memory_seconds_mode or "auto").lower()
-            not in {"auto"},
-            advanced.storage.max_memory_seconds
-            != simple_targets["storage.max_memory_seconds"],
-            str(advanced.performance.chunk_length_mode or "auto").lower()
-            not in {"auto"},
-            advanced.performance.chunk_length_sec
-            != simple_targets["performance.chunk_length_sec"],
-            bool(advanced.storage.save_temp_recordings),
-        ]
-
-        if not values.show_advanced and any(advanced_signals):
-            values.show_advanced = True
-
-        if not values.show_advanced:
-            advanced.ai.text_correction_enabled = simple_targets["ai.text_correction_enabled"]
-            advanced.ai.text_correction_service = simple_targets["ai.text_correction_service"]
-            advanced.ai.openrouter_prompt = simple_targets["ai.openrouter_prompt"]
-            advanced.ai.openrouter_timeout = simple_targets["ai.openrouter_timeout"]
-            advanced.ai.openrouter_max_attempts = simple_targets["ai.openrouter_max_attempts"]
-            advanced.ai.gemini_timeout = simple_targets["ai.gemini_timeout"]
-            advanced.ai.gemini_model = simple_targets["ai.gemini_model"]
-            advanced.ai.gemini_agent_model = simple_targets["ai.gemini_agent_model"]
-            advanced.ai.ai_provider = simple_targets["ai.ai_provider"]
-            advanced.ai.text_correction_timeout = simple_targets["ai.text_correction_timeout"]
-            advanced.ai.prompt_agentico = simple_targets["ai.prompt_agentico"]
-            advanced.ai.gemini_model_options = list(
-                simple_targets["ai.gemini_model_options"]
-            )
-            advanced.performance.batch_size_mode = simple_targets[
-                "performance.batch_size_mode"
-            ]
-            advanced.performance.manual_batch_size = simple_targets[
-                "performance.manual_batch_size"
-            ]
-            advanced.performance.chunk_length_mode = simple_targets[
-                "performance.chunk_length_mode"
-            ]
-            advanced.performance.chunk_length_sec = simple_targets[
-                "performance.chunk_length_sec"
-            ]
-            advanced.performance.max_parallel_downloads = simple_targets[
-                "performance.max_parallel_downloads"
-            ]
-            advanced.storage.record_storage_mode = simple_targets[
-                "storage.record_storage_mode"
-            ]
-            advanced.storage.record_storage_limit = simple_targets[
-                "storage.record_storage_limit"
-            ]
-            advanced.storage.max_memory_seconds_mode = simple_targets[
-                "storage.max_memory_seconds_mode"
-            ]
-            advanced.storage.max_memory_seconds = simple_targets[
-                "storage.max_memory_seconds"
-            ]
-            advanced.storage.min_free_ram_mb = simple_targets[
-                "storage.min_free_ram_mb"
-            ]
-            advanced.storage.auto_ram_threshold_percent = simple_targets[
-                "storage.auto_ram_threshold_percent"
-            ]
-            advanced.storage.save_temp_recordings = simple_targets[
-                "storage.save_temp_recordings"
-            ]
-            advanced.vad.use_vad = simple_targets["vad.use_vad"]
-            advanced.vad.vad_threshold = simple_targets["vad.vad_threshold"]
-            advanced.vad.vad_silence_duration = simple_targets[
-                "vad.vad_silence_duration"
-            ]
-            advanced.vad.vad_pre_speech_padding_ms = simple_targets[
-                "vad.vad_pre_speech_padding_ms"
-            ]
-            advanced.vad.vad_post_speech_padding_ms = simple_targets[
-                "vad.vad_post_speech_padding_ms"
-            ]
-
-        # Mirror advanced sections into the flattened namespace.
         hotkeys = advanced.hotkeys
-        values.agent_key = hotkeys.agent_key
-        values.agent_auto_paste = hotkeys.agent_auto_paste
-        values.auto_paste_modifier = hotkeys.auto_paste_modifier
-        values.hotkey_stability_service_enabled = hotkeys.hotkey_stability_service_enabled
-        values.keyboard_library = hotkeys.keyboard_library
+        self.record_key = hotkeys.record_key
+        self.record_mode = hotkeys.record_mode
+        self.auto_paste = hotkeys.auto_paste
+        self.agent_auto_paste = hotkeys.agent_auto_paste
+        self.auto_paste_modifier = hotkeys.auto_paste_modifier
+        self.agent_key = hotkeys.agent_key
+        self.keyboard_library = hotkeys.keyboard_library
+        self.hotkey_debounce_ms = hotkeys.hotkey_debounce_ms
+        self.hotkey_stability_service_enabled = hotkeys.hotkey_stability_service_enabled
 
         ai = advanced.ai
-        values.text_correction_enabled = ai.text_correction_enabled
-        values.text_correction_service = ai.text_correction_service
-        values.openrouter_api_key = ai.openrouter_api_key
-        values.openrouter_model = ai.openrouter_model
-        values.openrouter_timeout = ai.openrouter_timeout
-        values.openrouter_prompt = ai.openrouter_prompt
-        values.openrouter_max_attempts = ai.openrouter_max_attempts
-        values.gemini_api_key = ai.gemini_api_key
-        values.gemini_model = ai.gemini_model
-        values.gemini_agent_model = ai.gemini_agent_model
-        values.gemini_timeout = ai.gemini_timeout
-        values.gemini_prompt = ai.gemini_prompt
-        values.text_correction_timeout = ai.text_correction_timeout
-        values.ai_provider = ai.ai_provider
-        values.prompt_agentico = ai.prompt_agentico
-        values.gemini_model_options = list(ai.gemini_model_options)
+        self.text_correction_enabled = ai.text_correction_enabled
+        self.text_correction_service = ai.text_correction_service
+        self.openrouter_api_key = ai.openrouter_api_key
+        self.openrouter_model = ai.openrouter_model
+        self.openrouter_timeout = ai.openrouter_timeout
+        self.openrouter_prompt = ai.openrouter_prompt
+        self.openrouter_max_attempts = ai.openrouter_max_attempts
+        self.gemini_api_key = ai.gemini_api_key
+        self.gemini_model = ai.gemini_model
+        self.gemini_agent_model = ai.gemini_agent_model
+        self.gemini_timeout = ai.gemini_timeout
+        self.gemini_prompt = ai.gemini_prompt
+        self.text_correction_timeout = ai.text_correction_timeout
+        self.ai_provider = ai.ai_provider
+        self.prompt_agentico = ai.prompt_agentico
+        self.gemini_model_options = list(ai.gemini_model_options)
 
         performance = advanced.performance
-        values.batch_size = performance.batch_size
-        values.batch_size_mode = performance.batch_size_mode
-        values.manual_batch_size = performance.manual_batch_size
-        values.gpu_index = performance.gpu_index
-        values.chunk_length_sec = performance.chunk_length_sec
-        values.chunk_length_mode = performance.chunk_length_mode
-        values.clear_gpu_cache = performance.clear_gpu_cache
-        values.asr_compute_device = performance.asr_compute_device
-        values.asr_dtype = performance.asr_dtype
-        values.asr_ct2_compute_type = performance.asr_ct2_compute_type
-        values.asr_ct2_cpu_threads = performance.asr_ct2_cpu_threads
-        values.max_parallel_downloads = performance.max_parallel_downloads
+        self.batch_size = performance.batch_size
+        self.batch_size_mode = performance.batch_size_mode
+        self.manual_batch_size = performance.manual_batch_size
+        self.gpu_index = performance.gpu_index
+        self.chunk_length_sec = performance.chunk_length_sec
+        self.chunk_length_mode = performance.chunk_length_mode
+        self.enable_torch_compile = performance.enable_torch_compile
+        self.clear_gpu_cache = performance.clear_gpu_cache
+        self.asr_compute_device = performance.asr_compute_device
+        self.asr_dtype = performance.asr_dtype
+        self.asr_ct2_compute_type = performance.asr_ct2_compute_type
+        self.asr_ct2_cpu_threads = performance.asr_ct2_cpu_threads
+        self.max_parallel_downloads = performance.max_parallel_downloads
 
         storage = advanced.storage
-        values.save_temp_recordings = storage.save_temp_recordings
-        values.record_storage_mode = storage.record_storage_mode
-        values.record_storage_limit = storage.record_storage_limit
-        values.max_memory_seconds_mode = storage.max_memory_seconds_mode
-        values.max_memory_seconds = storage.max_memory_seconds
-        values.min_free_ram_mb = storage.min_free_ram_mb
-        values.auto_ram_threshold_percent = storage.auto_ram_threshold_percent
-        values.storage_root_dir = storage.storage_root_dir
-        values.models_storage_dir = storage.models_storage_dir
-        values.recordings_dir = storage.recordings_dir
-        values.asr_cache_dir = storage.asr_cache_dir
-        values.deps_install_dir = storage.deps_install_dir
-        values.hf_home_dir = storage.hf_home_dir
-        values.transformers_cache_dir = storage.transformers_cache_dir
-        values.python_packages_dir = storage.python_packages_dir
-        values.vad_models_dir = storage.vad_models_dir
-        values.hf_cache_dir = storage.hf_cache_dir
+        self.save_temp_recordings = storage.save_temp_recordings
+        self.record_storage_mode = storage.record_storage_mode
+        self.record_storage_limit = storage.record_storage_limit
+        self.max_memory_seconds_mode = storage.max_memory_seconds_mode
+        self.max_memory_seconds = storage.max_memory_seconds
+        self.min_free_ram_mb = storage.min_free_ram_mb
+        self.auto_ram_threshold_percent = storage.auto_ram_threshold_percent
+        self.storage_root_dir = storage.storage_root_dir
+        self.models_storage_dir = storage.models_storage_dir
+        self.recordings_dir = storage.recordings_dir
+        self.asr_cache_dir = storage.asr_cache_dir
+        self.deps_install_dir = storage.deps_install_dir
+        self.hf_home_dir = storage.hf_home_dir
+        self.transformers_cache_dir = storage.transformers_cache_dir
+        self.python_packages_dir = storage.python_packages_dir
+        self.vad_models_dir = storage.vad_models_dir
+        self.hf_cache_dir = storage.hf_cache_dir
 
         vad_cfg = advanced.vad
-        values.use_vad = vad_cfg.use_vad
-        values.vad_threshold = vad_cfg.vad_threshold
-        values.vad_silence_duration = vad_cfg.vad_silence_duration
-        values.vad_pre_speech_padding_ms = vad_cfg.vad_pre_speech_padding_ms
-        values.vad_post_speech_padding_ms = vad_cfg.vad_post_speech_padding_ms
+        self.use_vad = vad_cfg.use_vad
+        self.vad_threshold = vad_cfg.vad_threshold
+        self.vad_silence_duration = vad_cfg.vad_silence_duration
+        self.vad_pre_speech_padding_ms = vad_cfg.vad_pre_speech_padding_ms
+        self.vad_post_speech_padding_ms = vad_cfg.vad_post_speech_padding_ms
 
         workflow = advanced.workflow
-        values.display_transcripts_in_terminal = workflow.display_transcripts_in_terminal
+        self.display_transcripts_in_terminal = workflow.display_transcripts_in_terminal
 
         system = advanced.system
-        values.launch_at_startup = system.launch_at_startup
+        self.launch_at_startup = system.launch_at_startup
 
-        sound_cfg = values.sound or SoundSettings()
-        values.sound_enabled = sound_cfg.enabled
-        values.sound_frequency = sound_cfg.frequency
-        values.sound_duration = sound_cfg.duration
-        values.sound_volume = sound_cfg.volume
-
-        return values
+        sound_cfg = self.sound or SoundSettings()
+        self.sound_enabled = sound_cfg.enabled
+        self.sound_frequency = sound_cfg.frequency
+        self.sound_duration = sound_cfg.duration
+        self.sound_volume = sound_cfg.volume
 
 
 KEY_PATH_OVERRIDES: dict[str, tuple[str, ...]] = {


### PR DESCRIPTION
## Summary
- collapse the duplicated configuration schema definitions into a single AppConfig that mirrors the advanced namespaces in `model_post_init`
- introduce an `AdvancedHotkeyConfig` helper so hotkey-related validation lives in one place
- normalize keyboard debounce handling and add auxiliary thread shutdown logic to the hotkey manager

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e64dcd23cc8330a42a4560ff59cf13