### PR TITLE
Find and fix all application bugs

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -125,22 +125,22 @@ class CoreService:
             except Exception as e_gpu_int8:
                 logging.warning(f"GPU (int8) Load failed: {e_gpu_int8}")
                 logging.info("Falling back to CPU (Int8)...")
-            try:
-                download_root = self.settings.get("model_path")
-                if download_root and not download_root.strip(): download_root = None
-                
-                self.model = WhisperModel(model_name, device="cpu", compute_type="int8", download_root=download_root)
-                self.device_used = "cpu"
-                logging.info("Success! Model loaded on CPU.")
-            except Exception as e_cpu:
-                msg = f"Fatal: Failed to load model.\nGPU: {e_gpu}\nCPU: {e_cpu}"
-                logging.error(msg)
-                self.state = "error"
-                if self.ui_update_callback:
-                    self.ui_update_callback("error", "Model Load Failed")
-                if self.error_popup_callback:
-                    self.error_popup_callback("Critical Error", msg)
-                return
+                try:
+                    download_root = self.settings.get("model_path")
+                    if download_root and not download_root.strip(): download_root = None
+
+                    self.model = WhisperModel(model_name, device="cpu", compute_type="int8", download_root=download_root)
+                    self.device_used = "cpu"
+                    logging.info("Success! Model loaded on CPU.")
+                except Exception as e_cpu:
+                    msg = f"Fatal: Failed to load model.\nGPU: {e_gpu}\nCPU: {e_cpu}"
+                    logging.error(msg)
+                    self.state = "error"
+                    if self.ui_update_callback:
+                        self.ui_update_callback("error", "Model Load Failed")
+                    if self.error_popup_callback:
+                        self.error_popup_callback("Critical Error", msg)
+                    return
 
         if self.state != "shutdown":
             self.state = "idle"
@@ -169,7 +169,6 @@ class CoreService:
             except Exception: pass
             self.audio_stream = None
 
-        self.stop_recording()
         self.stop_recording()
         self.model = None
         

--- a/src/ui.py
+++ b/src/ui.py
@@ -39,7 +39,6 @@ class AppUI:
         self.auto_paste_switch: ft.Switch | None = None
         self.mic_dropdown: ft.Dropdown | None = None
         self.model_path_field: ft.TextField | None = None
-        self.model_path_field: ft.TextField | None = None
         
         # Tray is now handled by pystray in main.py
         self.tray_supported = False 


### PR DESCRIPTION
- Corrigir indentação incorreta no fallback de CPU em core.py O bloco try-except de fallback para CPU estava executando sempre que GPU float16 falhava, mesmo quando GPU int8 tinha sucesso. Agora o fallback para CPU só acontece quando ambos GPU float16 e GPU int8 falham.

- Remover chamada duplicada de stop_recording() em core.py A função shutdown() estava chamando stop_recording() duas vezes consecutivamente, causando processamento desnecessário.

- Remover duplicação da variável model_path_field em ui.py A variável estava sendo declarada duas vezes na inicialização da classe AppUI.