### PR TITLE
Fix operation ID propagation and restore config schema defaults

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -288,7 +288,6 @@ class AdvancedAIConfig(BaseModel):
     batch_size_specified: bool = False
     gpu_index_specified: bool = False
     first_run_completed: bool = False
-    advanced: AdvancedConfig = Field(default_factory=AdvancedConfig)
 
     @field_validator("text_correction_service", mode="before")
     @classmethod
@@ -481,6 +480,7 @@ class AppConfig(BaseModel):
     auto_paste: bool = True
     agent_auto_paste: bool | None = True
     auto_paste_modifier: str = "auto"
+    ui_language: str = _DEFAULT_UI_LANGUAGE
     min_record_duration: float = Field(default=0.5, ge=0.0)
     sound_enabled: bool = True
     sound_frequency: int = Field(default=400, ge=0)

--- a/src/transcription_handler.py
+++ b/src/transcription_handler.py
@@ -1379,10 +1379,20 @@ class TranscriptionHandler:
             emit_start=False,
         ):
             if agent_mode:
-                callback(processed_text)
+                try:
+                    callback(processed_text, operation_id=operation_id)
+                except TypeError:
+                    callback(processed_text)
             else:
                 corrected_payload = processed_text if processed_text != raw_text else None
-                callback(corrected_payload, raw_text)
+                try:
+                    callback(
+                        corrected_payload,
+                        raw_text,
+                        operation_id=operation_id,
+                    )
+                except TypeError:
+                    callback(corrected_payload, raw_text)
 
     def _format_audio_source(self, audio_source: str | np.ndarray | bytes | bytearray | list[float] | None) -> str:
         if audio_source is None:


### PR DESCRIPTION
## Summary
- ensure transcription and agent callbacks receive the operation identifier while preserving backward compatibility
- clean up AdvancedAIConfig circular default and reintroduce the ui_language field required by AppConfig validators

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e654efc3c48330bda46eb13f82326a